### PR TITLE
SSMパラメータのワイルドカードを具体的なパラメータ名に変更

### DIFF
--- a/doc/project_doc/2972/designdoc.md
+++ b/doc/project_doc/2972/designdoc.md
@@ -275,8 +275,7 @@ resource "aws_iam_policy" "ssm_reader_policy" {
           "ssm:DescribeParameters"
         ]
         Resource = [
-          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-access-key-id",
-          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-secret-access-key"
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/*"
         ]
       }
     ]

--- a/doc/project_doc/2972/designdoc.md
+++ b/doc/project_doc/2972/designdoc.md
@@ -184,7 +184,8 @@ resource "aws_iam_policy" "openhands_runtime_policy" {
           "ssm:GetParameters"
         ]
         Resource = [
-          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-*"
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-access-key-id",
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-secret-access-key"
         ]
       }
     ]
@@ -274,7 +275,8 @@ resource "aws_iam_policy" "ssm_reader_policy" {
           "ssm:DescribeParameters"
         ]
         Resource = [
-          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/*"
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-access-key-id",
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-secret-access-key"
         ]
       }
     ]


### PR DESCRIPTION
最小権限の原則に従い、SSMパラメータのワイルドカードパターン（`parameter-reader-*`と`parameter/*`）を具体的なパラメータ名（`parameter-reader-access-key-id`と`parameter-reader-secret-access-key`）に変更しました。

この変更により、IAMポリシーがより制限的になり、セキュリティが向上します。