### PR TITLE
fix: correct ansible role change detection in CI workflow

### DIFF
--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Detect changed roles
         id: changed-roles
         run: |
-          cd "ansible"
-          # Get list of changed ansible role files
+          # Get list of changed ansible role files (from project root)
           CHANGED_FILES=$(git diff --name-only origin/main...HEAD | grep "^ansible/roles/" || true)
           
           # Extract unique role names from changed files
@@ -61,6 +60,16 @@ jobs:
           
           echo "changed-files=$CHANGED_FILES"
           echo "changed-roles=$CHANGED_ROLES"
+          
+          # Debug output
+          echo "Debug: CHANGED_FILES content:"
+          echo "$CHANGED_FILES" | while read -r line; do
+            echo "  File: $line"
+          done
+          echo "Debug: CHANGED_ROLES content:"
+          echo "$CHANGED_ROLES" | while read -r line; do
+            echo "  Role: $line"
+          done
           
           # Set output for use in next step
           {


### PR DESCRIPTION
## Summary
Fix ansible role change detection in CI workflow to ensure molecule tests run for new/changed roles.

## Problem
- Molecule tests were not running for new ansible roles in PRs
- Role change detection was failing due to incorrect path resolution
- `pull_request_target` uses workflow files from main branch, so changes needed to be applied to main first

## Solution
- Move git diff execution to project root instead of ansible directory
- Add debug output to help troubleshoot role detection issues
- Fix path resolution for detecting changed ansible roles

## Changes
- Remove `cd "ansible"` before git diff execution
- Add comprehensive debug logging
- Ensure CHANGED_ROLES variable is properly populated

## Testing
- This fix will allow kubernetes_components role molecule tests to run in PR #4347
- Debug output will help identify any remaining issues

## Impact
- Fixes CI for all future ansible role PRs
- Ensures proper test coverage for ansible changes
- No impact on existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)