### PR TITLE
Update .openhands/microagents/repo.md and doc/project-structure.md to force OpenHands to read repo instructions

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -5,5 +5,6 @@ agent: CodeActAgent
 ---
 
 Before starting any task, you MUST read and understand the project structure described in `doc/project-structure.md`.
+Additionally, you MUST read and understand the project specification described in `doc/project-spec.md`.
 This file contains important information about the project's organization, dependencies, and coding conventions.
 Make sure you understand the contents of this file before making any changes to the codebase.

--- a/doc/project-structure.md
+++ b/doc/project-structure.md
@@ -68,6 +68,7 @@
 ├── .gitignore           # Gitで無視するファイルのリスト
 ├── .openhands/          # openhandsに関する重要な指示が記載されたマイクロエージェントファイルが含まれるディレクトリ。特に、.openhands/microagentsに記載された指示は必ず読んでください。
 
+（注: .openhands/microagents/repo.mdは、openhandsに強制的に読ませるドキュメントです）
 ├── LICENSE              # ライセンス情報
 ├── README.md            # プロジェクトの概要説明
 ├── renovate.json5       # Renovateの設定ファイル（依存関係自動更新ツール）


### PR DESCRIPTION
This PR updates .openhands/microagents/repo.md and doc/project-structure.md so that OpenHands always reads the repository-specific instructions. The update ensures that the repo instructions are forcefully read by OpenHands.