### PR TITLE
ci: create follow-up PR for Renovate token rotation drift

### DIFF
--- a/.github/scripts/create-renovate-plan-follow-up-pr.sh
+++ b/.github/scripts/create-renovate-plan-follow-up-pr.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${TFACTION_TARGET:?TFACTION_TARGET is required}"
+target="${target%/}"
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+base_ref="${BASE_REF:-main}"
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+pr_url="${server_url}/${repo}/pull/${pr_number}"
+target_slug="${target//\//-}"
+branch="tfaction/renovate-plan-follow-up/pr-${pr_number}-${target_slug}"
+
+plan_file="${target}/tfplan.binary"
+if [[ ! -f "$plan_file" ]] || ! terraform show -json "$plan_file" | jq -e 'any(.resource_changes[]?; .address == "time_rotating.token_rotation" and any(.change.actions[]?; . != "no-op"))' > /dev/null; then
+  echo "No token rotation change was found in ${plan_file}. Skip creating a Renovate plan follow-up PR."
+  exit 0
+fi
+
+if [[ "$(gh pr list --repo "$repo" --head "$branch" --state open --json number --jq 'length')" != "0" ]]; then
+  echo "Renovate plan follow-up PR already exists for ${pr_url} (${branch})"
+  exit 0
+fi
+
+git config user.name "boxp-tfaction[bot]"
+git config user.email "162872338+boxp-tfaction[bot]@users.noreply.github.com"
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${repo}.git"
+git fetch origin "$base_ref"
+git switch -C "$branch" "origin/${base_ref}"
+
+failed_prs_file="${target}/.tfaction/failed-prs"
+mkdir -p "$(dirname "$failed_prs_file")"
+if [[ ! -f "$failed_prs_file" ]]; then
+  {
+    echo "# This file is created and updated by tfaction for follow up pull requests."
+    echo "# You can remove this file safely."
+  } > "$failed_prs_file"
+fi
+
+if ! grep -Fxq "$pr_url" "$failed_prs_file"; then
+  echo "$pr_url" >> "$failed_prs_file"
+fi
+
+git add "$failed_prs_file"
+if git diff --cached --quiet; then
+  echo "No follow-up change was needed for ${pr_url}"
+  exit 0
+fi
+
+git commit -m "chore(${target}): follow up Renovate plan drift #${pr_number}"
+git push --force-with-lease origin "$branch"
+
+gh pr create \
+  --repo "$repo" \
+  --base "$base_ref" \
+  --head "$branch" \
+  --title "chore(${target}): follow up Renovate plan drift #${pr_number}" \
+  --body "This PR was created because Renovate PR #${pr_number} detected Terraform token rotation drift for \`${target}\` before merge.
+
+Review the Terraform plan for this PR. If the plan only contains expected token rotation, merge this PR first, then rerun or rebase the Renovate PR so it can get a fresh no-change plan."

--- a/.github/workflows/wc-plan.yaml
+++ b/.github/workflows/wc-plan.yaml
@@ -158,3 +158,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{steps.generate_token.outputs.token}} # For GitHub Provider and tfcmt and github-comment
           CLOUDFLARE_API_TOKEN: ${{secrets.gh_cloudflare_api_token}} # For cloudflare provider
+
+      - name: Create Renovate plan follow-up PR
+        if: |
+          failure() &&
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.user.login == 'renovate[bot]'
+        run: ${{ github.workspace }}/.github/scripts/create-renovate-plan-follow-up-pr.sh
+        env:
+          GITHUB_TOKEN: ${{steps.generate_token.outputs.token}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
+          BASE_REF: ${{github.event.pull_request.base.ref}}

--- a/docs/project_docs/task-20260502-001/plan.md
+++ b/docs/project_docs/task-20260502-001/plan.md
@@ -1,0 +1,22 @@
+# task-20260502-001: Renovate plan drift follow-up PR
+
+## Goal
+
+When a Renovate PR hits unrelated Terraform drift such as token rotation, create a separate PR that applies the drift before the Renovate PR is merged.
+
+## Background
+
+PR #8650 updates only aqua files, but `terraform/cloudflare/b0xp.io/grafana` plan reports `time_rotating.token_rotation` creation. Because tfaction requires Renovate PRs to be no-change, the Renovate PR is blocked. Forcing the Renovate PR through later causes apply to fail because the plan artifact is not available for the drifted state.
+
+## Approach
+
+- Keep tfaction's Renovate no-change safeguard.
+- Do not mark the Renovate plan as successful.
+- On Renovate plan failure, create a follow-up PR from the base branch.
+- The follow-up PR only updates `<target>/.tfaction/failed-prs`, so tfaction plans/applies the affected target without including the Renovate dependency update.
+- If the follow-up plan only contains expected drift such as token rotation, merge it first and rerun/rebase the Renovate PR.
+
+## Scope
+
+- Add a reusable script for creating the Renovate plan follow-up PR.
+- Call it from `wc-plan.yaml` only for failed `pull_request_target` runs from `renovate[bot]`.


### PR DESCRIPTION
## Summary
- create a Renovate plan follow-up PR when a Renovate PR detects token rotation drift
- keep the original Renovate plan failure/no-change safeguard intact
- add task plan documentation at docs/project_docs/task-20260502-001/plan.md

## Verification
- git diff --check
- bash -n .github/scripts/create-renovate-plan-follow-up-pr.sh
- python3 YAML parse for .github/workflows/wc-plan.yaml
- jq expression smoke test for time_rotating.token_rotation detection

## Notes
This addresses the #8650 style case: the Renovate PR remains blocked, but a separate base-branch follow-up PR is created immediately so token rotation can be reviewed and merged first.