### PR TITLE
fix: resolve Orange Pi Zero 3 build failures for shanghai-3

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,3 +4,5 @@ collections:
     version: ">=8.0.0"
   - name: ansible.posix
     version: ">=1.5.0"
+  - name: kubernetes.core
+    version: ">=3.0.0"

--- a/ansible/roles/kube_vip/handlers/main.yml
+++ b/ansible/roles/kube_vip/handlers/main.yml
@@ -6,6 +6,7 @@
     path: "{{ kube_vip_manifest_dir }}/kube-vip.yaml"
     state: present
   become: true
+  when: not (is_chroot_build | default(false))
 
 - name: Check kube-vip pod status
   ansible.builtin.shell: |
@@ -16,6 +17,8 @@
     fi
   register: kube_vip_pod_status
   become: true
-  when: ansible_virtualization_type != "docker"
+  when: 
+    - ansible_virtualization_type != "docker"
+    - not (is_chroot_build | default(false))
   changed_when: false
   failed_when: false

--- a/ansible/roles/kube_vip/tasks/main.yml
+++ b/ansible/roles/kube_vip/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # Main tasks file for kube_vip
 
+- name: Detect chroot build environment
+  ansible.builtin.set_fact:
+    is_chroot_build: "{{ chroot_build | default(false) | bool or (ansible_env.PWD | default('') | regex_search('/tmp/.*rootfs')) is not none }}"
+
+- name: Debug chroot detection
+  ansible.builtin.debug:
+    msg: "Chroot build detected: {{ is_chroot_build }}"
+  when: is_chroot_build
+
 - name: Validate required variables
   ansible.builtin.assert:
     that:
@@ -39,7 +48,9 @@
     dest: "{{ kube_vip_manifest_dir }}/kube-vip.yaml"
     mode: '0644'
   become: true
-  when: kubeconfig_stat.stat.exists
+  when: 
+    - kubeconfig_stat.stat.exists
+    - not is_chroot_build
   notify: Wait for kube-vip pod
 
 - name: Create RBAC resources for kube-vip
@@ -47,3 +58,4 @@
   when:
     - kube_vip_rbac_create
     - kubeconfig_stat.stat.exists
+    - not is_chroot_build

--- a/ansible/roles/kube_vip/templates/kube-vip.yaml.j2
+++ b/ansible/roles/kube_vip/templates/kube-vip.yaml.j2
@@ -44,9 +44,15 @@ spec:
     - name: log_level
       value: "{{ kube_vip_log_level }}"
     image: {{ kube_vip_image }}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     name: kube-vip
-    resources: {}
+    resources:
+      limits:
+        memory: "64Mi"
+        cpu: "100m"
+      requests:
+        memory: "16Mi"
+        cpu: "50m"
     securityContext:
       capabilities:
         add:

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -26,6 +26,15 @@ else
     exit 1
 fi
 
+# Install Ansible collections
+echo "📦 Installing Ansible collections..."
+cd /root/ansible
+if [ -f "requirements.yml" ]; then
+    ansible-galaxy collection install -r requirements.yml
+else
+    echo "⚠️ requirements.yml not found"
+fi
+
 # Set node name from environment
 NODE_NAME="${ORANGEPI_NODE_NAME:-unknown}"
 


### PR DESCRIPTION
Shanghai-3 ノードのOrange Pi Zero 3イメージビルド失敗を解決する修正を実装。

## 🔧 修正内容

**根本原因の修正:**
- kubernetes.core コレクション依存関係の欠如
- kube_vip ロールがchrootビルド中にK8s操作を試行
- Orange Pi Zero 3の限られたリソースに対する制限なし
- imagePullPolicy: Alwaysによるネットワークタイミング問題

**変更点:**
- ansible/requirements.yml にkubernetes.coreコレクションを追加
- kube_vipロールにchrootビルド環境検出ロジックを追加
- Kubernetes APIが利用不可時にRBAC作成をスキップ
- 適切なリソース制限（16Mi/64Mi メモリ）を追加
- imagePullPolicyをIfNotPresentに変更
- イメージカスタマイズ中にAnsibleコレクションをインストール

Shanghai-3ビルドが正常に完了するはずです。

Fixes #4427

🤖 Generated with [Claude Code](https://claude.ai/code)