### PR TITLE
feat(ansible): add kubelet resolv.conf configuration for control-plane nodes

### DIFF
--- a/ansible/roles/kubernetes_components/tasks/kubelet.yml
+++ b/ansible/roles/kubernetes_components/tasks/kubelet.yml
@@ -50,6 +50,18 @@
     mode: '0755'
   become: true
 
+- name: Configure kubelet resolv.conf settings
+  ansible.builtin.copy:
+    content: |
+      [Service]
+      Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
+    dest: /etc/systemd/system/kubelet.service.d/10-resolv-conf.conf
+    mode: '0644'
+  become: true
+  notify:
+    - Reload systemd
+    - Restart kubelet
+
 - name: Enable kubelet service via symlink
   ansible.builtin.file:
     src: /usr/lib/systemd/system/kubelet.service


### PR DESCRIPTION
## Summary
- Add systemd drop-in configuration for kubelet to use the correct resolv.conf path
- Configure kubelet to use `/run/systemd/resolve/resolv.conf` instead of the default path
- This ensures proper DNS resolution within containers on control-plane nodes

## Changes
- Added `10-resolv-conf.conf` systemd drop-in file creation in the kubernetes_components role
- The configuration sets `KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf`

## Test plan
- [ ] Deploy to a test control-plane node
- [ ] Verify the drop-in file exists at `/etc/systemd/system/kubelet.service.d/10-resolv-conf.conf`
- [ ] Check that kubelet is using the correct resolv.conf path
- [ ] Test DNS resolution within pods

🤖 Generated with [Claude Code](https://claude.ai/code)