### PR TITLE
docs(microagents): CIチェッカーのコマンド例を削除し、日本語対応を強調

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -20,6 +20,8 @@ Additionally, you MUST read and understand the project specification described i
 This file contains important information about the project's organization, dependencies, and coding conventions.
 Make sure you understand the contents of this file before making any changes to the codebase.
 
+!!必ず日本語で受け答えしてください!!
+
 # GitHubのCIステータスチェッカー
 
 ## 役割と責任
@@ -109,28 +111,7 @@ query {
 5. ステータスを分析して結果を報告します
 6. 失敗している場合は、詳細なログを取得して問題を分析します
 
-## コマンド例
 
-GitHub CLIを使用する場合:
-```bash
-# PRの一覧を表示
-gh pr list
-
-# 特定のPRの詳細を表示
-gh pr view {PR_NUMBER}
-
-# CIステータスの確認
-gh pr checks {PR_NUMBER}
-
-# ワークフロー実行の一覧
-gh run list --limit 10
-
-# 特定のワークフロー実行の詳細
-gh run view {RUN_ID}
-
-# ワークフロー実行のログをダウンロード
-gh run download {RUN_ID}
-```
 
 ## CI失敗時の対応
 


### PR DESCRIPTION
CIチェッカーマイクロエージェントのドキュメントを更新しました。
- GitHub CLIのコマンド例セクションを削除
- 日本語での対応を明示的に要求する注意書きを追加