### PR TITLE
fix: resolve node_ip variable issue in chroot environment

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -173,11 +173,15 @@ runs:
         echo "[chroots]" > chroot_inventory.ini
         echo "orangepi_chroot ansible_host=/mnt/orangepi ansible_connection=community.general.chroot" >> chroot_inventory.ini
         
+        # Extract node IP from node-specific playbook for control-plane
+        NODE_IP=$(grep "node_ip:" playbooks/node-${{ inputs.node_name }}.yml | head -1 | cut -d'"' -f2)
+        
         # Apply common control-plane configuration first
         sudo ansible-playbook \
           -i chroot_inventory.ini \
           -e chroot_build=true \
           -e ansible_python_interpreter=/usr/bin/python3 \
+          -e node_ip="$NODE_IP" \
           playbooks/control-plane.yml
         
         # Apply node-specific configuration


### PR DESCRIPTION
## Summary
- Fix undefined `node_ip` variable error in control-plane playbook
- Extract `node_ip` from node-specific playbook and pass it as extra variable

## Problem
The control-plane playbook was failing with:
```
'node_ip' is undefined
```

This occurred because the `community.general.chroot` connection doesn't properly inherit variables from the playbook context.

## Solution
- Extract `node_ip` value from the node-specific playbook using grep
- Pass the extracted value as an extra variable (`-e node_ip="$NODE_IP"`) to the control-plane playbook
- This ensures the network_configuration role receives the required IP address

## Test plan
- [ ] Test Orange Pi image build workflow
- [ ] Verify control-plane playbook runs without variable errors
- [ ] Confirm network configuration is applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)