### PR TITLE
feat: add deployment configuration for Orange Pi Zero 3

### DIFF
--- a/ansible/DEPLOYMENT.md
+++ b/ansible/DEPLOYMENT.md
@@ -1,0 +1,166 @@
+# Orange Pi Zero 3 Control Plane Deployment
+
+このドキュメントは、Orange Pi Zero 3ノード（shanghai-1/2/3）へのKubernetesコントロールプレーンデプロイ手順を説明します。
+
+## 前提条件
+
+### 1. Cloudflareトンネル設定
+各ノードがCloudflareトンネル経由でアクセス可能であること：
+- shanghai-1: `cloudflared access ssh --hostname shanghai-1`
+- shanghai-2: `cloudflared access ssh --hostname shanghai-2`  
+- shanghai-3: `cloudflared access ssh --hostname shanghai-3`
+
+### 2. SSH設定
+`~/.ssh/config` に以下を追加：
+```
+Host shanghai-1
+    ProxyCommand cloudflared access ssh --hostname %h
+    User boxp
+
+Host shanghai-2
+    ProxyCommand cloudflared access ssh --hostname %h
+    User boxp
+
+Host shanghai-3
+    ProxyCommand cloudflared access ssh --hostname %h
+    User boxp
+```
+
+### 3. 必要なツール
+- Ansible >= 2.12
+- cloudflared CLI
+- Python 3.8+
+
+## デプロイ手順
+
+### 1. 接続テスト
+```bash
+# 各ノードへの接続確認
+ansible control_plane -i inventories/production/hosts.yml -m ping
+```
+
+### 2. 段階的デプロイ
+
+#### ステップ1: ユーザーとネットワーク設定（ブートストラップ）
+```bash
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --tags "bootstrap" \
+  --ask-become-pass
+```
+
+#### ステップ2: Cloudflare CLI設定
+```bash
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --tags "cloudflare"
+```
+
+#### ステップ3: Kubernetesコンポーネント設定
+```bash
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --tags "kubernetes"
+```
+
+#### ステップ4: kube-vip高可用性設定
+```bash
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --tags "kube-vip"
+```
+
+### 3. 全体デプロイ（一括実行）
+```bash
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --ask-become-pass
+```
+
+### 4. 特定ノードのみデプロイ
+```bash
+# shanghai-1のみ
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --limit shanghai-1
+
+# 複数ノード指定
+ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml \
+  --limit "shanghai-1,shanghai-2"
+```
+
+## 設定確認
+
+### 1. サービス状態確認
+```bash
+ansible control_plane -i inventories/production/hosts.yml \
+  -m shell -a "systemctl status kubelet crio"
+```
+
+### 2. kube-vip動作確認
+```bash
+ansible control_plane -i inventories/production/hosts.yml \
+  -m shell -a "kubectl get pods -n kube-system | grep kube-vip"
+```
+
+### 3. VIP確認
+```bash
+# VIP 192.168.10.99の確認
+ping 192.168.10.99
+curl -k https://192.168.10.99:6443/version
+```
+
+## トラブルシューティング
+
+### 1. SSH接続エラー
+```bash
+# Cloudflareトンネル状態確認
+cloudflared tunnel list
+
+# SSH接続デバッグ
+ssh -vvv shanghai-1
+```
+
+### 2. Kubernetes設定確認
+```bash
+# ノード上で直接確認
+ssh shanghai-1
+sudo systemctl status kubelet
+sudo journalctl -u kubelet -f
+```
+
+### 3. kube-vip問題
+```bash
+# 静的Pod確認
+ssh shanghai-1
+sudo ls -la /etc/kubernetes/manifests/
+sudo kubectl logs -n kube-system kube-vip-shanghai-1
+```
+
+## クラスター初期化
+
+全ノードのセットアップ完了後、以下でKubernetesクラスターを初期化：
+
+```bash
+# 最初のマスターノード（shanghai-1）
+ssh shanghai-1
+sudo kubeadm init \
+  --control-plane-endpoint="192.168.10.99:6443" \
+  --upload-certs \
+  --pod-network-cidr="10.244.0.0/16"
+
+# kubeconfig設定
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+# 他のマスターノード参加（shanghai-2, shanghai-3）
+# kubeadm init出力のjoinコマンドを使用
+```
+
+## 注意事項
+
+1. **段階的デプロイ推奨**: 全ロールを一度に実行せず、段階的に適用することを推奨
+2. **バックアップ**: 重要な設定変更前は設定ファイルのバックアップを取得
+3. **ログ確認**: 各ステップ後にサービスログを確認
+4. **ネットワーク**: VIP 192.168.10.99が他のデバイスと競合しないよう確認
+
+## リソース
+
+- [Orange Pi Zero 3公式ドキュメント](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-Zero-3.html)
+- [kube-vip公式ドキュメント](https://kube-vip.io/)
+- [kubeadm公式ドキュメント](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/)

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -16,8 +16,23 @@ all:
         ansible_user: boxp
         ansible_ssh_common_args: '-o ProxyCommand="cloudflared access ssh --hostname %h"'
         ansible_python_interpreter: /usr/bin/python3
-        kubernetes_version: "1.32.0"
-        crio_version: "1.32.0"
+        
+        # Kubernetes configuration
+        kubernetes_version: "1.32"
+        kubernetes_package_version: "1.32.0-1.1"
+        crio_version: "1.32"
+        
+        # Cluster configuration
         cluster_vip: "192.168.10.99"
+        cluster_domain: "cluster.local"
+        cluster_dns: "10.96.0.10"
+        
+        # Hardware configuration
         hardware_type: "orange_pi_zero3"
         architecture: "arm64"
+        
+        # Network configuration
+        network_gateway: "192.168.10.1"
+        network_dns_servers:
+          - "8.8.8.8"
+          - "8.8.4.4"

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -16,21 +16,21 @@ all:
         ansible_user: boxp
         ansible_ssh_common_args: '-o ProxyCommand="cloudflared access ssh --hostname %h"'
         ansible_python_interpreter: /usr/bin/python3
-        
+
         # Kubernetes configuration
         kubernetes_version: "1.32"
         kubernetes_package_version: "1.32.0-1.1"
         crio_version: "1.32"
-        
+
         # Cluster configuration
         cluster_vip: "192.168.10.99"
         cluster_domain: "cluster.local"
         cluster_dns: "10.96.0.10"
-        
+
         # Hardware configuration
         hardware_type: "orange_pi_zero3"
         architecture: "arm64"
-        
+
         # Network configuration
         network_gateway: "192.168.10.1"
         network_dns_servers:

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -1,14 +1,40 @@
 ---
-- name: Configure control plane nodes
+- name: Configure Orange Pi Zero 3 control plane nodes
   hosts: control_plane
   become: true
   gather_facts: true
+  vars:
+    # Common cluster configuration
+    cluster_vip: "192.168.10.99"
+    cluster_domain: "cluster.local"
+    cluster_dns: "10.96.0.10"
+    
   roles:
     - role: user_management
-      tags: users
-
+      tags: [users, bootstrap]
+      
     - role: network_configuration
-      tags: network
+      tags: [network, bootstrap]
       vars:
         network_ip_address: "{{ node_ip }}"
         network_gateway: "192.168.10.1"
+        
+    - role: cloudflare_cli
+      tags: [cloudflare, external-access]
+      
+    - role: kubernetes_components
+      tags: [kubernetes, k8s-components]
+      vars:
+        kubernetes_version: "1.32"
+        kubernetes_package_version: "1.32.0-1.1"
+        crio_version: "1.32"
+        kubelet_cluster_dns: "{{ cluster_dns }}"
+        kubelet_cluster_domain: "{{ cluster_domain }}"
+        
+    - role: kube_vip
+      tags: [kube-vip, ha]
+      vars:
+        kube_vip_vip: "{{ cluster_vip }}"
+        kube_vip_interface: "eth0"
+        kube_vip_control_plane: true
+        kube_vip_services: false

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -8,20 +8,20 @@
     cluster_vip: "192.168.10.99"
     cluster_domain: "cluster.local"
     cluster_dns: "10.96.0.10"
-    
+
   roles:
     - role: user_management
       tags: [users, bootstrap]
-      
+
     - role: network_configuration
       tags: [network, bootstrap]
       vars:
         network_ip_address: "{{ node_ip }}"
         network_gateway: "192.168.10.1"
-        
+
     - role: cloudflare_cli
       tags: [cloudflare, external-access]
-      
+
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
@@ -30,7 +30,7 @@
         crio_version: "1.32"
         kubelet_cluster_dns: "{{ cluster_dns }}"
         kubelet_cluster_domain: "{{ cluster_domain }}"
-        
+
     - role: kube_vip
       tags: [kube-vip, ha]
       vars:


### PR DESCRIPTION
## Summary
SSH + Cloudflare経由でのOrange Pi Zero 3ノード（shanghai-1/2/3）への実際のAnsibleデプロイを可能にする設定を追加

## Changes

### 📋 統合プレイブック更新
- `ansible/playbooks/control-plane.yml` を全5ロール統合仕様に更新
- タグベースの段階的デプロイ対応
- 共通クラスター設定変数の追加
- kubernetes_components、kube_vip ロール統合

### 🌐 本番インベントリ更新  
- `ansible/inventories/production/hosts.yml` の変数名統一
- Cloudflareトンネル経由SSH設定
- 正しいKubernetes v1.32、CRI-O v1.32設定
- ネットワーク設定変数の追加

### 📖 デプロイメントドキュメント
- `ansible/DEPLOYMENT.md` 新規作成
- SSH + Cloudflare設定手順
- 段階的デプロイ手順（bootstrap → cloudflare → kubernetes → kube-vip）
- トラブルシューティングガイド
- クラスター初期化手順

## 実機デプロイコマンド

### 接続テスト
```bash
ansible control_plane -i inventories/production/hosts.yml -m ping
```

### 段階的デプロイ
```bash
# ステップ1: ユーザー・ネットワーク設定
ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --tags "bootstrap"

# ステップ2: Cloudflare CLI
ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --tags "cloudflare"

# ステップ3: Kubernetes コンポーネント
ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --tags "kubernetes"

# ステップ4: kube-vip 高可用性
ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --tags "kube-vip"
```

### 全体デプロイ
```bash
ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml
```

## 前提条件

1. **Cloudflareトンネル設定**: 各ノードがCloudflare経由でアクセス可能
2. **SSH設定**: `~/.ssh/config` にCloudflareプロキシ設定
3. **cloudflared CLI**: ローカル環境にインストール済み

## 技術仕様

- **対象ノード**: shanghai-1/2/3 (192.168.10.102-104)
- **VIP**: 192.168.10.99 (kube-vip管理)
- **Kubernetes**: v1.32.0-1.1
- **CRI-O**: v1.32
- **アーキテクチャ**: ARM64 (Orange Pi Zero 3)

## 影響範囲

この変更により、テスト環境から実際のOrange Pi Zero 3ノードへのデプロイが可能になります。既存のMoleculeテストには影響しません。

## Related Issues

Completes #4340 - Orange Pi Zero 3 control plane nodeのansible管理

🤖 Generated with [Claude Code](https://claude.ai/code)