### PR TITLE
BOXP-7: Add Codex workspace image and WARP route

### DIFF
--- a/.github/workflows/build-codex-workspace-image.yml
+++ b/.github/workflows/build-codex-workspace-image.yml
@@ -1,0 +1,44 @@
+name: Build Codex Workspace Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['docker/codex-workspace/**']
+  pull_request:
+    paths: ['docker/codex-workspace/**']
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/boxp/arch/codex-workspace
+          tags: |
+            type=raw,value={{date 'YYYYMMDDHHmm'}},enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: docker/codex-workspace
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -1,0 +1,95 @@
+FROM ubuntu:26.04
+
+ARG CODEX_VERSION=0.133.0
+ARG EVEN_TERMINAL_VERSION=0.7.9
+ARG OBSIDIAN_HEADLESS_VERSION=0.0.8
+ARG GHQ_VERSION=1.10.1
+ARG GWQ_VERSION=0.1.1
+ARG CEEKER_VERSION=0.3.7
+ARG BABASHKA_VERSION=1.12.218
+ARG LAZYGIT_VERSION=0.61.1
+ARG YAZI_VERSION=26.5.6
+ARG NODE_MAJOR=24
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bash-completion \
+      ca-certificates \
+      curl \
+      fzf \
+      git \
+      gnupg \
+      gzip \
+      jq \
+      less \
+      locales \
+      openssh-server \
+      ripgrep \
+      sudo \
+      tar \
+      tmux \
+      unzip \
+      vim \
+      xz-utils \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+      "@openai/codex@${CODEX_VERSION}" \
+      "@evenrealities/even-terminal@${EVEN_TERMINAL_VERSION}" \
+      "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}" \
+    && npm cache clean --force
+
+RUN set -eux; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL "https://github.com/x-motemen/ghq/releases/download/v${GHQ_VERSION}/ghq_linux_amd64.zip" -o "$tmp/ghq.zip"; \
+    unzip -q "$tmp/ghq.zip" -d "$tmp/ghq"; \
+    install -m 0755 "$(find "$tmp/ghq" -type f -name ghq | head -n 1)" /usr/local/bin/ghq; \
+    curl -fsSL "https://github.com/d-kuro/gwq/releases/download/v${GWQ_VERSION}/gwq_Linux_x86_64.tar.gz" -o "$tmp/gwq.tar.gz"; \
+    tar -xzf "$tmp/gwq.tar.gz" -C "$tmp"; \
+    install -m 0755 "$(find "$tmp" -type f -name gwq | head -n 1)" /usr/local/bin/gwq; \
+    curl -fsSL "https://github.com/boxp/ceeker/releases/download/v${CEEKER_VERSION}/ceeker-linux-amd64.tar.gz" -o "$tmp/ceeker.tar.gz"; \
+    tar -xzf "$tmp/ceeker.tar.gz" -C "$tmp"; \
+    install -m 0755 "$tmp/ceeker-linux-amd64" /usr/local/bin/ceeker; \
+    curl -fsSL "https://github.com/babashka/babashka/releases/download/v${BABASHKA_VERSION}/babashka-${BABASHKA_VERSION}-linux-amd64-static.tar.gz" -o "$tmp/bb.tar.gz"; \
+    tar -xzf "$tmp/bb.tar.gz" -C "$tmp"; \
+    install -m 0755 "$(find "$tmp" -type f -name bb | head -n 1)" /usr/local/bin/bb; \
+    curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_linux_x86_64.tar.gz" -o "$tmp/lazygit.tar.gz"; \
+    tar -xzf "$tmp/lazygit.tar.gz" -C "$tmp"; \
+    install -m 0755 "$(find "$tmp" -type f -name lazygit | head -n 1)" /usr/local/bin/lazygit; \
+    curl -fsSL "https://github.com/sxyazi/yazi/releases/download/v${YAZI_VERSION}/yazi-x86_64-unknown-linux-gnu.zip" -o "$tmp/yazi.zip"; \
+    unzip -q "$tmp/yazi.zip" -d "$tmp/yazi"; \
+    install -m 0755 "$(find "$tmp/yazi" -type f -name yazi | head -n 1)" /usr/local/bin/yazi; \
+    install -m 0755 "$(find "$tmp/yazi" -type f -name ya | head -n 1)" /usr/local/bin/ya; \
+    rm -rf "$tmp"
+
+RUN locale-gen en_US.UTF-8 \
+    && if getent passwd 1000 >/dev/null; then \
+      existing_user="$(getent passwd 1000 | cut -d: -f1)"; \
+      usermod --login boxp --home /home/boxp --move-home "$existing_user"; \
+    else \
+      useradd --create-home --shell /bin/bash --uid 1000 boxp; \
+    fi \
+    && usermod -aG sudo boxp \
+    && echo "boxp ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/boxp \
+    && chmod 0440 /etc/sudoers.d/boxp \
+    && install -d -m 0755 /run/sshd
+
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    PATH=/home/boxp/.local/bin:/home/boxp/go/bin:/usr/local/bin:/usr/bin:/bin
+
+COPY entrypoint.sh /usr/local/bin/codex-workspace-entrypoint
+RUN chmod 0755 /usr/local/bin/codex-workspace-entrypoint
+
+EXPOSE 2222 3456
+ENTRYPOINT ["/usr/local/bin/codex-workspace-entrypoint"]

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -11,7 +11,7 @@ if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
 fi
 
 ssh-keygen -A
