### PR TITLE
fix: remove unused grafana ssm parameters

### DIFF
--- a/terraform/cloudflare/b0xp.io/grafana/access.tf
+++ b/terraform/cloudflare/b0xp.io/grafana/access.tf
@@ -13,10 +13,10 @@ resource "cloudflare_access_application" "grafana_api" {
   service_auth_401_redirect = false
 }
 
-# GitHub Action用のサービストークン (Grafana API用)
+# Model Context Protocol 用のサービストークン (Grafana API用)
 resource "cloudflare_access_service_token" "grafana_api_service_token" {
   account_id           = var.account_id
-  name                 = "GitHub Action - Grafana API" # Changed from ArgoCD API
+  name                 = "Model Context Protocol - Grafana API"
   min_days_for_renewal = 30
 
   # トークンローテーション設定
@@ -32,7 +32,7 @@ resource "cloudflare_access_service_token" "grafana_api_service_token" {
 resource "cloudflare_access_policy" "grafana_api_policy" {
   application_id = cloudflare_access_application.grafana_api.id # Changed from argocd_api
   zone_id        = var.zone_id
-  name           = "GitHub Actions access policy for grafana-api.b0xp.io" # Changed from argocd-api
+  name           = "Model Context Protocol access policy for grafana-api.b0xp.io"
   precedence     = "1"
   decision       = "non_identity" # Use non_identity for service tokens
   include {
@@ -41,18 +41,3 @@ resource "cloudflare_access_policy" "grafana_api_policy" {
   }
 }
 
-# トークンIDをSSMに保存
-resource "aws_ssm_parameter" "grafana_api_github_action_token" {
-  name        = "grafana-api-github-action-token"         # Changed from argocd-api
-  description = "for GitHub Action to access Grafana API" # Changed from ArgoCD API
-  type        = "SecureString"
-  value       = sensitive(cloudflare_access_service_token.grafana_api_service_token.client_id) # Changed from github_action_token
-}
-
-# トークンシークレットをSSMに保存
-resource "aws_ssm_parameter" "grafana_api_github_action_secret" {
-  name        = "grafana-api-github-action-secret"        # Changed from argocd-api
-  description = "for GitHub Action to access Grafana API" # Changed from ArgoCD API
-  type        = "SecureString"
-  value       = sensitive(cloudflare_access_service_token.grafana_api_service_token.client_secret) # Changed from github_action_token
-}


### PR DESCRIPTION
PR #3209 でマージされた不要な Grafana API 関連の SSM パラメータを削除します。