### PR TITLE
fix(aws): Bedrock IAMポリシーにClaude 3.7 Sonnetモデルのリソース参照を追加

### DIFF
--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -26,7 +26,8 @@ resource "aws_iam_policy" "bedrock_policy" {
           "bedrock:GetFoundationModel"
         ]
         Resource = [
-          "arn:aws:bedrock:${var.bedrock_region}:${var.account_id}:inference-profile/${var.bedrock_model_id}"
+          "arn:aws:bedrock:${var.bedrock_region}:${var.account_id}:inference-profile/${var.bedrock_model_id}",
+          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0"
         ]
       }
     ]


### PR DESCRIPTION
AWS Bedrockの IAMポリシーに、Claude 3.7 Sonnetモデルの明示的なリソースパスを追加。us-east-1リージョンのAnthropicモデルを直接参照するように更新。