### PR TITLE
fix: pass node_ip to kubernetes_components role for kubelet configuration

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -100,3 +100,4 @@
         crio_version: "1.32"
         kubelet_cluster_dns: "{{ cluster_dns }}"
         kubelet_cluster_domain: "{{ cluster_domain }}"
+        kubelet_node_ip: "{{ node_ip }}"


### PR DESCRIPTION
## Summary
- Pass `node_ip` variable to kubernetes_components role as `kubelet_node_ip`
- Ensures each node uses its specific IP address defined in the playbook
- Fixes issue where `detected_node_ip` was not getting the correct node-specific IP

## Problem
The `detected_node_ip` variable in the kubernetes_components role was relying on `ansible_default_ipv4.address`, which may not return the correct IP address for each node. Each node playbook defines its own `node_ip`, but this wasn't being passed to the role.

## Solution
Added `kubelet_node_ip: "{{ node_ip }}"` to the kubernetes_components role vars in control-plane.yml, ensuring the node-specific IP is properly passed through.

## Test plan
- [ ] Deploy to test nodes and verify kubelet uses correct node IP
- [ ] Check `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` contains correct `--node-ip` value
- [ ] Verify nodes register with correct IP in the cluster

🤖 Generated with [Claude Code](https://claude.ai/code)