### PR TITLE
fix(aws): Bedrock IAMポリシーのリソース参照を更新

### DIFF
--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -26,7 +26,7 @@ resource "aws_iam_policy" "bedrock_policy" {
           "bedrock:GetFoundationModel"
         ]
         Resource = [
-          "arn:aws:bedrock:${var.bedrock_region}::foundation-model/${var.bedrock_model_id}"
+          "arn:aws:bedrock:${var.bedrock_region}:${var.account_id}:inference-profile/${var.bedrock_model_id}"
         ]
       }
     ]

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -9,3 +9,9 @@ variable "bedrock_region" {
   type        = string
   default     = "us-west-2"
 } 
+
+variable "account_id" {
+  description = "AWS account ID"
+  type        = string
+  default     = "839695154978"
+}

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -8,7 +8,7 @@ variable "bedrock_region" {
   description = "AWS region where Bedrock is available"
   type        = string
   default     = "us-west-2"
-} 
+}
 
 variable "account_id" {
   description = "AWS account ID"


### PR DESCRIPTION
AWS Bedrockモデルのリソース参照を、アカウントIDを含むより正確な形式に更新。IAMポリシーとvariables.tfファイルを修正し、Bedrockモデルの推論プロファイルを明示的に指定。