### PR TITLE
fix: add missing ansible dependency to image build action

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget xz-utils kpartx
+        sudo apt-get install -y wget xz-utils kpartx ansible
 
     - name: Download Orange Pi Zero 3 server image
       shell: bash


### PR DESCRIPTION
The ansible-playbook command was not found because ansible package was not installed in the dependencies step.

🤖 Generated with [Claude Code](https://claude.ai/code)