### PR TITLE
refactor: optimize Orange Pi build dependencies

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -29,16 +29,7 @@ runs:
           qemu-user-static \
           debootstrap \
           rsync \
-          parted \
-          kpartx \
-          ansible \
-          python3-dev \
-          python3-pip \
-          bc \
-          binfmt-support
-        
-        # Install Ansible collections needed for chroot
-        ansible-galaxy collection install community.general
+          bc
 
     - name: Clone Armbian build system
       shell: bash


### PR DESCRIPTION
## Summary
- Remove unnecessary packages from Orange Pi build action
- Optimize build time by eliminating redundant installations
- Move Ansible installation to customize-image.sh where it's actually used

## Changes
**Removed packages:**
- `parted`, `kpartx`: Armbian build system handles image partitioning internally
- `ansible`, `python3-dev`, `python3-pip`: These are installed in customize-image.sh during chroot phase
- `binfmt-support`: Already handled by docker/setup-qemu-action
- `ansible-galaxy collection install`: Moved to customize-image.sh

**Kept essential packages:**
- `git`: Required for Armbian repository cloning
- `build-essential`: Core build tools
- `qemu-user-static`: Required for ARM64 emulation in chroot
- `debootstrap`: Used by Armbian build system
- `rsync`: File synchronization
- `bc`: Shell script calculations

## Benefits
- Faster build times (fewer packages to install)
- Cleaner separation of concerns (Ansible only installed where needed)
- Reduced GitHub Actions runner resource usage

## Test plan
- [ ] Run Orange Pi build workflow to verify functionality
- [ ] Confirm build time improvement
- [ ] Verify customize-image.sh still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)