### PR TITLE
GitHub Actions用のOIDCプロバイダーとIAMロール、ポリシーを追加。信頼ポリシーに条件を設定し、ECRおよびSSMパラメー…

### DIFF
--- a/terraform/aws/openhands/github_actions_oidc.tf
+++ b/terraform/aws/openhands/github_actions_oidc.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_openid_connect_provider" "github_actions" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
   thumbprint_list = [
     "6938fd4d98bab03faadb97b34396831e3780aea1",
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "openhands_runtime_gha_assume_role_policy" {
       type        = "Federated"
       identifiers = ["arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com"]
     }
-    
+
     # audience条件 - GitHub Actionsが使用する標準値
     condition {
       test     = "StringEquals"

--- a/terraform/aws/openhands/github_actions_oidc.tf
+++ b/terraform/aws/openhands/github_actions_oidc.tf
@@ -1,0 +1,88 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ]
+}
+
+# GitHub ActionsのOIDCプロバイダーが利用するIAMロールのための信頼ポリシー
+data "aws_iam_policy_document" "openhands_runtime_gha_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com"]
+    }
+    
+    # audience条件 - GitHub Actionsが使用する標準値
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # subject条件 - リポジトリとブランチを制限
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:boxp/openhands-runtime:ref:refs/heads/main"]
+    }
+  }
+}
+
+# GitHub Actions用のIAMロール
+resource "aws_iam_role" "openhands_runtime_role" {
+  name               = "openhands-runtime-role"
+  assume_role_policy = data.aws_iam_policy_document.openhands_runtime_gha_assume_role_policy.json
+}
+
+# GitHub Actions用のポリシー（ECRとSSMパラメータストアへのアクセス）
+resource "aws_iam_policy" "openhands_runtime_policy" {
+  name        = "openhands-runtime-policy"
+  description = "Policy for OpenHands Runtime GitHub Actions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:ecr:${var.region}:${var.account_id}:repository/openhands-runtime"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ]
+        Resource = [
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-*"
+        ]
+      }
+    ]
+  })
+}
+
+# ポリシーをロールにアタッチ
+resource "aws_iam_role_policy_attachment" "openhands_runtime_policy_attachment" {
+  role       = aws_iam_role.openhands_runtime_role.name
+  policy_arn = aws_iam_policy.openhands_runtime_policy.arn
+} 


### PR DESCRIPTION
…タストアへのアクセス権を付与。