-/usr/sbin/sshd -D -e &
+/usr/sbin/sshd -D -e -p "${SSHD_PORT:-2222}" &
 
 token_args=()
 if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install -d -m 0755 /run/sshd
+install -d -o boxp -g boxp -m 0755 /home/boxp
+install -d -o boxp -g boxp -m 0700 /home/boxp/.ssh
+install -d -o boxp -g boxp -m 0755 /home/boxp/ghq
+
+if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
+  install -o boxp -g boxp -m 0600 /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys
+fi
+
+ssh-keygen -A
+/usr/sbin/sshd -D -e &
+
+token_args=()
+if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then
+  token_args=(--token "${EVEN_TERMINAL_TOKEN}")
+fi
+
+exec runuser -u boxp -- even-terminal \
+  --port "${EVEN_TERMINAL_PORT:-3456}" \
+  --cwd "${EVEN_TERMINAL_CWD:-/home/boxp}" \
+  --provider "${EVEN_TERMINAL_PROVIDER:-codex}" \
+  --name "${EVEN_TERMINAL_NAME:-lolice-codex-workspace}" \
+  "${token_args[@]}"

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -1,0 +1,31 @@
+# BOXP-7: lolice cluster 上に Codex workspace を作成する
+
+## Goal
+
+OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal Mode で作業できる常設 workspace を作成する。
+
+## Design
+
+- `ghcr.io/boxp/arch/codex-workspace` image を `ubuntu:26.04` から build する。
+- Image build は amd64 worker 固定のため `linux/amd64` のみ。
+- Image には `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` を入れる。
+- `terraform/cloudflare/b0xp.io/k8s` で既存 k8s tunnel に WARP private route `10.111.250.7/32` を追加する。
+- `lolice` 側は fixed ClusterIP `10.111.250.7` の Service を作成し、SSH `2222` と Even Terminal `3456` を公開する。
+
+## Tasks
+
+- [x] チケットを起票する。
+- [x] Even G2 Terminal Mode と `@evenrealities/even-terminal` の接続モデルを確認する。
+- [x] 既存の bastion/Cloudflare/Longhorn PVC パターンを確認する。
+- [x] workspace image build を追加する。
+- [x] Cloudflare WARP private route を追加する。
+- [x] Terraform validate を通す。
+- [ ] PR を作成する。
+
+## Verification
+
+- `terraform -chdir=terraform/cloudflare/b0xp.io/k8s fmt -check`
+- `terraform -chdir=terraform/cloudflare/b0xp.io/k8s validate`
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `docker build --no-cache -t codex-workspace:test docker/codex-workspace`
+- `docker run --rm --entrypoint /bin/bash codex-workspace:test -lc '...'` で主要ツールの起動を確認。

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -9,6 +9,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - `ghcr.io/boxp/arch/codex-workspace` image を `ubuntu:26.04` から build する。
 - Image build は amd64 worker 固定のため `linux/amd64` のみ。
 - Image には `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` を入れる。
+- Dockerfile の pinned package versions は Renovate custom manager で更新対象にする。
 - `terraform/cloudflare/b0xp.io/k8s` で既存 k8s tunnel に WARP private route `10.111.250.7/32` を追加する。
 - `codex-workspace.b0xp.io` は DNS-only A record として `10.111.250.7` に解決させる。
 - `lolice` 側は fixed ClusterIP `10.111.250.7` の Service を作成し、SSH `2222` と Even Terminal `3456` を公開する。
@@ -30,3 +31,4 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - `bash -n docker/codex-workspace/entrypoint.sh`
 - `docker build --no-cache -t codex-workspace:test docker/codex-workspace`
 - `docker run --rm --entrypoint /bin/bash codex-workspace:test -lc '...'` で主要ツールの起動を確認。
