### PR TITLE
Revert "fix: orangepizero3のビルドブランチをlegacyに変更"

### DIFF
--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -95,7 +95,7 @@ runs:
         
         ./compile.sh shanghai \
           BOARD=orangepizero3 \
-          BRANCH=legacy \
+          BRANCH=current \
           RELEASE=noble \
           BUILD_MINIMAL=yes \
           BUILD_DESKTOP=no \


### PR DESCRIPTION
Reverts boxp/arch#4505