### PR TITLE
fix: return to parent directory after ansible execution

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -157,6 +157,9 @@ runs:
           -e target_mount=/mnt/orangepi \
           playbooks/node-${{ inputs.node_name }}.yml
         
+        # Return to parent directory
+        cd ..
+        
         # Cleanup
         sudo umount /mnt/orangepi
         sudo losetup -d "$LOOP_DEVICE"


### PR DESCRIPTION
## Summary
- Fix directory issue causing xz compression failure
- The script was staying in ansible/ directory after running playbooks
- Added `cd ..` to return to parent directory where image file is located

## Root cause
- `cd ansible` moved working directory to run playbooks
- Image file `orangepi-zero3-noble-server.img` remained in parent directory
- xz compression failed because it couldn't find the file

## Test plan
- [x] Add directory navigation fix
- [ ] Test shanghai-2 build with proper directory handling

🤖 Generated with [Claude Code](https://claude.ai/code)