### PR TITLE
fix: update filename pattern to match armbian/build output

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -96,7 +96,7 @@ runs:
         echo "🎯 Armbian build completed!"
         
         # Find the generated image
-        OUTPUT_IMAGE=$(find output/images -name "Armbian_*_Orangepizero3_*.img.xz" | head -n1)
+        OUTPUT_IMAGE=$(find output/images -name "Armbian*Orangepizero3*.img.xz" | head -n1)
         if [ -z "$OUTPUT_IMAGE" ]; then
           echo "❌ Error: No output image found"
           echo "📁 Available files in output/images:"


### PR DESCRIPTION
## Summary
- Fix armbian/build filename pattern matching in GitHub Actions
- The armbian/build system generates images with 'Armbian-unofficial' prefix using hyphens
- Updated pattern from `Armbian_*_Orangepizero3_*.img.xz` to `Armbian*Orangepizero3*.img.xz`
- This matches actual output: `Armbian-unofficial_25.08.0-trunk_Orangepizero3_noble_current_6.12.35_minimal.img.xz`

## Test plan
- [x] Verify pattern matches armbian/build output format
- [ ] Test shanghai-2 build after merge

🤖 Generated with [Claude Code](https://claude.ai/code)