### PR TITLE
feat: enable GitHub SSH key fetching for user management

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -60,6 +60,9 @@
   roles:
     - role: user_management
       tags: [users, bootstrap]
+      vars:
+        user_management_use_github_keys: true
+        user_management_github_username: "boxp"
     - role: network_configuration
       tags: [network, bootstrap]
       vars:


### PR DESCRIPTION
- Set user_management_use_github_keys to true in control-plane.yml
- Configure user_management_github_username as 'boxp'
- Allow automatic SSH key provisioning from GitHub profile

🤖 Generated with [Claude Code](https://claude.ai/code)