### PR TITLE
chore: disable Cloudflare provider updates until v5.2.0 is released

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,5 +24,11 @@
         '/.*/',
       ],
     },
+    {
+      matchDatasources: ["terraform-provider"],
+      matchPackageNames: ["cloudflare/cloudflare"],
+      enabled: false,
+      description: "Disable Cloudflare provider updates until v5.2.0 is released"
+    },
   ],
 }


### PR DESCRIPTION
## 概要
Cloudflare provider v5.2.0 がリリースされるまで、Renovate による Cloudflare provider の自動更新を一時的に無効化します。

## 変更内容
- renovate.json5 に Cloudflare provider の更新を無効化するルールを追加
- 他の Terraform プロバイダーや依存関係の更新は通常通り行われます

## 備考
Cloudflare provider v5.2.0 がリリースされた後、この設定を削除するか `enabled: true` に変更することで、再び更新を有効にできます。