### PR TITLE
fix: update Molecule tests to Ubuntu Noble and add SSH server setup

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -9,6 +9,44 @@
     cluster_domain: "cluster.local"
     cluster_dns: "10.96.0.10"
 
+  tasks:
+    - name: Ensure SSH server is installed and configured
+      block:
+        - name: Install OpenSSH server
+          ansible.builtin.apt:
+            name: openssh-server
+            state: present
+            update_cache: yes
+          tags: [ssh, bootstrap]
+
+        - name: Ensure SSH service is enabled and started
+          ansible.builtin.systemd:
+            name: ssh
+            enabled: yes
+            state: started
+          tags: [ssh, bootstrap]
+
+        - name: Configure SSH server
+          ansible.builtin.lineinfile:
+            path: /etc/ssh/sshd_config
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+            validate: 'sshd -t -f %s'
+          loop:
+            - { regexp: '^#?PermitRootLogin', line: 'PermitRootLogin no' }
+            - { regexp: '^#?PasswordAuthentication', line: 'PasswordAuthentication no' }
+            - { regexp: '^#?PubkeyAuthentication', line: 'PubkeyAuthentication yes' }
+            - { regexp: '^#?ChallengeResponseAuthentication', line: 'ChallengeResponseAuthentication no' }
+          notify: restart ssh
+          tags: [ssh, bootstrap]
+      tags: [ssh, bootstrap]
+
+  handlers:
+    - name: restart ssh
+      ansible.builtin.systemd:
+        name: ssh
+        state: restarted
+
   roles:
     - role: user_management
       tags: [users, bootstrap]

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -11,18 +11,19 @@
 
   tasks:
     - name: Ensure SSH server is installed and configured
+      tags: [ssh, bootstrap]
       block:
         - name: Install OpenSSH server
           ansible.builtin.apt:
             name: openssh-server
             state: present
-            update_cache: yes
+            update_cache: true
           tags: [ssh, bootstrap]
 
         - name: Ensure SSH service is enabled and started
           ansible.builtin.systemd:
             name: ssh
-            enabled: yes
+            enabled: true
             state: started
           tags: [ssh, bootstrap]
 
@@ -37,12 +38,11 @@
             - { regexp: '^#?PasswordAuthentication', line: 'PasswordAuthentication no' }
             - { regexp: '^#?PubkeyAuthentication', line: 'PubkeyAuthentication yes' }
             - { regexp: '^#?ChallengeResponseAuthentication', line: 'ChallengeResponseAuthentication no' }
-          notify: restart ssh
+          notify: Restart SSH service
           tags: [ssh, bootstrap]
-      tags: [ssh, bootstrap]
 
   handlers:
-    - name: restart ssh
+    - name: Restart SSH service
       ansible.builtin.systemd:
         name: ssh
         state: restarted

--- a/ansible/roles/cloudflare_cli/molecule/default/molecule.yml
+++ b/ansible/roles/cloudflare_cli/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: geerlingguy/docker-debian11-ansible:latest
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
     # Use ARM64 platform in CI, native platform locally for development
     platform: "${MOLECULE_DOCKER_PLATFORM:-linux/amd64}"
     command: /sbin/init

--- a/ansible/roles/kube_vip/molecule/default/molecule.yml
+++ b/ansible/roles/kube_vip/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: geerlingguy/docker-debian11-ansible:latest
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true

--- a/ansible/roles/kubernetes_components/molecule/default/molecule.yml
+++ b/ansible/roles/kubernetes_components/molecule/default/molecule.yml
@@ -5,8 +5,8 @@ driver:
   name: docker
 platforms:
   - name: instance
-    # Use systemd-enabled image that simulates Orange Pi Zero 3 environment
-    image: "geerlingguy/docker-debian11-ansible:latest"
+    # Use systemd-enabled Ubuntu Noble image that matches Armbian build
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     # Use ARM64 platform in CI, native platform locally for development
     platform: "${MOLECULE_DOCKER_PLATFORM:-linux/amd64}"
     pre_build_image: true

--- a/ansible/roles/network_configuration/molecule/default/molecule.yml
+++ b/ansible/roles/network_configuration/molecule/default/molecule.yml
@@ -5,8 +5,8 @@ driver:
   name: docker
 platforms:
   - name: instance
-    # Use systemd-enabled image that simulates Orange Pi Zero 3 environment
-    image: "geerlingguy/docker-debian11-ansible:latest"
+    # Use systemd-enabled Ubuntu Noble image that matches Armbian build
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     # Use ARM64 platform in CI, native platform locally for development
     platform: "${MOLECULE_DOCKER_PLATFORM:-linux/amd64}"
     pre_build_image: true

--- a/ansible/roles/user_management/molecule/default/molecule.yml
+++ b/ansible/roles/user_management/molecule/default/molecule.yml
@@ -5,8 +5,8 @@ driver:
   name: docker
 platforms:
   - name: instance
-    # Use systemd-enabled image that simulates Orange Pi Zero 3 environment
-    image: "geerlingguy/docker-debian11-ansible:latest"
+    # Use systemd-enabled Ubuntu Noble image that matches Armbian build
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     pre_build_image: true
     privileged: true
     volumes:
@@ -15,6 +15,8 @@ platforms:
     command: /lib/systemd/systemd
     env:
       DEBIAN_FRONTEND: noninteractive
+    # Support ARM64 platform for Orange Pi Zero 3
+    platform: "${MOLECULE_DOCKER_PLATFORM:-linux/amd64}"
     # Simulate Orange Pi Zero 3 environment
     groups:
       - orange_pi_zero3


### PR DESCRIPTION
## Summary
- Update Molecule test configurations to use Ubuntu Noble (24.04) instead of Debian 11
- Add SSH server setup to control-plane Ansible playbook
- Configure SSH with security hardening

## Changes
1. **Molecule Test Updates**:
   - Changed all roles from `geerlingguy/docker-debian11-ansible:latest` to `geerlingguy/docker-ubuntu2404-ansible:latest`
   - This matches the Ubuntu Noble base used in Armbian builds

2. **SSH Server Configuration**:
   - Install openssh-server package
   - Enable and start SSH service
   - Configure security settings:
     - Disable root login
     - Disable password authentication
     - Enable public key authentication only
     - Disable challenge-response authentication

## Test plan
- [ ] Merge and run Molecule tests locally with `cd ansible/roles/[role] && uv run molecule test`
- [ ] Test ARM64 platform: `MOLECULE_DOCKER_PLATFORM=linux/arm64 uv run molecule test`
- [ ] Deploy new Orange Pi image and verify SSH access works with public key

🤖 Generated with [Claude Code](https://claude.ai/code)