### PR TITLE
fix: add s3:GetObject permission to GitHub Actions IAM role

### DIFF
--- a/terraform/aws/orange-pi-images/main.tf
+++ b/terraform/aws/orange-pi-images/main.tf
@@ -186,7 +186,8 @@ resource "aws_iam_role_policy" "github_actions_orangepi_s3" {
         Action = [
           "s3:PutObject",
           "s3:PutObjectAcl",
-          "s3:PutObjectTagging"
+          "s3:PutObjectTagging",
+          "s3:GetObject"
         ]
         Resource = "${aws_s3_bucket.orange_pi_images.arn}/images/orange-pi-zero3/*"
       },


### PR DESCRIPTION
Add missing s3:GetObject permission to allow copy-object operation for creating latest.img.xz symlink. This fixes the AccessDenied error when copying uploaded images to create the latest reference.

🤖 Generated with [Claude Code](https://claude.ai/code)