### PR TITLE
fix(aws): Bedrock IAMポリシーにus-west-2リージョンのClaude 3.7 Sonnetモデルを追加

### DIFF
--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -27,7 +27,8 @@ resource "aws_iam_policy" "bedrock_policy" {
         ]
         Resource = [
           "arn:aws:bedrock:${var.bedrock_region}:${var.account_id}:inference-profile/${var.bedrock_model_id}",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0"
         ]
       }
     ]


### PR DESCRIPTION
us-west-2リージョンのAnthropicモデルのリソースパスをBedrockのIAMポリシーに追加し、モデルアクセスの柔軟性を向上