### PR TITLE
docs(microagents): CIチェッカーのドキュメントを簡素化し、指示を明確化

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -2,39 +2,24 @@
 name: repo
 type: repo
 agent: CodeActAgent
-triggers:
-- ci
-- workflow
-- github actions
-- pull request
-- PR
-- check
-- test
-- build
 ---
 
 # プロジェクト指示
 
-Before starting any task, you MUST read and understand the project structure described in `doc/project-structure.md`.
-Additionally, you MUST read and understand the project specification described in `doc/project-spec.md`.
-This file contains important information about the project's organization, dependencies, and coding conventions.
-Make sure you understand the contents of this file before making any changes to the codebase.
+タスクに取り掛かるまえに、必ず以下のファイルを読んでください
+
+- doc/project-structure.md
+- doc/project-spec.md
 
 !!必ず日本語で受け答えしてください!!
 
-# GitHubのCIステータスチェッカー
-
-## 役割と責任
-
-このマイクロエージェントには以下の役割があります：
-1. プルリクエストのCIステータスの確認
-2. CI実行結果の詳細情報へのアクセスと分析
-3. 失敗したCIチェックの分析と問題解決の提案
-4. CIステータスに基づく次のアクションの提案
+# GitHubに関する指示に対しての注意事項
 
 ## 呼び出し方
 
-以下のような表現で呼び出すことができます：
+以下のような表現で呼び出されることがあります
+これより下のドキュメントを参考に対応してください
+
 - "CIの状態を確認して"
 - "このPRのテスト結果を見せて"
 - "ワークフローの実行結果を教えて"
@@ -110,8 +95,6 @@ query {
 4. そのコミットのCIステータスとチェック結果を取得します
 5. ステータスを分析して結果を報告します
 6. 失敗している場合は、詳細なログを取得して問題を分析します
-
-
 
 ## CI失敗時の対応
 


### PR DESCRIPTION
CIチェッカーマイクロエージェントのドキュメントを更新しました：
- トリガーキーワードを削除
- プロジェクト指示セクションを簡潔に再構成
- GitHub関連の指示セクションを整理