### PR TITLE
[codex] Stabilize Tailscale Terraform plan

### DIFF
--- a/docs/project_docs/arch-tailscale-plan-drift/plan.md
+++ b/docs/project_docs/arch-tailscale-plan-drift/plan.md
@@ -1,0 +1,31 @@
+# Stabilize Tailscale Terraform Plan
+
+## Context
+
+Renovate pull requests that touch `terraform/tailscale/lolice` are failing in
+tfaction plan even though the dependency update is unrelated to live Tailscale
+configuration.
+
+The observed plan difference is limited to:
+
+- `aws_ssm_parameter.subnet_router_auth_key`
+- `/lolice/tailscale/subnet-router-auth-key`
+
+Terraform plans an in-place SSM parameter update for the auth key value.  This
+is a generated secret consumed outside Terraform, so dependency update PRs
+should not be blocked by value drift in that parameter.
+
+## Plan
+
+1. Keep the Tailscale Terraform target and GitHub Actions secrets in place.
+2. Match the subnet router auth key SSM parameter to the existing operator OAuth
+   SSM parameters by ignoring value-only drift.
+3. Re-run the failing Renovate PRs after this fix lands:
+   - `boxp/arch#9591`
+   - `boxp/arch#9519`
+   - `boxp/arch#9619`
+
+## Validation
+
+- `terraform fmt -check terraform/tailscale/lolice`
+- `git diff --check`

--- a/terraform/tailscale/lolice/auth_key.tf
+++ b/terraform/tailscale/lolice/auth_key.tf
@@ -18,4 +18,8 @@ resource "aws_ssm_parameter" "subnet_router_auth_key" {
   description = "Tailscale auth key for lolice subnet router Pod"
   type        = "SecureString"
   value       = tailscale_tailnet_key.subnet_router.key
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }


### PR DESCRIPTION
Closed after investigation.

The latest `terraform/tailscale/lolice` plan failure is not caused by `aws_ssm_parameter.subnet_router_auth_key` drift. The job now fails earlier while refreshing `tailscale_acl.this`:

```text
Error: Failed to fetch ACL
API token invalid (401)
```

So ignoring the SSM parameter value would not address the current failure mode. The next step is to fix or rotate the `TAILSCALE_API_KEY` GitHub secret, then re-run the affected Tailscale Renovate PRs and reassess whether the subnet router auth key drift still appears.