### PR TITLE
[codex] Extend Orange Pi image build timeout

### DIFF
--- a/.github/workflows/build-orange-pi-images.yml
+++ b/.github/workflows/build-orange-pi-images.yml
@@ -35,7 +35,7 @@ jobs:
   build-images:
     needs: determine-nodes
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

- Increase the `build-images` job timeout in `build-orange-pi-images.yml` from 30 minutes to 120 minutes.
- Keep the existing workflow structure unchanged.

## Why

Recent Orange Pi image builds are being cancelled after roughly 30 minutes even though historical successful runs take a little over an hour. The cancellation is caused by the workflow job timeout added for ghalint compliance, not by a GitHub Actions platform-wide 30 minute limit.

## Validation

- `actionlint .github/workflows/build-orange-pi-images.yml`
- `git diff --check`