### PR TITLE
Cursor用の読み取り専用IAMユーザーを追加

### DIFF
--- a/terraform/aws/users/iam.tf
+++ b/terraform/aws/users/iam.tf
@@ -1,0 +1,26 @@
+# IAM User for Cursor with read-only access to the entire AWS account
+resource "aws_iam_user" "cursor_readonly" {
+  name = "cursor-readonly"
+  path = "/"
+}
+
+# Create access key for the Cursor user
+resource "aws_iam_access_key" "cursor_readonly" {
+  user = aws_iam_user.cursor_readonly.name
+}
+
+# Attach the AWS managed ReadOnlyAccess policy to the Cursor user
+resource "aws_iam_user_policy_attachment" "cursor_readonly_policy" {
+  user       = aws_iam_user.cursor_readonly.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# Output the access key and secret key (sensitive)
+output "cursor_readonly_access_key" {
+  value = aws_iam_access_key.cursor_readonly.id
+}
+
+output "cursor_readonly_secret_key" {
+  value     = aws_iam_access_key.cursor_readonly.secret
+  sensitive = true
+}

--- a/terraform/aws/users/iam.tf
+++ b/terraform/aws/users/iam.tf
@@ -4,23 +4,8 @@ resource "aws_iam_user" "cursor_readonly" {
   path = "/"
 }
 
-# Create access key for the Cursor user
-resource "aws_iam_access_key" "cursor_readonly" {
-  user = aws_iam_user.cursor_readonly.name
-}
-
 # Attach the AWS managed ReadOnlyAccess policy to the Cursor user
 resource "aws_iam_user_policy_attachment" "cursor_readonly_policy" {
   user       = aws_iam_user.cursor_readonly.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-# Output the access key and secret key (sensitive)
-output "cursor_readonly_access_key" {
-  value = aws_iam_access_key.cursor_readonly.id
-}
-
-output "cursor_readonly_secret_key" {
-  value     = aws_iam_access_key.cursor_readonly.secret
-  sensitive = true
 }


### PR DESCRIPTION
Cursorツールのために、AWS全体に対する読み取り専用権限を持つIAMユーザーを追加しました。

## 変更内容
- `cursor-readonly`という名前のIAMユーザーを作成
- AWS管理ポリシー`ReadOnlyAccess`をアタッチして全体の読み取り権限を付与

## 使用方法
1. `terraform apply`実行後、AWSコンソールからCursorユーザーのアクセスキーを手動で作成してください。
2. 作成した認証情報をCursorに設定してください。