### PR TITLE
feat(aws): AWS Bedrock統合のための設計と準備

### DIFF
--- a/doc/project_doc/add-bedrock/designdoc.md
+++ b/doc/project_doc/add-bedrock/designdoc.md
@@ -1,0 +1,257 @@
+# AWS Bedrock (Claude 3.7 Sonnet) 利用のための設計ドキュメント
+
+## 1. 目的
+
+lolice clusterで稼働しているopenhandsアプリケーションから、AWS Bedrockが提供するClaude 3.7 Sonnet AIモデルを利用できるようにするための設計と変更内容をまとめる。
+
+## 2. 概要
+
+このプロジェクトでは、以下の流れでAWS Bedrockへのアクセスを実現する：
+
+1. archで専用のIAMユーザーとポリシーをTerraformで作成
+2. 作成したIAMユーザーのアクセスキーをSSMパラメータストアに安全に保存
+3. lolice clusterのExternal Secrets Operatorを使ってSSMパラメータの値をKubernetesのSecretとして取得
+4. openhandsのPodに環境変数としてAWS認証情報を渡す
+
+## 3. 変更が必要なコードベース
+
+### 3.1 arch リポジトリの変更
+
+#### 3.1.1 追加するTerraformファイル
+
+**terraform/aws/openhands/variables.tf**
+```hcl
+# terraform/aws/openhands/variables.tf
+
+variable "bedrock_model_id" {
+  description = "AWS Bedrock model ID for Claude 3.7 Sonnet"
+  type        = string
+  default     = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+}
+
+variable "bedrock_region" {
+  description = "AWS region where Bedrock is available"
+  type        = string
+  default     = "us-west-2"
+}
+```
+
+**terraform/aws/openhands/iam.tf**
+```hcl
+# terraform/aws/openhands/iam.tf
+resource "aws_iam_user" "bedrock_user" {
+  name = "bedrock-openhands-user"
+  path = "/service/"
+}
+
+resource "aws_iam_access_key" "bedrock_user_key" {
+  user = aws_iam_user.bedrock_user.name
+}
+
+# カスタムポリシーの作成（最小権限の原則に基づく）
+resource "aws_iam_policy" "bedrock_policy" {
+  name        = "bedrock-openhands-policy"
+  description = "Policy for accessing AWS Bedrock Claude 3.7 Sonnet"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+          "bedrock:GetModelCustomizationJob",
+          "bedrock:ListModelCustomizationJobs",
+          "bedrock:ListFoundationModels",
+          "bedrock:GetFoundationModel"
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/${var.bedrock_model_id}"
+        ]
+      }
+    ]
+  })
+}
+
+# ポリシーをIAMユーザーにアタッチ
+resource "aws_iam_user_policy_attachment" "bedrock_policy_attachment" {
+  user       = aws_iam_user.bedrock_user.name
+  policy_arn = aws_iam_policy.bedrock_policy.arn
+}
+```
+
+**terraform/aws/openhands/ssm.tf**
+```hcl
+# terraform/aws/openhands/ssm.tf
+# アクセスキーIDをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_access_key_id" {
+  name        = "bedrock-access-key-id"
+  description = "AWS Access Key ID for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.id
+}
+
+# シークレットアクセスキーをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_secret_access_key" {
+  name        = "bedrock-secret-access-key"
+  description = "AWS Secret Access Key for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.secret
+}
+```
+
+### 3.2 lolice リポジトリの変更
+
+#### 3.2.1 ExternalSecret設定
+
+**manifests/openhands/external-secrets.yaml**
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: bedrock-credentials
+  namespace: openhands
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: parameterstore
+    kind: ClusterSecretStore
+  target:
+    name: bedrock-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: AWS_ACCESS_KEY_ID
+    remoteRef:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: bedrock-access-key-id
+      metadataPolicy: None
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    remoteRef:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: bedrock-secret-access-key
+      metadataPolicy: None
+```
+
+#### 3.2.3 openhands Deploymentの更新
+
+**manifests/openhands/deployment.yaml**（既存のファイル名・パスは異なる可能性あり）
+
+以下の環境変数設定を既存のDeploymentに追加：
+
+```yaml
+# openhandsのDeployment/StatefulSetの環境変数部分に追加
+env:
+# 既存の環境変数...
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: bedrock-credentials
+      key: AWS_ACCESS_KEY_ID
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: bedrock-credentials
+      key: AWS_SECRET_ACCESS_KEY
+- name: AWS_REGION
+  value: "us-west-2"
+- name: AWS_DEFAULT_REGION
+  value: "us-west-2"
+- name: BEDROCK_MODEL_ID
+  value: "anthropic.claude-3-7-sonnet-20250219-v1:0"
+```
+
+## 4. デプロイ手順
+
+### 4.1 arch側の変更適用
+
+1. 上記のTerraformファイルを`terraform/aws/openhands/`ディレクトリに追加
+2. Terraformを実行して変更を適用
+
+```bash
+cd terraform/aws/openhands
+terraform init
+terraform plan  # 変更内容を確認
+terraform apply # 変更を適用
+```
+
+### 4.2 lolice側の変更適用
+
+1. 上記のKubernetesマニフェストファイルを適切なディレクトリに追加
+2. マニフェストファイルを適用
+
+```bash
+# 必要に応じてkubeconfigを設定
+kubectl apply -f manifests/external-secrets/secretstore.yaml
+kubectl apply -f manifests/openhands/external-secrets.yaml
+kubectl apply -f manifests/openhands/deployment.yaml  # または既存のDeploymentを更新
+```
+
+## 5. 検証方法
+
+以下の手順で設定が正しく機能しているか検証する：
+
+1. Terraformの適用が成功し、IAMユーザーが作成されていることを確認
+   ```bash
+   aws iam get-user --user-name bedrock-openhands-user
+   ```
+
+2. SSMパラメータが正しく作成されていることを確認
+   ```bash
+   aws ssm get-parameter --name bedrock-access-key-id --with-decryption
+   aws ssm get-parameter --name bedrock-secret-access-key --with-decryption
+   ```
+
+3. External Secretが正しく機能していることを確認
+   ```bash
+   kubectl get externalsecret bedrock-credentials -n openhands
+   kubectl get secret bedrock-credentials -n openhands
+   ```
+
+4. openhandsのPodに環境変数が正しく設定されていることを確認
+   ```bash
+   kubectl exec -it <openhands-pod-name> -n openhands -- env | grep AWS
+   kubectl exec -it <openhands-pod-name> -n openhands -- env | grep BEDROCK
+   ```
+
+5. openhandsアプリケーションからBedrockへのアクセスを実際に試して機能することを確認
+
+## 6. ロールバック計画
+
+設定に問題がある場合のロールバック手順：
+
+1. openhandsのDeploymentから環境変数設定を削除
+   ```bash
+   kubectl edit deployment <openhands-deployment-name> -n openhands
+   # 環境変数設定を削除
+   ```
+
+2. ExternalSecretとSecretを削除
+   ```bash
+   kubectl delete externalsecret bedrock-credentials -n openhands
+   kubectl delete secret bedrock-credentials -n openhands
+   ```
+
+3. archリポジトリでTerraformの変更を元に戻す
+   ```bash
+   # Terraformファイルを削除または変更前に戻し、適用
+   cd terraform/aws/openhands
+   terraform destroy -target=aws_iam_user_policy_attachment.bedrock_policy_attachment
+   terraform destroy -target=aws_iam_policy.bedrock_policy
+   terraform destroy -target=aws_ssm_parameter.bedrock_secret_access_key
+   terraform destroy -target=aws_ssm_parameter.bedrock_access_key_id
+   terraform destroy -target=aws_iam_access_key.bedrock_user_key
+   terraform destroy -target=aws_iam_user.bedrock_user
+   ```
+
+## 7. セキュリティ上の考慮事項
+
+1. IAM権限は必要最小限に設定
+2. アクセスキーはSecureStringタイプのSSMパラメータで保存
+3. アクセスキーの定期的なロー
+1. アクセスキーのローテーションを自動化
+2. IAM Roleベースの認証に移行
+3. AWS Bedrockの使用量とコストの監視メカニズムの導入
+4. 複数のモデルバージョンへの対応

--- a/doc/project_doc/add-bedrock/prepare.md
+++ b/doc/project_doc/add-bedrock/prepare.md
@@ -1,0 +1,293 @@
+# AWS Bedrock (Claude 3.7 Sonnet)利用のための準備
+
+## 概要
+
+このドキュメントでは、lolice clusterでホスティングされているopenhandsでAWS Bedrockが提供するClaude 3.7 Sonnet AIを利用するための準備手順を説明します。AWSリソースの作成はTerraformを使用して行います。
+
+## 前提条件
+
+- AWS アカウントへのアクセス権限
+- Terraformのインストール（バージョン1.0以上推奨）
+- AWS CLIの設定（Terraformの実行用）
+- lolice clusterの管理権限
+
+## AWS Bedrockサービスの事前設定
+
+Terraformでリソースを作成する前に、AWS Bedrockサービスに関する以下の事前設定が必要です：
+
+### 1. AWS Bedrockサービスへのアクセス権限の確認
+
+AWS Bedrockは一部のリージョンでのみ利用可能で、特に新しいモデル（Claude 3.7 Sonnet）へのアクセスには制限がある場合があります。
+
+1. AWSコンソールにログインし、Bedrockサービスにアクセスできることを確認
+2. 使用するリージョン（us-west-2）でBedrockサービスが利用可能であることを確認
+
+### 2. Claude 3.7 Sonnetモデルへのアクセス許可申請
+
+1. AWSコンソールで「AWS Bedrock」サービスに移動
+2. 「Model access」または「モデルアクセス」セクションに進む
+3. Claude 3.7 Sonnetモデル（anthropic.claude-3-7-sonnet-20250219-v1:0）にアクセス申請（Access request）を行う
+4. 利用規約に同意し、アクセス申請を送信
+5. 申請が承認されるまで待機（通常は数分〜24時間程度）
+
+### 3. サービスクォータの確認と調整
+
+1. AWSコンソールの「Service Quotas」に移動
+2. AWS Bedrockサービスのクォータを確認
+3. 特に以下のクォータに注目し、必要に応じて引き上げリクエストを行う：
+   - InvokeModel API requests per second
+   - InvokeModelWithResponseStream API requests per second
+   - Tokens per minute for Claude 3.7 Sonnet
+
+### 4. 料金体系の確認
+
+- AWS Bedrockの料金は使用したトークン数に基づいて課金
+- Claude 3.7 Sonnetの入力/出力トークンそれぞれの料金を確認し、予算計画を立てる
+
+## 手順の流れ
+
+1. Terraformを使用したAWS IAM Userの作成とBedrockに必要な権限の付与
+2. Terraformを使用したSSM Parameterへの認証情報の保存
+3. External Secrets Operatorの設定
+4. openhandsへの環境変数の設定
+
+## 1. Terraformを使用したAWS IAM Userの作成と権限付与
+
+### 1.1 Terraformファイルの準備
+
+`terraform/aws/openhands/`ディレクトリにはすでに以下のファイルが存在しています：
+
+```
+terraform/aws/openhands/
+├── backend.tf        # すでに存在（S3バックエンドの設定）
+├── provider.tf       # すでに存在（AWS Provider設定）
+├── tfaction.yaml     # すでに存在
+└── その他の設定ファイル
+```
+
+以下の新しいファイルを追加します：
+
+```
+terraform/aws/openhands/
+├── variables.tf      # 変数定義
+├── iam.tf            # IAMリソース定義
+└── ssm.tf            # SSMパラメータ定義
+```
+
+### 1.2 variables.tfの作成
+
+```hcl
+# terraform/aws/openhands/variables.tf
+variable "environment" {
+  description = "Environment name (e.g. dev, prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "bedrock_model_id" {
+  description = "AWS Bedrock model ID for Claude 3.7 Sonnet"
+  type        = string
+  default     = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+}
+
+variable "bedrock_region" {
+  description = "AWS region where Bedrock is available"
+  type        = string
+  default     = "us-west-2"
+}
+```
+
+### 1.3 iam.tfの作成（IAMユーザーと権限の設定）
+
+```hcl
+# terraform/aws/openhands/iam.tf
+resource "aws_iam_user" "bedrock_user" {
+  name = "bedrock-openhands-user"
+  path = "/service/"
+}
+
+resource "aws_iam_access_key" "bedrock_user_key" {
+  user = aws_iam_user.bedrock_user.name
+}
+
+# カスタムポリシーの作成（最小権限の原則に基づく）
+resource "aws_iam_policy" "bedrock_policy" {
+  name        = "bedrock-openhands-policy"
+  description = "Policy for accessing AWS Bedrock Claude 3.7 Sonnet"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+          "bedrock:GetModelCustomizationJob",
+          "bedrock:ListModelCustomizationJobs",
+          "bedrock:ListFoundationModels",
+          "bedrock:GetFoundationModel"
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/${var.bedrock_model_id}"
+        ]
+      }
+    ]
+  })
+}
+
+# ポリシーをIAMユーザーにアタッチ
+resource "aws_iam_user_policy_attachment" "bedrock_policy_attachment" {
+  user       = aws_iam_user.bedrock_user.name
+  policy_arn = aws_iam_policy.bedrock_policy.arn
+}
+```
+
+### 1.4 ssm.tfの作成（SSMパラメータの設定）
+
+```hcl
+# terraform/aws/openhands/ssm.tf
+# アクセスキーIDをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_access_key_id" {
+  name        = "bedrock-access-key-id"
+  description = "AWS Access Key ID for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.id
+}
+
+# シークレットアクセスキーをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_secret_access_key" {
+  name        = "bedrock-secret-access-key"
+  description = "AWS Secret Access Key for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.secret
+}
+```
+
+### 1.5 Terraformの実行
+
+準備したTerraformファイルを実行して、AWSリソースを作成します。
+
+```bash
+cd terraform/aws/openhands
+terraform init
+terraform plan
+terraform apply
+```
+
+承認を求められたら、`yes`と入力して実行を続行します。
+
+## 2. External Secrets Operatorの設定
+
+lolice clusterでExternal Secrets Operator (ESO)を使用して、AWS SSM Parameterに保存された認証情報をKubernetes Secretとして取得します。
+
+### 2.1 SecretStoreの設定
+
+1. AWS SSMへのアクセス権を持つSecretStoreリソースを作成（既存のものがあれば再利用可）:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secretstore
+  namespace: openhands
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: ap-northeast-1  # backend.tfで設定されているregionと同じにする
+      auth:
+        # クラスター上のサービスアカウントまたはIAM Roleの設定によって異なる
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa
+```
+
+### 2.2 ExternalSecretの設定
+
+AWS SSM Parameterから値を取得してKubernetes Secretを作成するExternalSecretを定義:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: bedrock-credentials
+  namespace: openhands
+spec:
+  refreshInterval: "15m"  # 更新間隔
+  secretStoreRef:
+    name: aws-secretstore
+    kind: SecretStore
+  target:
+    name: bedrock-credentials  # 作成されるKubernetes Secretの名前
+  data:
+  - secretKey: AWS_ACCESS_KEY_ID
+    remoteRef:
+      key: bedrock-access-key-id
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    remoteRef:
+      key: bedrock-secret-access-key
+```
+
+## 3. openhandsへの環境変数の設定
+
+作成されたKubernetes Secretをopenhandsのコンテナに環境変数として渡します。
+
+### 3.1 Deploymentの更新
+
+openhandsのDeploymentまたはStatefulSetを更新して、SecretからAWS認証情報を環境変数として設定:
+
+```yaml
+# openhandsのDeployment/StatefulSetの一部
+spec:
+  template:
+    spec:
+      containers:
+      - name: openhands
+        # 他の設定...
+        env:
+        # 既存の環境変数...
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: bedrock-credentials
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: bedrock-credentials
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_REGION
+          value: "us-west-2"  # Bedrockが利用可能なリージョン（variables.tfで設定したbedrock_region）
+```
+
+### 3.2 その他の必要な環境変数
+
+AWS Bedrockを使用するために、追加の環境変数が必要な場合があります:
+
+```yaml
+env:
+# 上記に加えて...
+- name: AWS_DEFAULT_REGION
+  value: "us-west-2"  # Bedrockが利用可能なリージョン
+- name: BEDROCK_MODEL_ID
+  value: "anthropic.claude-3-7-sonnet-20250219-v1:0"  # Claude 3.7 Sonnetのモデルid
+```
+
+## 注意事項
+
+- Terraformの状態ファイル（`.tfstate`）は既にS3バックエンドに保存されるよう設定されています
+- IAM権限は最小権限の原則に従い、必要最低限に設定してください
+- 本番環境ではさらに堅牢な認証方法（IAM Roleの使用など）を検討してください
+- AWS Bedrockの料金体系を確認し、コスト管理を行ってください
+- アクセスキーのローテーションを行う場合は、Terraformで新しいキーを生成し、古いキーを無効化してください
+
+## トラブルシューティング
+
+認証情報が正しく設定されているにもかかわらず接続に問題がある場合:
+
+1. AWS_REGIONがBedrockサービスが利用可能なリージョンに設定されていることを確認
+2. IAMユーザーに適切な権限が付与されていることを確認
+3. lolice cluster内のPod/Containerから適切なネットワーク経路でAWSサービスにアクセスできることを確認
+4. Secretが正しく作成され、環境変数が正しく設定されていることを確認
+5. Terraformで作成したリソースが意図した通りに作成されているか確認

--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -1,0 +1,40 @@
+resource "aws_iam_user" "bedrock_user" {
+  name = "bedrock-openhands-user"
+  path = "/service/"
+}
+
+resource "aws_iam_access_key" "bedrock_user_key" {
+  user = aws_iam_user.bedrock_user.name
+}
+
+# カスタムポリシーの作成（最小権限の原則に基づく）
+resource "aws_iam_policy" "bedrock_policy" {
+  name        = "bedrock-openhands-policy"
+  description = "Policy for accessing AWS Bedrock Claude 3.7 Sonnet"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+          "bedrock:GetModelCustomizationJob",
+          "bedrock:ListModelCustomizationJobs",
+          "bedrock:ListFoundationModels",
+          "bedrock:GetFoundationModel"
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/${var.bedrock_model_id}"
+        ]
+      }
+    ]
+  })
+}
+
+# ポリシーをIAMユーザーにアタッチ
+resource "aws_iam_user_policy_attachment" "bedrock_policy_attachment" {
+  user       = aws_iam_user.bedrock_user.name
+  policy_arn = aws_iam_policy.bedrock_policy.arn
+} 

--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -11,7 +11,7 @@ resource "aws_iam_access_key" "bedrock_user_key" {
 resource "aws_iam_policy" "bedrock_policy" {
   name        = "bedrock-openhands-policy"
   description = "Policy for accessing AWS Bedrock Claude 3.7 Sonnet"
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -26,7 +26,7 @@ resource "aws_iam_policy" "bedrock_policy" {
           "bedrock:GetFoundationModel"
         ]
         Resource = [
-          "arn:aws:bedrock:*::foundation-model/${var.bedrock_model_id}"
+          "arn:aws:bedrock:${var.bedrock_region}::foundation-model/${var.bedrock_model_id}"
         ]
       }
     ]

--- a/terraform/aws/openhands/ssm.tf
+++ b/terraform/aws/openhands/ssm.tf
@@ -1,0 +1,15 @@
+# アクセスキーIDをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_access_key_id" {
+  name        = "bedrock-access-key-id"
+  description = "AWS Access Key ID for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.id
+}
+
+# シークレットアクセスキーをSSMパラメータに保存
+resource "aws_ssm_parameter" "bedrock_secret_access_key" {
+  name        = "bedrock-secret-access-key"
+  description = "AWS Secret Access Key for Bedrock service"
+  type        = "SecureString"
+  value       = aws_iam_access_key.bedrock_user_key.secret
+} 

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -1,0 +1,11 @@
+variable "bedrock_model_id" {
+  description = "AWS Bedrock model ID for Claude 3.7 Sonnet"
+  type        = string
+  default     = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+}
+
+variable "bedrock_region" {
+  description = "AWS region where Bedrock is available"
+  type        = string
+  default     = "us-west-2"
+} 


### PR DESCRIPTION
AWS Bedrockを利用するための基盤を構築。以下の主要な変更を実施:

- AWS IAMユーザーとポリシーの作成
- SSMパラメータストアへの認証情報保存
- Terraformによるリソース定義
- Claude 3.7 Sonnetモデル利用のための設定ドキュメント追加

関連ファイル:
- terraform/aws/openhands/iam.tf
- terraform/aws/openhands/ssm.tf
- terraform/aws/openhands/variables.tf
- doc/project_doc/add-bedrock/designdoc.md
- doc/project_doc/add-bedrock/prepare.md