### PR TITLE
OpenHands Runtime IAMポリシーの修正

### DIFF
--- a/terraform/aws/openhands/github_actions_oidc.tf
+++ b/terraform/aws/openhands/github_actions_oidc.tf
@@ -65,7 +65,8 @@ resource "aws_iam_policy" "openhands_runtime_policy" {
           "ssm:GetParameters"
         ]
         Resource = [
-          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-*"
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-access-key-id",
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/parameter-reader-secret-access-key"
         ]
       }
     ]


### PR DESCRIPTION
設計ドキュメントに合わせてOpenHands RuntimeのIAMポリシーを修正しました。

## 変更内容
- SSMパラメータへのアクセス権限をワイルドカード指定から明示的な指定に変更
- `parameter-reader-access-key-id`と`parameter-reader-secret-access-key`の2つのパラメータに限定

## 背景
設計ドキュメント（doc/project_doc/2972/designdoc.md）では、特定のSSMパラメータへのアクセス権限を明示的に指定していましたが、実際のコードではワイルドカード（`parameter-reader-*`）を使用していました。最小権限の原則に従い、設計ドキュメントに合わせて修正しました。