### PR TITLE
[codex] Fix etcd snapshot backup flow

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -29,6 +29,7 @@ on:
 env:
   NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104"}'
   ALL_NODE_IPS: "192.168.10.102 192.168.10.103 192.168.10.104"
+  ETCD_SNAPSHOT_S3_URI: s3://arch-etcd-snapshots/kubernetes-upgrade
 
 jobs:
   extract-versions:
@@ -190,6 +191,8 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
+          ETCD_SNAPSHOT_ARTIFACT_DIR="/tmp/etcd-snapshots"
+          mkdir -p "${ETCD_SNAPSHOT_ARTIFACT_DIR}"
           cd ansible
           source .venv/bin/activate
           echo "Running pre-upgrade checks with K8S_VERSION=${K8S_VERSION}"
@@ -201,6 +204,8 @@ jobs:
             -e "kubernetes_upgrade_version=${K8S_VERSION}" \
             -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
             -e "crio_upgrade_version=${CRIO_VERSION}" \
+            -e "etcd_snapshot_local_dir=${ETCD_SNAPSHOT_ARTIFACT_DIR}" \
+            -e "etcd_snapshot_force=true" \
             -vv 2>&1 | tee /tmp/pre-check-ansible.log
 
       - name: Upload pre-check logs
@@ -210,6 +215,25 @@ jobs:
           name: pre-check-ansible-log
           path: /tmp/pre-check-ansible.log
           retention-days: 14
