### PR TITLE
[codex] Set strict Kubernetes log rotation

### DIFF
--- a/ansible/roles/kubernetes_components/defaults/main.yml
+++ b/ansible/roles/kubernetes_components/defaults/main.yml
@@ -15,6 +15,9 @@ kubelet_cluster_domain: "cluster.local"
 
 # Container runtime configuration
 container_runtime: "cri-o"
+container_log_max_size: "1Mi"
+container_log_max_files: 2
+crio_log_size_max: 1048576
 
 # System configuration
 kubernetes_disable_swap: true

--- a/ansible/roles/kubernetes_components/molecule/default/verify.yml
+++ b/ansible/roles/kubernetes_components/molecule/default/verify.yml
@@ -33,6 +33,28 @@
           - crio_config.stat.exists
         fail_msg: "CRI-O configuration file does not exist"
 
+    - name: Check if CRI-O log rotation configuration exists
+      ansible.builtin.stat:
+        path: /etc/crio/crio.conf.d/99-log-rotation.conf
+      register: crio_log_rotation_config
+
+    - name: Assert CRI-O log rotation configuration exists
+      ansible.builtin.assert:
+        that:
+          - crio_log_rotation_config.stat.exists
+        fail_msg: "CRI-O log rotation configuration file does not exist"
+
+    - name: Read CRI-O log rotation configuration
+      ansible.builtin.slurp:
+        path: /etc/crio/crio.conf.d/99-log-rotation.conf
+      register: crio_log_rotation_content
+
+    - name: Assert CRI-O log size limit is configured
+      ansible.builtin.assert:
+        that:
+          - "'log_size_max = 1048576' in (crio_log_rotation_content.content | b64decode)"
+        fail_msg: "CRI-O log size limit is not configured"
+
     - name: Check if kubelet configuration exists
       ansible.builtin.stat:
         path: /etc/kubernetes/kubelet-config.yaml
@@ -43,6 +65,18 @@
         that:
           - kubelet_config.stat.exists
         fail_msg: "Kubelet configuration file does not exist"
+
+    - name: Read kubelet configuration
+      ansible.builtin.slurp:
+        path: /etc/kubernetes/kubelet-config.yaml
+      register: kubelet_config_content
+
+    - name: Assert kubelet container log rotation is configured
+      ansible.builtin.assert:
+        that:
+          - "'containerLogMaxSize: 1Mi' in (kubelet_config_content.content | b64decode)"
+          - "'containerLogMaxFiles: 2' in (kubelet_config_content.content | b64decode)"
+        fail_msg: "Kubelet container log rotation is not configured"
 
     - name: Check if kubelet systemd configuration exists
       ansible.builtin.stat:

--- a/ansible/roles/kubernetes_components/tasks/crio.yml
+++ b/ansible/roles/kubernetes_components/tasks/crio.yml
@@ -66,6 +66,16 @@
   become: true
   notify: Restart crio
 
+- name: Configure CRI-O container log size limit
+  ansible.builtin.copy:
+    dest: /etc/crio/crio.conf.d/99-log-rotation.conf
+    content: |
+      [crio.runtime]
+      log_size_max = {{ crio_log_size_max }}
+    mode: '0644'
+  become: true
+  notify: Restart crio
+
 - name: Create systemd multi-user.target.wants directory
   ansible.builtin.file:
     path: /etc/systemd/system/multi-user.target.wants

--- a/ansible/roles/kubernetes_components/templates/kubelet-config.yaml.j2
+++ b/ansible/roles/kubernetes_components/templates/kubelet-config.yaml.j2
@@ -13,6 +13,8 @@ clusterDNS:
   - {{ kubelet_cluster_dns }}
 clusterDomain: {{ kubelet_cluster_domain }}
 containerRuntimeEndpoint: unix:///var/run/crio/crio.sock
+containerLogMaxSize: {{ container_log_max_size }}
+containerLogMaxFiles: {{ container_log_max_files }}
 cgroupDriver: systemd
 failSwapOn: false
 serverTLSBootstrap: true

--- a/docs/project_docs/strict-k8s-log-rotation/plan.md
+++ b/docs/project_docs/strict-k8s-log-rotation/plan.md
@@ -1,0 +1,13 @@
+# strict-k8s-log-rotation
+
+## 背景
+
+Orange Pi control plane nodes の `/var/log` は Armbian の zram 上にあり、容量が小さい。Kubernetes/CRI-O の pod log が無制限またはデフォルトの大きめの上限で残ると、障害時の高頻度ログで `/var/log` が埋まり、kubelet/CRI-O の復旧を妨げる。
+
+## 計画
+
+1. `kubernetes_components` role に container log rotation のデフォルト値を追加する。
+2. kubelet config template に `containerLogMaxSize` と `containerLogMaxFiles` を出力する。
+3. CRI-O drop-in に `log_size_max` を設定して runtime 側でも 1MiB 上限を持たせる。
+4. Molecule verify で kubelet/CRI-O の設定ファイル内容を確認する。
+5. `ansible-lint` を実行し、既存 role の品質チェックを通す。


### PR DESCRIPTION
## Summary

- Add strict Kubernetes container log rotation defaults to the `kubernetes_components` role.
- Configure kubelet with `containerLogMaxSize: 1Mi` and `containerLogMaxFiles: 2`.
- Configure CRI-O with `log_size_max = 1048576` via a managed drop-in.
- Add Molecule verification for the kubelet and CRI-O log rotation settings.

## Why

Shanghai control-plane nodes mount `/var/log` on a small Armbian zram filesystem. During the shanghai-1 recovery incident, Kubernetes pod logs filled `/var/log`, which made kubelet/CRI-O recovery harder. The previous CRI-O config allowed unbounded container logs, and kubelet did not explicitly cap container log retention.

## Validation

- `cd ansible && uv run ansible-lint`
- Applied the same settings manually to `shanghai-1` and `shanghai-2`.
- Confirmed both nodes stayed `Ready` and `https://192.168.10.99:6443/readyz` returned `ok` after restarting `crio` and `kubelet`.