### PR TITLE
fix: Longhorn S3バックアップのAWS_ENDPOINTSエラーを修正

### DIFF
--- a/terraform/aws/longhorn/ssm.tf
+++ b/terraform/aws/longhorn/ssm.tf
@@ -25,12 +25,12 @@ resource "aws_ssm_parameter" "longhorn_backup_secret_key" {
 
 resource "aws_ssm_parameter" "longhorn_backup_endpoints" {
   name        = "/longhorn/backup/aws-endpoints"
-  description = "AWS endpoints for Longhorn backup optional"
+  description = "AWS endpoints for Longhorn backup"
   type        = "String"
-  value       = "default" # デフォルトのAWSエンドポイントを使用
+  value       = "s3.amazonaws.com"
 
   tags = {
-    Description = "Longhorn backup AWS endpoints optional"
+    Description = "Longhorn backup AWS endpoints"
     Project     = "lolice"
   }
 }


### PR DESCRIPTION
## Summary
- AWS_ENDPOINTSの値を"default"から"s3.amazonaws.com"に修正
- LonghornがDNS解決エラーで正しいS3エンドポイントにアクセスできない問題を解決

## Problem
Longhornが以下のエラーでS3バックアップに失敗していた：
```
dial tcp: lookup default on 10.96.0.10:53: no such host
```

これは`AWS_ENDPOINTS`パラメータが`"default"`という値になっており、Longhornがこれをホスト名として解釈していたため。

## Solution
`terraform/aws/longhorn/ssm.tf`で以下を修正：
- **Before**: `value = "default"`
- **After**: `value = "s3.amazonaws.com"`

これによりLonghornが正しいAWS S3エンドポイントにアクセスできるようになり、バックアップ機能が正常に動作する。

## Test plan
- [x] Terraformの設定検証
- [ ] マージ後、Longhornのバックアップ機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)