### PR TITLE
build: 修正されたOrange Piイメージビルドアクションとカスタマイズスクリプトの更新

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -99,9 +99,9 @@ runs:
         echo "🚀 Using $CPUS CPU cores for parallel build"
         
         # Configure build with customization support
-        export ORANGEPI_NODE_NAME="${{ inputs.node_name }}"
+        echo 'export ORANGEPI_NODE_NAME="${{ inputs.node_name }}"' >> userpatches/config-shanghai.conf.sh
         
-        ./compile.sh \
+        ./compile.sh shanghai \
           BOARD=orangepizero3 \
           BRANCH=current \
           RELEASE=noble \
@@ -115,8 +115,7 @@ runs:
           PARALLEL="$CPUS" \
           PROGRESS_LOG_TO_FILE=yes \
           SYNC_CLOCK=no \
-          SKIP_EXTERNAL_TOOLCHAINS=yes \
-          ORANGEPI_NODE_NAME="${{ inputs.node_name }}"
+          SKIP_EXTERNAL_TOOLCHAINS=yes
         
         echo "🎯 Armbian build with customization completed!"
         

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -13,8 +13,6 @@ echo "  - Running as: $(whoami)"
 echo "📦 Installing Ansible..."
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y ansible python3-pip
-pip3 install ansible-core
-ansible-galaxy collection install community.general ansible.posix
 
 # Copy Ansible playbooks from build environment to rootfs
 # The /tmp/overlay is where Armbian mounts external files


### PR DESCRIPTION
- **action.yml**: ORANGEPI_NODE_NAMEの設定をuserpatches/config-shanghai.conf.shに追加し、compile.shの引数を修正
- **customize-image.sh**: Ansible関連のインストール手順を削除し、シンプルな構成に変更

これにより、ビルドプロセスが簡素化され、Ansibleの統合が改善されました。