### PR TITLE
[codex] Fix etcd snapshot copy without cat

### DIFF
--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -16,7 +16,7 @@ upgrade_health_check_delay: 10       # seconds
 
 # etcd snapshot
 etcd_snapshot_dir: /var/lib/etcd-snapshots
-etcd_snapshot_pod_dir: /tmp
+etcd_snapshot_pod_dir: /var/lib/etcd
 etcd_snapshot_local_dir: ""
 etcd_snapshot_cleanup_pod_file: true
 etcd_snapshot_force: false

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -53,22 +53,6 @@
   when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
   tags: [etcd_snapshot, pre_checks]
 
-- name: Copy etcd snapshot from pod to control plane host
-  ansible.builtin.shell: |
-    set -o pipefail
-    kubectl \
-      --kubeconfig={{ kubeconfig_path | quote }} \
-      -n kube-system \
-      exec etcd-{{ inventory_hostname | quote }} \
-      -- cat {{ _etcd_snapshot_pod_path | quote }} \
-      > {{ _etcd_snapshot_remote_path | quote }}
-  args:
-    executable: /bin/bash
-  become: true
-  changed_when: true
-  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
-  tags: [etcd_snapshot, pre_checks]
-
 - name: Verify etcd snapshot integrity inside etcd pod
   ansible.builtin.command:
     argv:
@@ -86,6 +70,17 @@
       - --write-out=table
   become: true
   changed_when: false
+  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+  tags: [etcd_snapshot, pre_checks]
+
+- name: Move etcd snapshot from host-mounted etcd data directory
+  ansible.builtin.command:
+    argv:
+      - mv
+      - "{{ _etcd_snapshot_pod_path }}"
+      - "{{ _etcd_snapshot_remote_path }}"
+  become: true
+  changed_when: true
   when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
   tags: [etcd_snapshot, pre_checks]
 
@@ -108,21 +103,14 @@
   when: etcd_snapshot_local_dir | length > 0
   tags: [etcd_snapshot, pre_checks]
 
-- name: Remove temporary etcd snapshot from pod
+- name: Remove temporary etcd snapshot from host-mounted etcd data directory
   ansible.builtin.command:
     argv:
-      - kubectl
-      - "--kubeconfig={{ kubeconfig_path }}"
-      - -n
-      - kube-system
-      - exec
-      - "etcd-{{ inventory_hostname }}"
-      - --
       - rm
       - -f
       - "{{ _etcd_snapshot_pod_path }}"
   become: true
-  changed_when: true
+  changed_when: false
   when:
     - etcd_snapshot_cleanup_pod_file | bool
     - (etcd_snapshot_force | bool) or existing_snapshots.matched == 0

--- a/docs/project_docs/BOXP-2-etcd-snapshot-catless-copy/plan.md
+++ b/docs/project_docs/BOXP-2-etcd-snapshot-catless-copy/plan.md
@@ -1,0 +1,13 @@
+# BOXP-2 etcd snapshot catless copy plan
+
+## Context
+
+The Kubernetes Upgrade dry run failed after creating the etcd snapshot because the etcd container image does not provide `cat`.
+
+## Plan
+
+1. Stop relying on `kubectl exec ... cat` to copy snapshot bytes out of the etcd container.
+2. Save the snapshot inside the etcd pod under `/var/lib/etcd`, which is hostPath-mounted by kubeadm static etcd pods.
+3. Verify the snapshot inside the pod before moving it.
+4. Move the snapshot on the control plane host from `/var/lib/etcd` into `/var/lib/etcd-snapshots`.
+5. Keep the existing fetch-to-runner and S3 upload flow unchanged.


### PR DESCRIPTION
## Summary

- Save etcd snapshots under the etcd hostPath-mounted data directory instead of `/tmp`
- Remove the `kubectl exec ... cat` copy path that failed because the etcd image does not include `cat`
- Move the snapshot on the control plane host before fetching it to the GitHub Actions runner and uploading to S3
- Add the required project plan document

## Root Cause

The Kubernetes Upgrade dry run created the snapshot successfully inside the etcd pod, but failed when copying it back to the host:

```text
executable file `cat` not found in $PATH
```

Because the copy failed, no `.db` reached `/tmp/etcd-snapshots`, and the S3 upload step had nothing to upload.

## Validation

- `git diff --check`
- `ansible-playbook --syntax-check -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml`
- `ansible-lint --offline roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/defaults/main.yml roles/kubernetes_upgrade/molecule/default/prepare.yml`
- `codex review --uncommitted`

Failed dry-run reference: https://github.com/boxp/arch/actions/runs/26409732299