### PR TITLE
OpenHands用のGoogle API Key SSM Parameterを追加

### DIFF
--- a/terraform/aws/openhands/ssm.tf
+++ b/terraform/aws/openhands/ssm.tf
@@ -13,3 +13,11 @@ resource "aws_ssm_parameter" "ssm_reader_secret_access_key" {
   type        = "SecureString"
   value       = aws_iam_access_key.ssm_reader_user_key.secret
 }
+
+# Google API用のAPIキーをSSMパラメータに保存
+resource "aws_ssm_parameter" "google_api_key" {
+  name        = "openhands-google-api-key"
+  description = "Google API Key for OpenHands"
+  type        = "SecureString"
+  value       = var.google_api_key
+}

--- a/terraform/aws/openhands/variables.tf
+++ b/terraform/aws/openhands/variables.tf
@@ -9,3 +9,9 @@ variable "account_id" {
   type        = string
   default     = "839695154978"
 }
+
+variable "google_api_key" {
+  description = "Google API Key for OpenHands"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
このPRでは、OpenHands用のGoogle API KeyをAWS SSM Parameter Storeに保存するための設定を追加しています。

## 変更内容

- `terraform/aws/openhands/ssm.tf`に新しいSSM Parameterリソース`aws_ssm_parameter.google_api_key`を追加
- `terraform/aws/openhands/variables.tf`に新しい変数`google_api_key`を追加

## 使用方法

Terraformを適用する際に、以下のようにGoogle API Keyを指定します：

```bash
terraform apply -var="google_api_key=YOUR_GOOGLE_API_KEY"
```