### PR TITLE
BOXP-7: Unlock Codex workspace user

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -86,6 +86,7 @@ RUN locale-gen en_US.UTF-8 \
       useradd --create-home --shell /bin/bash --uid 1000 --gid 1000 boxp; \
     fi \
     && usermod -aG sudo boxp \
+    && passwd -d boxp \
     && echo "boxp ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/boxp \
     && chmod 0440 /etc/sudoers.d/boxp \
     && install -d -m 0755 /run/sshd

--- a/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
+++ b/docs/project_docs/BOXP-7-codex-workspace-on-lolice/plan.md
@@ -10,6 +10,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - Image build は amd64 worker 固定のため `linux/amd64` のみ。
 - Image には `codex`, `@evenrealities/even-terminal`, `obsidian-headless`, `git`, `ghq`, `gwq`, `boxp/ceeker`, `bb`, `lazygit`, `yazi`, `vim`, `node`, `npm` を入れる。
 - Ubuntu base image の UID/GID 1000 既存ユーザーを利用する場合も user/group を `boxp:boxp` に揃え、entrypoint の `/home/boxp` 初期化が失敗しないようにする。
+- `boxp` user は SSH public key login 用に locked account にしない。`PasswordAuthentication no` のため password login は無効。
 - `obsidian-headless` package は `ob` command として利用する。
 - entrypoint は `/usr/sbin/runuser` で `even-terminal` を `boxp` user として起動する。
 - `even-terminal` のログやユーザー設定が root filesystem 直下へ出ないよう、process cwd と `HOME` を `/home/boxp` に揃える。
@@ -28,6 +29,7 @@ OpenClaw の代替として、`lolice` cluster 上に Codex と Even G2 Terminal
 - [x] 既存の bastion/Cloudflare/Longhorn PVC パターンを確認する。
 - [x] workspace image build を追加する。
 - [x] workspace image 内の `boxp` user/group 作成を修正する。
+- [x] workspace image 内の `boxp` account lock を解除する。
 - [x] workspace image entrypoint で `/usr/sbin/runuser` を使うように修正する。
 - [x] workspace image entrypoint で `even-terminal` の cwd/HOME を `/home/boxp` に揃える。
 - [x] Cloudflare WARP private route を追加する。


### PR DESCRIPTION
## Summary
- unlock the boxp account in the codex-workspace image so OpenSSH accepts public key login
- keep password login disabled by the Kubernetes sshd_config (PasswordAuthentication no)

## Verification
- bash -n docker/codex-workspace/entrypoint.sh
- docker build -t codex-workspace:unlock-test docker/codex-workspace
- docker run --rm --entrypoint /bin/bash codex-workspace:unlock-test -lc 'getent passwd boxp; getent shadow boxp; passwd -S boxp'