### PR TITLE
fix: export FINAL_IMAGE variable to GITHUB_ENV for S3 upload step

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -191,6 +191,9 @@ runs:
           "github_sha": "$GITHUB_SHA"
         }
         EOF
+        
+        # Export variables for next steps
+        echo "FINAL_IMAGE=$FINAL_IMAGE" >> "$GITHUB_ENV"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4


### PR DESCRIPTION
## Summary
- Fix "path does not exist" error in Orange Pi build workflow
- Export FINAL_IMAGE variable to GITHUB_ENV to make it available across workflow steps

## Test plan
- [ ] Merge and trigger shanghai-2 build workflow
- [ ] Verify image is uploaded successfully to S3
- [ ] Confirm latest.img.xz symlink is created

🤖 Generated with [Claude Code](https://claude.ai/code)