+
+      - name: Upload etcd snapshot to S3
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          snapshots=(/tmp/etcd-snapshots/*.db)
+          if [ "${#snapshots[@]}" -eq 0 ]; then
+            echo "No etcd snapshots found to upload"
+            exit 0
+          fi
+
+          for snapshot in "${snapshots[@]}"; do
+            aws s3 cp "${snapshot}" \
+              "${ETCD_SNAPSHOT_S3_URI}/run-${GITHUB_RUN_ID}/$(basename "${snapshot}")" \
+              --sse AES256
+          done
 
   upgrade-cp-1:
     name: Upgrade shanghai-1 (first CP)

--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -16,6 +16,10 @@ upgrade_health_check_delay: 10       # seconds
 
 # etcd snapshot
 etcd_snapshot_dir: /var/lib/etcd-snapshots
+etcd_snapshot_pod_dir: /tmp
+etcd_snapshot_local_dir: ""
+etcd_snapshot_cleanup_pod_file: true
+etcd_snapshot_force: false
 etcd_cacert: /etc/kubernetes/pki/etcd/ca.crt
 etcd_cert: /etc/kubernetes/pki/etcd/healthcheck-client.crt
 etcd_key: /etc/kubernetes/pki/etcd/healthcheck-client.key

--- a/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
@@ -126,6 +126,35 @@
             *"uncordon"*)
               echo "node/control-plane-test uncordoned"
               ;;
+            *"exec etcd-"*"etcdctl snapshot save"*)
+              snapshot_path=""
+              previous=""
+              for arg in "$@"; do
+                if [ "$previous" = "save" ]; then
+                  snapshot_path="$arg"
+                  break
+                fi
+                previous="$arg"
+              done
+              mkdir -p "$(dirname "$snapshot_path")"
+              printf "mock snapshot\n" > "$snapshot_path"
+              echo "Snapshot saved at $snapshot_path"
+              ;;
+            *"exec etcd-"*"etcdctl snapshot status"*)
+              echo "+----------+----------+------------+------------+"
+              echo "|   HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |"
+              echo "+----------+----------+------------+------------+"
+              echo "| abcd1234 |    12345 |       1000 |     5.0 MB |"
+              echo "+----------+----------+------------+------------+"
+              ;;
+            *"exec etcd-"*" cat "*)
+              snapshot_path="${@: -1}"
+              cat "$snapshot_path"
+              ;;
+            *"exec etcd-"*" rm -f "*)
+              snapshot_path="${@: -1}"
+              rm -f "$snapshot_path"
+              ;;
             *)
               echo "mock kubectl: $*"
               ;;

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create etcd snapshot directory
+- name: Create etcd snapshot directory on control plane host
   ansible.builtin.file:
     path: "{{ etcd_snapshot_dir }}"
     state: directory
@@ -15,39 +15,115 @@
   register: existing_snapshots
   tags: [etcd_snapshot, pre_checks]
 
-- name: Take etcd snapshot before upgrade
+- name: Set etcd snapshot paths
+  ansible.builtin.set_fact:
+    _etcd_snapshot_filename: "pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+    _etcd_snapshot_pod_path: "{{ etcd_snapshot_pod_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+    _etcd_snapshot_remote_path: "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Reuse existing etcd snapshot for today
+  ansible.builtin.set_fact:
+    _etcd_snapshot_remote_path: "{{ (existing_snapshots.files | sort(attribute='mtime') | last).path }}"
+    _etcd_snapshot_filename: "{{ (existing_snapshots.files | sort(attribute='mtime') | last).path | basename }}"
+  when:
+    - not (etcd_snapshot_force | bool)
+    - existing_snapshots.matched > 0
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Take etcd snapshot inside etcd pod
   ansible.builtin.command:
     argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - -n
+      - kube-system
+      - exec
+      - "etcd-{{ inventory_hostname }}"
+      - --
       - etcdctl
       - snapshot
       - save
-      - "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+      - "{{ _etcd_snapshot_pod_path }}"
       - "--cacert={{ etcd_cacert }}"
       - "--cert={{ etcd_cert }}"
       - "--key={{ etcd_key }}"
   become: true
   changed_when: true
-  when: existing_snapshots.matched == 0
+  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
   tags: [etcd_snapshot, pre_checks]
 
-- name: Set snapshot path for verification
-  ansible.builtin.set_fact:
-    _etcd_verify_snapshot: >-
-      {% if existing_snapshots.matched > 0 %}
-      {{ (existing_snapshots.files | sort(attribute='mtime') | last).path }}
-      {% else %}
-      {{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db
-      {% endif %}
+- name: Copy etcd snapshot from pod to control plane host
+  ansible.builtin.shell: |
+    set -o pipefail
+    kubectl \
+      --kubeconfig={{ kubeconfig_path | quote }} \
+      -n kube-system \
+      exec etcd-{{ inventory_hostname | quote }} \
+      -- cat {{ _etcd_snapshot_pod_path | quote }} \
+      > {{ _etcd_snapshot_remote_path | quote }}
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: true
+  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
   tags: [etcd_snapshot, pre_checks]
 
-- name: Verify etcd snapshot integrity
+- name: Verify etcd snapshot integrity inside etcd pod
   ansible.builtin.command:
     argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - -n
+      - kube-system
+      - exec
+      - "etcd-{{ inventory_hostname }}"
+      - --
       - etcdctl
       - snapshot
       - status
-      - "{{ _etcd_verify_snapshot | trim }}"
+      - "{{ _etcd_snapshot_pod_path }}"
       - --write-out=table
   become: true
   changed_when: false
+  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Create local etcd snapshot artifact directory
+  ansible.builtin.file:
+    path: "{{ etcd_snapshot_local_dir }}"
+    state: directory
+    mode: '0700'
+  delegate_to: localhost
+  become: false
+  when: etcd_snapshot_local_dir | length > 0
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Fetch etcd snapshot to local artifact directory
+  ansible.builtin.fetch:
+    src: "{{ _etcd_snapshot_remote_path }}"
+    dest: "{{ etcd_snapshot_local_dir }}/{{ _etcd_snapshot_filename }}"
+    flat: true
+  become: true
+  when: etcd_snapshot_local_dir | length > 0
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Remove temporary etcd snapshot from pod
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - -n
+      - kube-system
+      - exec
+      - "etcd-{{ inventory_hostname }}"
+      - --
+      - rm
+      - -f
+      - "{{ _etcd_snapshot_pod_path }}"
+  become: true
+  changed_when: true
+  when:
+    - etcd_snapshot_cleanup_pod_file | bool
+    - (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
   tags: [etcd_snapshot, pre_checks]

--- a/docs/project_docs/BOXP-2-etcd-snapshot-artifact/plan.md
+++ b/docs/project_docs/BOXP-2-etcd-snapshot-artifact/plan.md
@@ -1,0 +1,14 @@
+# BOXP-2 etcd Snapshot Artifact Plan
+
+## Context
+
+The Kubernetes Upgrade workflow failed during pre-check because `etcdctl` is not installed on the control-plane host. The working command path is inside the static etcd pod via `kubectl exec`.
+
+## Plan
+
+1. Run `etcdctl snapshot save` inside the target etcd pod.
+2. Copy the snapshot from the pod to the control-plane host as a staging file.
+3. Fetch the staged snapshot to the GitHub Actions runner when `etcd_snapshot_local_dir` is set.
+4. Upload fetched snapshots from the GitHub Actions runner to `s3://arch-etcd-snapshots/kubernetes-upgrade/`.
+5. Keep the pod snapshot temporary and remove it after verification.
+6. Manage the S3 bucket, encryption, lifecycle, and GitHub Actions role permissions in Terraform.

--- a/terraform/aws/github-actions-ansible/etcd_snapshots.tf
+++ b/terraform/aws/github-actions-ansible/etcd_snapshots.tf
@@ -1,0 +1,102 @@
+resource "aws_s3_bucket" "etcd_snapshots" {
+  bucket = "arch-etcd-snapshots"
+}
+
+resource "aws_s3_bucket_public_access_block" "etcd_snapshots" {
+  bucket = aws_s3_bucket.etcd_snapshots.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "etcd_snapshots" {
+  bucket = aws_s3_bucket.etcd_snapshots.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "etcd_snapshots" {
+  bucket = aws_s3_bucket.etcd_snapshots.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "etcd_snapshots" {
+  bucket = aws_s3_bucket.etcd_snapshots.id
+
+  rule {
+    id     = "expire-etcd-snapshots"
+    status = "Enabled"
+
+    filter {
+      prefix = "kubernetes-upgrade/"
+    }
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_iam_policy" "etcd_snapshot_s3_write" {
+  name        = "GitHubActions_Ansible_EtcdSnapshotS3Write"
+  path        = "/"
+  description = "Allow GitHub Actions Ansible role to write Kubernetes etcd snapshots to S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation"
+        ]
+        Resource = aws_s3_bucket.etcd_snapshots.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = aws_s3_bucket.etcd_snapshots.arn
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              "kubernetes-upgrade/*"
+            ]
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = "${aws_s3_bucket.etcd_snapshots.arn}/kubernetes-upgrade/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_ansible_etcd_snapshot_s3_write" {
+  role       = aws_iam_role.github_actions_ansible.name
+  policy_arn = aws_iam_policy.etcd_snapshot_s3_write.arn
+}


### PR DESCRIPTION
## Summary

- Run `etcdctl snapshot save` inside the etcd pod instead of assuming `etcdctl` exists on the control-plane host.
- Fetch the staged snapshot back to the GitHub Actions runner and upload it to `s3://arch-etcd-snapshots/kubernetes-upgrade/run-${GITHUB_RUN_ID}/` with S3 server-side encryption.
- Add Terraform for the dedicated S3 bucket, lifecycle policy, public access block, encryption, and GitHub Actions role write permissions.
- Add the required project plan document for BOXP-2.

## Root Cause

The pre-upgrade workflow was running `etcdctl` directly on the control-plane host, but `etcdctl` is only available inside the static etcd pod.

## Validation

- `git diff --check`
- `ansible-playbook --syntax-check -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml`
- `ansible-lint --offline roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/defaults/main.yml roles/kubernetes_upgrade/molecule/default/prepare.yml`
- `terraform fmt -check` for `terraform/aws/github-actions-ansible`
- `terraform validate` for `terraform/aws/github-actions-ansible`