### PR TITLE
Rename microagent configuration file to .openhands.yaml

### DIFF
--- a/.openhands.yaml
+++ b/.openhands.yaml
@@ -1,0 +1,5 @@
+agent: microagent
+version: "1.0"
+always_read:
+  - doc/project-structure.md
+  - doc/project-spec.md


### PR DESCRIPTION
This PR renames the microagent configuration file to .openhands.yaml to ensure the microagent always reads the necessary documentation files.