### PR TITLE
fix: use community.general.chroot connection plugin for improved Orange Pi image builds

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -36,6 +36,9 @@ runs:
           python3-pip \
           bc \
           binfmt-support
+        
+        # Install Ansible collections needed for chroot
+        ansible-galaxy collection install community.general
 
     - name: Clone Armbian build system
       shell: bash
@@ -143,35 +146,45 @@ runs:
         sudo mkdir -p /mnt/orangepi
         sudo mount "${LOOP_DEVICE}p1" /mnt/orangepi
         
-        # Set up chroot environment
+        # Set up chroot environment properly
         echo "Setting up chroot environment..."
         sudo mount -t proc /proc /mnt/orangepi/proc
-        sudo mount -t sysfs /sys /mnt/orangepi/sys
+        sudo mount -t sysfs /sys /mnt/orangepi/sys  
         sudo mount -o bind /dev /mnt/orangepi/dev
         sudo mount -o bind /dev/pts /mnt/orangepi/dev/pts
+        sudo mount -t tmpfs tmpfs /mnt/orangepi/tmp
+        sudo mount -t tmpfs tmpfs /mnt/orangepi/run
         
-        # Copy resolv.conf for network access in chroot
+        # Copy DNS configuration for network access in chroot
         sudo cp /etc/resolv.conf /mnt/orangepi/etc/resolv.conf
+        sudo cp /etc/hosts /mnt/orangepi/etc/hosts
+        
+        # Create temporary inventory for chroot
+        cd ansible
+        cat > /tmp/chroot_inventory << EOF
+        [all]
+        orangepi_chroot ansible_connection=community.general.chroot ansible_chroot=/mnt/orangepi
+        EOF
         
         # Apply common control-plane configuration first
-        cd ansible
         sudo ansible-playbook \
-          -i /mnt/orangepi, \
-          -c chroot \
+          -i /tmp/chroot_inventory \
           -e chroot_build=true \
           playbooks/control-plane.yml
         
         # Apply node-specific configuration
         sudo ansible-playbook \
-          -i /mnt/orangepi, \
-          -c chroot \
+          -i /tmp/chroot_inventory \
           -e chroot_build=true \
           playbooks/node-${{ inputs.node_name }}.yml
         
-        # Return to parent directory
+        # Return to parent directory and cleanup
         cd ..
+        rm -f /tmp/chroot_inventory
         
         # Cleanup chroot mounts
+        sudo umount /mnt/orangepi/run || true
+        sudo umount /mnt/orangepi/tmp || true
         sudo umount /mnt/orangepi/dev/pts || true
         sudo umount /mnt/orangepi/dev || true
         sudo umount /mnt/orangepi/sys || true

--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -155,9 +155,20 @@ runs:
         sudo mount -t tmpfs tmpfs /mnt/orangepi/tmp
         sudo mount -t tmpfs tmpfs /mnt/orangepi/run
         
-        # Copy DNS configuration for network access in chroot
-        sudo cp /etc/resolv.conf /mnt/orangepi/etc/resolv.conf
-        sudo cp /etc/hosts /mnt/orangepi/etc/hosts
+        # Set up DNS configuration for network access in chroot
+        echo "Setting up DNS in chroot environment..."
+        sudo rm -f /mnt/orangepi/etc/resolv.conf
+        echo "nameserver 8.8.8.8" | sudo tee /mnt/orangepi/etc/resolv.conf
+        echo "nameserver 8.8.4.4" | sudo tee -a /mnt/orangepi/etc/resolv.conf
+        
+        # Ensure basic hosts file exists
+        if [ ! -f "/mnt/orangepi/etc/hosts" ]; then
+          cat << 'HOSTS_EOF' | sudo tee /mnt/orangepi/etc/hosts
+127.0.0.1	localhost
+127.0.1.1	orangepi
+::1		localhost ip6-localhost ip6-loopback
+HOSTS_EOF
+        fi
         
         # Create temporary inventory for chroot
         cd ansible


### PR DESCRIPTION
## Summary
- Switch from basic `chroot` to `community.general.chroot` connection plugin for more reliable chroot operations
- Add proper chroot environment setup with tmpfs mounts for /run and /tmp
- Install required Ansible collections in build environment
- Use proper inventory file for chroot connection

## Background
The previous implementation using `-c chroot` was failing during Orange Pi image builds. The `community.general.chroot` plugin provides more robust chroot handling with better error handling and environment setup.

## Changes
- Replace `-c chroot` with `-c community.general.chroot` in ansible-playbook calls
- Create proper inventory file with `ansible_connection=community.general.chroot`
- Add tmpfs mounts for `/run` and `/tmp` directories in chroot environment
- Install `community.general` collection during build process
- Improve cleanup to handle additional mounts

## Test plan
- [ ] Test Orange Pi image build workflow
- [ ] Verify chroot environment is properly set up
- [ ] Confirm Ansible playbooks execute successfully in chroot
- [ ] Check that generated images work on Orange Pi hardware

🤖 Generated with [Claude Code](https://claude.ai/code)