### PR TITLE
fix: handle swapoff failure in chroot environment during image build

### DIFF
--- a/ansible/roles/kubernetes_components/tasks/system_preparation.yml
+++ b/ansible/roles/kubernetes_components/tasks/system_preparation.yml
@@ -1,11 +1,31 @@
 ---
 # System preparation tasks for Kubernetes
 
+- name: Check if running in chroot environment
+  ansible.builtin.stat:
+    path: /proc/1/root/.
+  register: chroot_check
+  changed_when: false
+  failed_when: false
+
+- name: Set chroot fact
+  ansible.builtin.set_fact:
+    is_chroot: "{{ chroot_check.stat.ino is not defined or chroot_check.stat.ino != 2 }}"
+
 - name: Disable swap
   ansible.builtin.command: swapoff -a
   become: true
-  when: kubernetes_disable_swap
+  when:
+    - kubernetes_disable_swap
+    - not is_chroot
   changed_when: false
+
+- name: Skip swap disable in chroot
+  ansible.builtin.debug:
+    msg: "Skipping swapoff in chroot environment. Swap will be disabled via fstab."
+  when:
+    - kubernetes_disable_swap
+    - is_chroot
 
 - name: Remove swap from /etc/fstab
   ansible.builtin.lineinfile:


### PR DESCRIPTION
## Summary
- Fix swapoff command failure (exit code 32) in chroot environment during Armbian image build
- Add chroot environment detection to skip swap disable command when running inside chroot
- Rely on fstab modification to ensure swap is disabled in the final image

## Problem
The Orange Pi Zero 3 image build was failing because the `swapoff -a` command cannot execute in a chroot environment, returning error code 32. This was preventing successful completion of the Ansible playbooks during the Armbian customize-image.sh phase.

## Solution
Added chroot detection logic that:
1. Checks if running in chroot by examining `/proc/1/root/.` inode
2. Skips the swapoff command when in chroot environment
3. Still removes swap entries from /etc/fstab to ensure swap is disabled in the final image

## Test plan
- [ ] Run the Orange Pi image build workflow
- [ ] Verify Ansible playbooks complete without errors
- [ ] Confirm swap is properly disabled in the generated image

🤖 Generated with [Claude Code](https://claude.ai/code)