### PR TITLE
OpenHands: Bedrockユーザー削除とSSMパラメータ読み取りユーザー追加

### DIFF
--- a/terraform/aws/openhands/iam.tf
+++ b/terraform/aws/openhands/iam.tf
@@ -1,16 +1,17 @@
-resource "aws_iam_user" "bedrock_user" {
-  name = "bedrock-openhands-user"
+# SSMパラメータ読み取り用のIAMユーザー
+resource "aws_iam_user" "ssm_reader_user" {
+  name = "ssm-reader-openhands-user"
   path = "/service/"
 }
 
-resource "aws_iam_access_key" "bedrock_user_key" {
-  user = aws_iam_user.bedrock_user.name
+resource "aws_iam_access_key" "ssm_reader_user_key" {
+  user = aws_iam_user.ssm_reader_user.name
 }
 
-# カスタムポリシーの作成（最小権限の原則に基づく）
-resource "aws_iam_policy" "bedrock_policy" {
-  name        = "bedrock-openhands-policy"
-  description = "Policy for accessing AWS Bedrock Claude 3.7 Sonnet"
+# SSMパラメータ読み取り用のポリシー
+resource "aws_iam_policy" "ssm_reader_policy" {
+  name        = "ssm-reader-openhands-policy"
+  description = "Policy for reading SSM parameters"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -18,18 +19,12 @@ resource "aws_iam_policy" "bedrock_policy" {
       {
         Effect = "Allow"
         Action = [
-          "bedrock:InvokeModel",
-          "bedrock:InvokeModelWithResponseStream",
-          "bedrock:GetModelCustomizationJob",
-          "bedrock:ListModelCustomizationJobs",
-          "bedrock:ListFoundationModels",
-          "bedrock:GetFoundationModel"
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:DescribeParameters"
         ]
         Resource = [
-          "arn:aws:bedrock:${var.bedrock_region}:${var.account_id}:inference-profile/${var.bedrock_model_id}",
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
-          "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
-          "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0"
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/*"
         ]
       }
     ]
@@ -37,7 +32,7 @@ resource "aws_iam_policy" "bedrock_policy" {
 }
 
 # ポリシーをIAMユーザーにアタッチ
-resource "aws_iam_user_policy_attachment" "bedrock_policy_attachment" {
-  user       = aws_iam_user.bedrock_user.name
-  policy_arn = aws_iam_policy.bedrock_policy.arn
+resource "aws_iam_user_policy_attachment" "ssm_reader_policy_attachment" {
+  user       = aws_iam_user.ssm_reader_user.name
+  policy_arn = aws_iam_policy.ssm_reader_policy.arn
 }

--- a/terraform/aws/openhands/ssm.tf
+++ b/terraform/aws/openhands/ssm.tf
@@ -1,15 +1,15 @@
-# アクセスキーIDをSSMパラメータに保存
-resource "aws_ssm_parameter" "bedrock_access_key_id" {
-  name        = "bedrock-access-key-id"
-  description = "AWS Access Key ID for Bedrock service"
+# SSMリーダーユーザーのアクセスキーIDをSSMパラメータに保存
+resource "aws_ssm_parameter" "ssm_reader_access_key_id" {
+  name        = "ssm-reader-access-key-id"
+  description = "AWS Access Key ID for SSM Parameter Reader"
   type        = "SecureString"
-  value       = aws_iam_access_key.bedrock_user_key.id
+  value       = aws_iam_access_key.ssm_reader_user_key.id
 }
 
-# シークレットアクセスキーをSSMパラメータに保存
-resource "aws_ssm_parameter" "bedrock_secret_access_key" {
-  name        = "bedrock-secret-access-key"
-  description = "AWS Secret Access Key for Bedrock service"
+# SSMリーダーユーザーのシークレットアクセスキーをSSMパラメータに保存
+resource "aws_ssm_parameter" "ssm_reader_secret_access_key" {
+  name        = "ssm-reader-secret-access-key"
+  description = "AWS Secret Access Key for SSM Parameter Reader"
   type        = "SecureString"
-  value       = aws_iam_access_key.bedrock_user_key.secret
-} 
+  value       = aws_iam_access_key.ssm_reader_user_key.secret
+}

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -1,11 +1,5 @@
-variable "bedrock_model_id" {
-  description = "AWS Bedrock model ID for Claude 3.7 Sonnet"
-  type        = string
-  default     = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-}
-
-variable "bedrock_region" {
-  description = "AWS region where Bedrock is available"
+variable "region" {
+  description = "AWS region"
   type        = string
   default     = "us-west-2"
 }

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -1,7 +1,7 @@
 variable "region" {
   description = "AWS region"
   type        = string
-  default     = "us-west-2"
+  default     = "asia-northeast-1"
 }
 
 variable "account_id" {


### PR DESCRIPTION
## 変更内容

- Bedrockユーザー（bedrock-openhands-user）とそのIAMポリシーを削除
- Bedrockユーザー関連のSSMパラメータ（bedrock-access-key-idとbedrock-secret-access-key）を削除
- 新しいSSMパラメータ読み取り用のIAMユーザー（ssm-reader-openhands-user）を作成
- SSMパラメータ読み取り用のIAMポリシーを作成し、ユーザーにアタッチ
- 新しいユーザーのアクセスキーをSSMパラメータに保存