### PR TITLE
BOXP-7: Run Even Terminal from persistent home

### DIFF
--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -13,12 +13,14 @@ fi
 ssh-keygen -A
 /usr/sbin/sshd -D -e -p "${SSHD_PORT:-2222}" &
 
+cd /home/boxp
+
 token_args=()
 if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then
   token_args=(--token "${EVEN_TERMINAL_TOKEN}")
 fi
 
-exec /usr/sbin/runuser -u boxp -- even-terminal \
+exec /usr/sbin/runuser -u boxp -- env HOME=/home/boxp even-terminal \
   --port "${EVEN_TERMINAL_PORT:-3456}" \
   --cwd "${EVEN_TERMINAL_CWD:-/home/boxp}" \
   --provider "${EVEN_TERMINAL_PROVIDER:-codex}" \

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -12,6 +12,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - Ubuntu base image の UID/GID 1000 既存ユーザーを利用する場合も user/group を `boxp:boxp` に揃え、entrypoint の `/home/boxp` 初期化が失敗しないようにする。
 - `obsidian-headless` package は `ob` command として利用する。
 - entrypoint は `/usr/sbin/runuser` で `even-terminal` を `boxp` user として起動する。
+- `even-terminal` のログやユーザー設定が root filesystem 直下へ出ないよう、process cwd と `HOME` を `/home/boxp` に揃える。
 - Dockerfile の pinned package versions は Renovate custom manager で更新対象にする。
 - `terraform/cloudflare/b0xp.io/k8s` で既存 k8s tunnel に WARP private route `10.111.250.7/32` を追加する。
 - `codex-workspace.b0xp.io` は DNS-only A record として `10.111.250.7` に解決させる。
@@ -25,6 +26,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] workspace image build を追加する。
 - [x] workspace image 内の `boxp` user/group 作成を修正する。
 - [x] workspace image entrypoint で `/usr/sbin/runuser` を使うように修正する。
+- [x] workspace image entrypoint で `even-terminal` の cwd/HOME を `/home/boxp` に揃える。
 - [x] Cloudflare WARP private route を追加する。
 - [x] Terraform validate を通す。
 - [ ] PR を作成する。


### PR DESCRIPTION
## Summary

- set the workspace process cwd to `/home/boxp` before starting Even Terminal
- pass `HOME=/home/boxp` through `runuser` so Even Terminal writes logs/config under the persistent home directory
- update the BOXP-7 plan with the runtime home requirement

## Verification

- `git diff --check`
- `bash -n docker/codex-workspace/entrypoint.sh`
- `docker build -t codex-workspace:even-home docker/codex-workspace`
- `docker run --rm --entrypoint /bin/bash codex-workspace:even-home -lc 'cd /home/boxp && /usr/sbin/runuser -u boxp -- env HOME=/home/boxp sh -lc '\''test "$HOME" = /home/boxp; test "$(pwd)" = /home/boxp; touch even-terminal-write-test.log; stat -c "%U:%G %n" even-terminal-write-test.log'\'''`