### PR TITLE
IAMロールにssm:DescribeParametersアクションを追加

### DIFF
--- a/terraform/aws/openhands/github_actions_oidc.tf
+++ b/terraform/aws/openhands/github_actions_oidc.tf
@@ -67,6 +67,13 @@ resource "aws_iam_policy" "openhands_runtime_policy" {
         Resource = [
           "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-*"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:DescribeParameters"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
設計書に従って、GitHub Actionsワークフローが正常に動作するようにIAMロールの権限を修正しました。

- GitHub Actionsロールに`ssm:DescribeParameters`アクションを追加
- `ssm:DescribeParameters`はリソースレベルの権限をサポートしていないため、リソース指定を`*`に変更