### PR TITLE
fix: skip kernel module loading in chroot environment during image build

### DIFF
--- a/ansible/roles/kubernetes_components/tasks/system_preparation.yml
+++ b/ansible/roles/kubernetes_components/tasks/system_preparation.yml
@@ -41,7 +41,17 @@
     state: present
   become: true
   loop: "{{ kernel_modules }}"
-  when: kubernetes_enable_modules and not (ansible_virtualization_type | default('') == 'docker' and item == 'br_netfilter')
+  when:
+    - kubernetes_enable_modules
+    - not is_chroot
+    - not (ansible_virtualization_type | default('') == 'docker' and item == 'br_netfilter')
+
+- name: Skip kernel module loading in chroot
+  ansible.builtin.debug:
+    msg: "Skipping kernel module loading in chroot environment. Modules will be loaded on first boot."
+  when:
+    - kubernetes_enable_modules
+    - is_chroot
 
 - name: Ensure kernel modules are loaded at boot
   ansible.builtin.lineinfile:
@@ -51,18 +61,27 @@
     mode: '0644'
   become: true
   loop: "{{ kernel_modules }}"
-  when: kubernetes_enable_modules and not (ansible_virtualization_type | default('') == 'docker' and item == 'br_netfilter')
+  when:
+    - kubernetes_enable_modules
+    - not (ansible_virtualization_type | default('') == 'docker' and item == 'br_netfilter')
 
 - name: Configure sysctl parameters
   ansible.posix.sysctl:
     name: "{{ item.key }}"
     value: "{{ item.value }}"
-    sysctl_set: true
+    sysctl_set: "{{ not is_chroot }}"
     state: present
-    reload: true
+    reload: "{{ not is_chroot }}"
   become: true
   loop: "{{ sysctl_config | dict2items }}"
-  when: not (ansible_virtualization_type | default('') == 'docker' and item.key is match('net\.bridge\..*'))
+  when:
+    - not (ansible_virtualization_type | default('') == 'docker' and item.key is match('net\.bridge\..*'))
+    - not (is_chroot and item.key is match('net\.bridge\..*'))
+
+- name: Skip sysctl runtime configuration in chroot
+  ansible.builtin.debug:
+    msg: "Skipping sysctl runtime configuration in chroot environment. Parameters will be applied on first boot."
+  when: is_chroot
 
 - name: Create sysctl configuration file
   ansible.builtin.template:


### PR DESCRIPTION
## Summary
- Fix kernel module loading failures during Orange Pi image build in GitHub Actions
- Skip modprobe commands in chroot environment while preserving module configuration
- Ensure modules are properly configured for loading on first boot

## Problem
The Orange Pi image build was failing with this error:
```
FileNotFoundError: [Errno 2] No such file or directory: '/lib/modules/6.11.0-1018-azure/modules.builtin'
failed: [localhost] (item=br_netfilter)
```

This occurs because:
1. GitHub Actions runner uses Azure kernel (6.11.0-1018-azure)
2. In chroot environment, modprobe tries to access host kernel modules
3. Host kernel module files don't exist in the target ARM64 rootfs

## Solution
Added chroot environment detection to skip actual module loading while preserving configuration:

1. **Skip modprobe in chroot**: Added `not is_chroot` condition to prevent module loading attempts
2. **Preserve module configuration**: `/etc/modules-load.d/k8s.conf` is still created for first boot
3. **Clear messaging**: Added debug message explaining why modules are skipped

## Technical Details
- Uses existing `is_chroot` fact from previous chroot detection logic
- Modules will be loaded automatically on first boot with the target Orange Pi kernel
- No functionality is lost - just deferred to the appropriate time

## Test plan
- [ ] Run Orange Pi image build workflow
- [ ] Verify Ansible playbooks complete without module loading errors
- [ ] Confirm `/etc/modules-load.d/k8s.conf` is created in the image
- [ ] Test that modules load correctly on actual Orange Pi boot

🤖 Generated with [Claude Code](https://claude.ai/code)