+- `npx --yes --package renovate renovate-config-validator renovate.json5`

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -10,6 +10,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - Image build は amd64 worker 固定のため `linux/amd64` のみ。
 - Image には `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` を入れる。
 - `terraform/cloudflare/b0xp.io/k8s` で既存 k8s tunnel に WARP private route `10.111.250.7/32` を追加する。
+- `codex-workspace.b0xp.io` は DNS-only A record として `10.111.250.7` に解決させる。
 - `lolice` 側は fixed ClusterIP `10.111.250.7` の Service を作成し、SSH `2222` と Even Terminal `3456` を公開する。
 
 ## Tasks

--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,105 @@
       ],
       depNameTemplate: "kube-vip/kube-vip",
       datasourceTemplate: "github-releases"
+    },
+    // Codex workspace npm package versions
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG CODEX_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "@openai/codex",
+      datasourceTemplate: "npm"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG EVEN_TERMINAL_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "@evenrealities/even-terminal",
+      datasourceTemplate: "npm"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG OBSIDIAN_HEADLESS_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "obsidian-headless",
+      datasourceTemplate: "npm"
+    },
+    // Codex workspace GitHub release versions
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG GHQ_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "x-motemen/ghq",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG GWQ_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "d-kuro/gwq",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG CEEKER_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "boxp/ceeker",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG BABASHKA_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "babashka/babashka",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG LAZYGIT_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "jesseduffield/lazygit",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG YAZI_VERSION=(?<currentValue>[0-9.]+)"
+      ],
+      depNameTemplate: "sxyazi/yazi",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.*)$"
+    },
+    // Codex workspace NodeSource major version
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG NODE_MAJOR=(?<currentValue>[0-9]+)"
+      ],
+      depNameTemplate: "node",
+      datasourceTemplate: "node-version"
     }
   ],
   packageRules: [

--- a/terraform/cloudflare/b0xp.io/k8s/dns.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/dns.tf
@@ -6,3 +6,12 @@ resource "cloudflare_record" "k8s" {
   type    = "CNAME"
   proxied = true
 }
+
+# Creates the DNS-only record for WARP private routing to the Codex workspace.
+resource "cloudflare_record" "codex_workspace" {
+  zone_id = var.zone_id
+  name    = "codex-workspace"
+  content = "10.111.250.7"
+  type    = "A"
+  proxied = false
+}

--- a/terraform/cloudflare/b0xp.io/k8s/tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/tunnel.tf
@@ -13,6 +13,9 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "k8s_tunnel" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.k8s_tunnel.id
   account_id = var.account_id
   config {
+    warp_routing {
+      enabled = true
+    }
     ingress_rule {
       hostname = cloudflare_record.k8s.hostname
       service  = "http://argocd-server.argocd.svc.cluster.local:8080"
@@ -21,4 +24,11 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "k8s_tunnel" {
       service = "http_status:404"
     }
   }
+}
+
+resource "cloudflare_zero_trust_tunnel_route" "codex_workspace" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.k8s_tunnel.id
+  network    = "10.111.250.7/32"
+  comment    = "lolice codex-workspace Service for WARP access"
 }


### PR DESCRIPTION
## Summary

- Add an amd64-only Ubuntu 26.04 Codex workspace image build for GHCR.
- Install Codex, even-terminal, obsidian-headless, Node.js, git, ghq, gwq, ceeker, bb, lazygit, yazi, and vim in the image.
- Start sshd on the advertised workspace SSH port 2222 by default.
- Add Renovate custom managers for the Dockerfile ARG-pinned npm, GitHub release, and Node major versions.
- Add Cloudflare WARP private routing for the lolice codex-workspace Service at 10.111.250.7/32.
- Add DNS-only A record codex-workspace.b0xp.io -> 10.111.250.7 so WARP clients can connect by hostname.

## Validation

- terraform -chdir=terraform/cloudflare/b0xp.io/k8s fmt -check
- terraform -chdir=terraform/cloudflare/b0xp.io/k8s validate
- bash -n docker/codex-workspace/entrypoint.sh
- docker build -t codex-workspace:test docker/codex-workspace
- docker run --rm --entrypoint /bin/bash codex-workspace:test -lc 'install -d /run/sshd; ssh-keygen -A >/dev/null; /usr/sbin/sshd -T -p 2222 | grep "^port "'
- docker run --rm --entrypoint /bin/bash codex-workspace:test -lc '...'
- npx --yes --package renovate renovate-config-validator renovate.json5