### PR TITLE
BOXP-7: Fix Codex workspace boxp group

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -73,11 +73,17 @@ RUN set -eux; \
     rm -rf "$tmp"
 
 RUN locale-gen en_US.UTF-8 \
+    && if getent group 1000 >/dev/null; then \
+      existing_group="$(getent group 1000 | cut -d: -f1)"; \
+      if [ "$existing_group" != "boxp" ]; then groupmod --new-name boxp "$existing_group"; fi; \
+    else \
+      groupadd --gid 1000 boxp; \
+    fi \
     && if getent passwd 1000 >/dev/null; then \
       existing_user="$(getent passwd 1000 | cut -d: -f1)"; \
-      usermod --login boxp --home /home/boxp --move-home "$existing_user"; \
+      usermod --login boxp --home /home/boxp --gid 1000 --move-home "$existing_user"; \
     else \
-      useradd --create-home --shell /bin/bash --uid 1000 boxp; \
+      useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 boxp; \
     fi \
     && usermod -aG sudo boxp \
     && echo "boxp ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/boxp \

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -9,6 +9,8 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - `ghcr.io/boxp/arch/codex-workspace` image を `ubuntu:26.04` から build する。
 - Image build は amd64 worker 固定のため `linux/amd64` のみ。
 - Image には `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` を入れる。
+- Ubuntu base image の UID/GID 1000 既存ユーザーを利用する場合も user/group を `boxp:boxp` に揃え、entrypoint の `/home/boxp` 初期化が失敗しないようにする。
+- `obsidian-headless` package は `ob` command として利用する。
 - Dockerfile の pinned package versions は Renovate custom manager で更新対象にする。
 - `terraform/cloudflare/b0xp.io/k8s` で既存 k8s tunnel に WARP private route `10.111.250.7/32` を追加する。
 - `codex-workspace.b0xp.io` は DNS-only A record として `10.111.250.7` に解決させる。
@@ -20,6 +22,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] Even G2 Terminal Mode と `@evenrealities/even-terminal` の接続モデルを確認する。
 - [x] 既存の bastion/Cloudflare/Longhorn PVC パターンを確認する。
 - [x] workspace image build を追加する。
+- [x] workspace image 内の `boxp` user/group 作成を修正する。
 - [x] Cloudflare WARP private route を追加する。
 - [x] Terraform validate を通す。
 - [ ] PR を作成する。


### PR DESCRIPTION
## Summary

- ensure the Codex workspace image creates or renames GID 1000 to `boxp`
- set the `boxp` user primary group to GID 1000 so entrypoint ownership setup can use `boxp:boxp`
- document that `obsidian-headless` is provided through the `ob` command

## Verification

- `git diff --check`
- `bash -n docker/codex-workspace/entrypoint.sh`
- `docker build -t codex-workspace:boxp-group docker/codex-workspace`
- `docker run --rm --entrypoint /bin/bash codex-workspace:boxp-group -lc 'getent passwd boxp; getent group boxp; install -d -o boxp -g boxp -m 0755 /tmp/boxp-test; stat -c "%U:%G %a" /tmp/boxp-test; codex --version; even-terminal --version; ob --version; node --version; npm --version'`