### PR TITLE
fix(aws): Bedrockモデル識別子のリージョン指定を更新

### DIFF
--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -1,7 +1,7 @@
 variable "bedrock_model_id" {
   description = "AWS Bedrock model ID for Claude 3.7 Sonnet"
   type        = string
-  default     = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+  default     = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 }
 
 variable "bedrock_region" {


### PR DESCRIPTION
AWS Bedrockモデル識別子を、より正確なリージョン指定に更新。us.プレフィックスを追加し、モデルの明示的なリージョン参照を改善。