### PR TITLE
[codex] Add Codex workspace cron scheduler

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -103,8 +103,11 @@ ENV LANG=en_US.UTF-8 \
     PATH=/home/boxp/.local/bin:/home/boxp/go/bin:/usr/local/bin:/usr/bin:/bin
 
 COPY entrypoint.sh /usr/local/bin/codex-workspace-entrypoint
+COPY cron/ /opt/codex-workspace/cron/
 COPY skills/ /opt/codex-workspace/skills/
-RUN chmod 0755 /usr/local/bin/codex-workspace-entrypoint
+RUN chmod 0755 /usr/local/bin/codex-workspace-entrypoint \
+    && find /opt/codex-workspace/cron -type f -name "*.sh" -exec chmod 0755 {} + \
+    && find /opt/codex-workspace/cron -type f -name "*.bb" -exec chmod 0755 {} +
 
 EXPOSE 2222 3456
 ENTRYPOINT ["/usr/local/bin/codex-workspace-entrypoint"]

--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -103,6 +103,7 @@ ENV LANG=en_US.UTF-8 \
     PATH=/home/boxp/.local/bin:/home/boxp/go/bin:/usr/local/bin:/usr/bin:/bin
 
 COPY entrypoint.sh /usr/local/bin/codex-workspace-entrypoint
+COPY skills/ /opt/codex-workspace/skills/
 RUN chmod 0755 /usr/local/bin/codex-workspace-entrypoint
 
 EXPOSE 2222 3456

--- a/docker/codex-workspace/cron/codex_cron_lib.bb
+++ b/docker/codex-workspace/cron/codex_cron_lib.bb
@@ -1,0 +1,82 @@
+(ns codex-cron-lib
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+(def default-root "/home/boxp/.codex-cron")
+(def default-registry "jobs.edn")
+(def default-state "jobs-state.edn")
+
+(defn fail [message]
+  (binding [*out* *err*]
+    (println (str "error: " message)))
+  (System/exit 1))
+
+(defn root []
+  (or (System/getProperty "codex.cron.root")
+      (System/getenv "CODEX_CRON_ROOT")
+      default-root))
+
+(defn registry-path []
+  (fs/path (root) (or (System/getenv "CODEX_CRON_JOBS_FILE") default-registry)))
+
+(defn state-path []
+  (fs/path (root) default-state))
+
+(defn prompts-dir []
+  (fs/path (root) "prompts"))
+
+(defn runs-dir []
+  (fs/path (root) "runs"))
+
+(defn locks-dir []
+  (fs/path (root) "locks"))
+
+(defn ensure-root! []
+  (doseq [path [(root) (prompts-dir) (runs-dir) (locks-dir)]]
+    (fs/create-dirs path))
+  (when-not (fs/exists? (registry-path))
+    (spit (str (registry-path)) "{:version 1\n :jobs []}\n")))
+
+(defn read-edn-file [path fallback]
+  (if (fs/exists? path)
+    (edn/read-string (slurp (str path)))
+    fallback))
+
+(defn write-edn-file! [path value]
+  (fs/create-dirs (fs/parent path))
+  (spit (str path) (str (pr-str value) "\n")))
+
+(defn registry []
+  (ensure-root!)
+  (let [value (read-edn-file (registry-path) {:version 1 :jobs []})]
+    (cond
+      (vector? value) {:version 1 :jobs value}
+      (map? value) (update value :jobs #(vec (or % [])))
+      :else (fail (str "invalid registry: " (registry-path))))))
+
+(defn save-registry! [value]
+  (write-edn-file! (registry-path) (update value :jobs vec)))
+
+(defn jobs []
+  (:jobs (registry)))
+
+(defn job [job-id]
+  (or (first (filter #(= job-id (:id %)) (jobs)))
+      (fail (str "job not found: " job-id))))
+
+(defn prompt-path [job-or-id]
+  (let [job (if (map? job-or-id) job-or-id (job job-or-id))
+        value (:prompt-file job)]
+    (cond
+      (nil? value) (fs/path (prompts-dir) (str (:id job) ".md"))
+      (str/starts-with? value "/") (fs/path value)
+      :else (fs/path (root) value))))
+
+(defn shell-quote [value]
+  (let [s (str value)]
+    (str "'" (str/replace s #"'" "'\"'\"'") "'")))
+
+(defn emit [name value]
+  (when-not (or (nil? value) (= "" value))
+    (println (str name "=" (shell-quote value)))))

--- a/docker/codex-workspace/cron/run-codex-cron.sh
+++ b/docker/codex-workspace/cron/run-codex-cron.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+job_id="${1:-${CODEX_CRON_JOB_ID:-}}"
+if [[ -z "${job_id}" ]]; then
+  echo "usage: run-codex-cron.sh <job-id>" >&2
+  exit 2
+fi
+
+cron_root="${CODEX_CRON_ROOT:-/home/boxp/.codex-cron}"
+
+eval "$(
+  bb /opt/codex-workspace/cron/select-codex-cron-job.bb "${job_id}"
+)"
+
+job_name="${CODEX_CRON_NAME:-${job_id}}"
+prompt_file="${CODEX_CRON_PROMPT_FILE:?CODEX_CRON_PROMPT_FILE is required}"
+workdir="${CODEX_CRON_WORKDIR:-/home/boxp}"
+output_root="${CODEX_CRON_OUTPUT_ROOT:-${cron_root}/runs}"
+lock_root="${CODEX_CRON_LOCK_ROOT:-${cron_root}/locks}"
+run_id="${CODEX_CRON_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+run_dir="${output_root}/${job_id}/${run_id}"
+lock_dir="${lock_root}/${job_id}.lock"
+
+mkdir -p "${run_dir}" "${lock_root}"
+
+if ! mkdir "${lock_dir}" 2>/dev/null; then
+  lock_stale_seconds="${CODEX_CRON_LOCK_STALE_SECONDS:-43200}"
+  lock_mtime="$(stat -c %Y "${lock_dir}" 2>/dev/null || echo 0)"
+  now_epoch="$(date -u +%s)"
+  if (( now_epoch - lock_mtime > lock_stale_seconds )); then
+    echo "removing stale codex cron lock: ${lock_dir}" >&2
+    rm -rf "${lock_dir}"
+    mkdir "${lock_dir}"
+  else
+    echo "codex cron job '${job_name}' is already running: ${lock_dir}" >&2
+    exit 75
+  fi
+fi
+
+cleanup() {
+  rmdir "${lock_dir}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+stdout_log="${run_dir}/events.jsonl"
+stderr_log="${run_dir}/stderr.log"
+last_message="${run_dir}/last-message.md"
+summary_file="${run_dir}/summary.edn"
+
+codex_args=(exec --json --cd "${workdir}" --output-last-message "${last_message}")
+
+if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
+  codex_args+=(--dangerously-bypass-approvals-and-sandbox)
+else
+  codex_args+=(--sandbox "${CODEX_CRON_SANDBOX:-workspace-write}")
+fi
+
+if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
+  codex_args+=(--model "${CODEX_CRON_MODEL}")
+fi
+
+if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
+  codex_args+=(--profile "${CODEX_CRON_PROFILE}")
+fi
+
+if [[ -n "${CODEX_CRON_EXTRA_ARGS:-}" ]]; then
+  read -r -a extra_args <<< "${CODEX_CRON_EXTRA_ARGS}"
+  codex_args+=("${extra_args[@]}")
+fi
+
+{
+  echo "job=${job_name}"
+  echo "job_id=${job_id}"
+  echo "run_id=${run_id}"
+  echo "started_at=${started_at}"
+  echo "workdir=${workdir}"
+  echo "prompt_file=${prompt_file}"
+  echo "codex_args=${codex_args[*]}"
+} > "${run_dir}/metadata.env"
+
+set +e
+codex "${codex_args[@]}" - < "${prompt_file}" > "${stdout_log}" 2> "${stderr_log}"
+exit_code=$?
+set -e
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+status="ok"
+if [[ "${exit_code}" -ne 0 ]]; then
+  status="error"
+fi
+
+cat > "${summary_file}" <<EOF
+{:job "${job_id}"
+ :name "${job_name}"
+ :run-id "${run_id}"
+ :status :${status}
+ :exit-code ${exit_code}
+ :started-at "${started_at}"
+ :finished-at "${finished_at}"
+ :workdir "${workdir}"
+ :prompt-file "${prompt_file}"}
+EOF
+
+echo "Codex cron ${job_id}/${run_id}: ${status} (exit ${exit_code})"
+exit "${exit_code}"

--- a/docker/codex-workspace/cron/scheduler.bb
+++ b/docker/codex-workspace/cron/scheduler.bb
@@ -1,0 +1,114 @@
+#!/usr/bin/env bb
+
+(require '[babashka.process :as p]
+         '[babashka.fs :as fs]
+         '[clojure.set :as set]
+         '[clojure.string :as str])
+
+(load-file (str (fs/parent *file*) "/codex_cron_lib.bb"))
+(require '[codex-cron-lib :as lib])
+
+(defn parse-long* [s]
+  (try
+    (Long/parseLong (str s))
+    (catch Exception _
+      (lib/fail (str "invalid cron number: " s)))))
+
+(defn expand-part [part min-v max-v]
+  (let [[base step-raw] (str/split part #"/" 2)
+        step (if step-raw (parse-long* step-raw) 1)
+        range-values (fn [start end] (range start (inc end)))]
+    (when (not (pos? step))
+      (lib/fail (str "invalid cron step: " part)))
+    (let [[step-start values] (cond
+                                (= "*" base) [min-v (range-values min-v max-v)]
+                                (str/includes? base "-") (let [[a b] (map parse-long* (str/split base #"-" 2))]
+                                                           [a (range-values a b)])
+                                :else (let [v (parse-long* base)]
+                                        [v [v]]))]
+      (->> values
+         (filter #(<= min-v % max-v))
+         (filter #(zero? (mod (- % step-start) step)))
+         set))))
+
+(defn parse-field [field min-v max-v]
+  (if (= "*" field)
+    :any
+    (apply set/union (map #(expand-part % min-v max-v) (str/split field #",")))))
+
+(defn cron-spec [schedule]
+  (let [fields (str/split (str/trim schedule) #"\s+")]
+    (when-not (= 5 (count fields))
+      (lib/fail (str "only 5-field cron is supported: " schedule)))
+    (zipmap [:minute :hour :day-of-month :month :day-of-week]
+            [(parse-field (nth fields 0) 0 59)
+             (parse-field (nth fields 1) 0 23)
+             (parse-field (nth fields 2) 1 31)
+             (parse-field (nth fields 3) 1 12)
+             (parse-field (nth fields 4) 0 7)])))
+
+(defn contains-any? [values value]
+  (or (= :any values) (contains? values value)))
+
+(defn due? [job zdt]
+  (let [spec (cron-spec (:schedule job))
+        dow (mod (.getValue (.getDayOfWeek zdt)) 7)]
+    (and (contains-any? (:minute spec) (.getMinute zdt))
+         (contains-any? (:hour spec) (.getHour zdt))
+         (contains-any? (:day-of-month spec) (.getDayOfMonth zdt))
+         (contains-any? (:month spec) (.getMonthValue zdt))
+         (or (contains-any? (:day-of-week spec) dow)
+             (and (zero? dow) (contains-any? (:day-of-week spec) 7))))))
+
+(defn minute-key [zdt]
+  (.toString (.truncatedTo zdt java.time.temporal.ChronoUnit/MINUTES)))
+
+(defn state []
+  (lib/read-edn-file (lib/state-path) {:last-fired {}}))
+
+(defn save-state! [value]
+  (lib/write-edn-file! (lib/state-path) value))
+
+(defn job-time [job]
+  (java.time.ZonedDateTime/now
+   (java.time.ZoneId/of (or (:time-zone job) "Etc/UTC"))))
+
+(defn fire! [job]
+  (let [id (:id job)]
+    (println (str "codex cron firing " id))
+    (p/process ["/opt/codex-workspace/cron/run-codex-cron.sh" id]
+               {:out :inherit :err :inherit})))
+
+(defn tick! []
+  (let [state (state)]
+    (loop [jobs (lib/jobs)
+           state state]
+      (if-not (seq jobs)
+        (save-state! state)
+        (let [job (first jobs)
+              id (:id job)
+              now (job-time job)
+              key (minute-key now)
+              state-key (keyword id)]
+          (if (and (true? (:enabled job))
+                   (:schedule job)
+                   (due? job now)
+                   (not= key (get-in state [:last-fired state-key])))
+            (do
+              (fire! job)
+              (recur (rest jobs) (assoc-in state [:last-fired state-key] key)))
+            (recur (rest jobs) state)))))))
+
+(defn -main []
+  (lib/ensure-root!)
+  (println (str "codex cron scheduler started, registry=" (lib/registry-path)))
+  (loop []
+    (try
+      (tick!)
+      (catch Exception e
+        (binding [*out* *err*]
+          (println (str "codex cron scheduler tick failed: " (.getMessage e))))))
+    (Thread/sleep (* 1000 (Long/parseLong (or (System/getenv "CODEX_CRON_POLL_SECONDS") "30"))))
+    (recur)))
+
+(-main)

--- a/docker/codex-workspace/cron/select-codex-cron-job.bb
+++ b/docker/codex-workspace/cron/select-codex-cron-job.bb
@@ -1,0 +1,24 @@
+#!/usr/bin/env bb
+
+(require '[babashka.fs :as fs])
+
+(load-file (str (fs/parent *file*) "/codex_cron_lib.bb"))
+(require '[codex-cron-lib :as lib])
+
+(let [[job-id] *command-line-args*]
+  (when-not job-id
+    (lib/fail "usage: select-codex-cron-job.bb <job-id>"))
+  (let [job (lib/job job-id)
+        prompt-file (lib/prompt-path job)]
+    (when-not (true? (:enabled job))
+      (lib/fail (str "codex cron job is disabled: " job-id)))
+    (when-not (fs/exists? prompt-file)
+      (lib/fail (str "prompt file does not exist: " prompt-file)))
+    (lib/emit "CODEX_CRON_NAME" (or (:name job) (:id job)))
+    (lib/emit "CODEX_CRON_PROMPT_FILE" (str prompt-file))
+    (lib/emit "CODEX_CRON_WORKDIR" (:workdir job))
+    (lib/emit "CODEX_CRON_OUTPUT_ROOT" (:output-root job))
+    (lib/emit "CODEX_CRON_MODEL" (:model job))
+    (lib/emit "CODEX_CRON_PROFILE" (:profile job))
+    (lib/emit "CODEX_CRON_BYPASS_APPROVALS" (str (get job :bypass-approvals true)))
+    (lib/emit "CODEX_CRON_EXTRA_ARGS" (:extra-args job))))

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -5,6 +5,7 @@ install -d -m 0755 /run/sshd
 install -d -o boxp -g boxp -m 0755 /home/boxp
 install -d -o boxp -g boxp -m 0700 /home/boxp/.ssh
 install -d -o boxp -g boxp -m 0755 /home/boxp/.codex/skills
+install -d -o boxp -g boxp -m 0755 /home/boxp/.codex-cron
 install -d -o boxp -g boxp -m 0755 /home/boxp/ghq
 
 if [[ -d /opt/codex-workspace/skills ]]; then

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 install -d -m 0755 /run/sshd
 install -d -o boxp -g boxp -m 0755 /home/boxp
 install -d -o boxp -g boxp -m 0700 /home/boxp/.ssh
+install -d -o boxp -g boxp -m 0755 /home/boxp/.codex/skills
 install -d -o boxp -g boxp -m 0755 /home/boxp/ghq
+
+if [[ -d /opt/codex-workspace/skills ]]; then
+  cp -a /opt/codex-workspace/skills/. /home/boxp/.codex/skills/
+  chown -R boxp:boxp /home/boxp/.codex/skills
+fi
 
 if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
   install -o boxp -g boxp -m 0600 /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys

--- a/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
+++ b/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: codex-workspace-cron
+description: Manage Codex workspace scheduled prompt jobs in boxp/lolice. Use when the user asks to list, show, add, edit, enable, disable, delete, or manually run Codex cron jobs backed by argoproj/codex-workspace jobs.yaml and Kubernetes CronJobs.
+---
+
+# Codex Workspace Cron
+
+Use this skill to operate the Codex workspace prompt scheduler from inside the Codex workspace.
+
+The scheduler is GitOps-managed in `boxp/lolice`:
+
+- `argoproj/codex-workspace/cron-configmap.yaml`
+  - embedded `jobs.yaml` registry
+  - `prompt-*.md` prompt bodies
+  - runner scripts
+- `argoproj/codex-workspace/cronjob.yaml`
+  - one Kubernetes CronJob per registered job
+
+## Workflow
+
+1. Work in a `boxp/lolice` worktree, preferably using the `worktree` skill.
+2. Use the bundled script for manifest CRUD:
+
+   ```bash
+   bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice list
+   ```
+
+3. After changes, run:
+
+   ```bash
+   kustomize build argoproj/codex-workspace
+   git diff --check
+   ```
+
+4. Commit and update the `boxp/lolice` PR.
+
+## Commands
+
+List jobs:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice list
+```
+
+Show one job:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice show <job-id>
+```
+
+Add a job:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice add \
+  --id daily-report \
+  --name "Daily report" \
+  --schedule "0 22 * * *" \
+  --prompt-file prompt-daily-report.md \
+  --prompt "調査して日本語で報告してください。" \
+  --enabled false
+```
+
+Update metadata or prompt:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice update daily-report \
+  --schedule "30 22 * * *" \
+  --prompt "新しいプロンプト"
+```
+
+Enable or disable:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice enable daily-report
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice disable daily-report
+```
+
+Delete:
+
+```bash
+bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice delete daily-report
+```
+
+## Safety
+
+- New jobs should default to disabled unless the user explicitly asks to enable them.
+- Keep `jobs.yaml enabled` and CronJob `spec.suspend` consistent.
+- Do not run `kubectl` mutations unless the user explicitly asks for live cluster operations.
+- For manual live runs, prefer documenting the command from `argoproj/codex-workspace/cron.md`.

--- a/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
+++ b/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
@@ -1,69 +1,58 @@
 ---
 name: codex-workspace-cron
-description: Manage Codex workspace scheduled prompt jobs in boxp/lolice. Use when the user asks to list, show, add, edit, enable, disable, delete, or manually run Codex cron jobs backed by argoproj/codex-workspace jobs.yaml and Kubernetes CronJobs.
+description: Manage Codex workspace scheduled prompt jobs stored under ~/.codex-cron. Use when the user asks to list, show, add, edit, enable, disable, delete, or manually run Codex cron jobs.
 ---
 
 # Codex Workspace Cron
 
 Use this skill to operate the Codex workspace prompt scheduler from inside the Codex workspace.
 
-The scheduler is GitOps-managed in `boxp/lolice`:
+The live scheduler reads and writes only the workspace home PVC:
 
-- `argoproj/codex-workspace/cron-configmap.yaml`
-  - embedded `jobs.yaml` registry
-  - `prompt-*.md` prompt bodies
-  - runner scripts
-- `argoproj/codex-workspace/cronjob.yaml`
-  - one Kubernetes CronJob per registered job
+- `/home/boxp/.codex-cron/jobs.edn`: job registry.
+- `/home/boxp/.codex-cron/prompts/*.md`: prompt bodies.
+- `/home/boxp/.codex-cron/jobs-state.edn`: scheduler bookkeeping.
+- `/home/boxp/.codex-cron/runs/<job>/<run-id>/`: run logs.
 
 ## Workflow
 
-1. Work in a `boxp/lolice` worktree, preferably using the `worktree` skill.
-2. Use the bundled script for manifest CRUD:
+1. Use the bundled helper for CRUD:
 
    ```bash
-   bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice list
+   bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb list
    ```
 
-3. After changes, run:
-
-   ```bash
-   kustomize build argoproj/codex-workspace
-   git diff --check
-   ```
-
-4. Commit and update the `boxp/lolice` PR.
+2. New jobs should default to disabled unless the user explicitly asks to enable them.
+3. Use `run` only when the user asks for a manual execution or validation run.
 
 ## Commands
 
 List jobs:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice list
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb list
 ```
 
 Show one job:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice show <job-id>
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb show <job-id>
 ```
 
-Add a job:
+Add a disabled job:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice add \
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb add \
   --id daily-report \
   --name "Daily report" \
   --schedule "0 22 * * *" \
-  --prompt-file prompt-daily-report.md \
-  --prompt "調査して日本語で報告してください。" \
-  --enabled false
+  --prompt "調査して日本語で報告してください。"
 ```
 
 Update metadata or prompt:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice update daily-report \
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-report \
   --schedule "30 22 * * *" \
   --prompt "新しいプロンプト"
 ```
@@ -71,19 +60,24 @@ bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice update daily-r
 Enable or disable:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice enable daily-report
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice disable daily-report
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb enable daily-report
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb disable daily-report
 ```
 
 Delete:
 
 ```bash
-bb <this-skill>/scripts/codex_cron_jobs.bb --repo /path/to/lolice delete daily-report
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb delete daily-report
+```
+
+Manual run:
+
+```bash
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb run daily-report
 ```
 
 ## Safety
 
-- New jobs should default to disabled unless the user explicitly asks to enable them.
-- Keep `jobs.yaml enabled` and CronJob `spec.suspend` consistent.
-- Do not run `kubectl` mutations unless the user explicitly asks for live cluster operations.
-- For manual live runs, prefer documenting the command from `argoproj/codex-workspace/cron.md`.
+- Confirm schedule, prompt, and enabled state before turning a job on.
+- The scheduler supports standard 5-field cron expressions and polls every 30 seconds by default.
+- Do not edit Kubernetes CronJobs for individual schedules; the resident scheduler sidecar reads `~/.codex-cron/jobs.edn`.

--- a/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
+++ b/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
@@ -1,0 +1,399 @@
+#!/usr/bin/env bb
+
+(require '[babashka.fs :as fs]
+         '[clojure.string :as str])
+
+(def configmap-path "argoproj/codex-workspace/cron-configmap.yaml")
+(def cronjob-path "argoproj/codex-workspace/cronjob.yaml")
+(def job-key-order
+  ["id" "name" "enabled" "schedule" "timeZone" "session" "promptFile"
+   "workdir" "outputRoot" "model" "profile" "bypassApprovals" "extraArgs"])
+
+(defn fail [message]
+  (binding [*out* *err*]
+    (println (str "error: " message)))
+  (System/exit 1))
+
+(defn usage []
+  (println "usage: codex_cron_jobs.bb [--repo PATH] <list|show|add|update|enable|disable|delete> ...")
+  (System/exit 2))
+
+(defn parse-scalar [raw]
+  (let [value (str/trim (or raw ""))]
+    (cond
+      (and (>= (count value) 2)
+           (= (first value) (last value))
+           (#{\" \'} (first value)))
+      (subs value 1 (dec (count value)))
+
+      (= "true" (str/lower-case value)) true
+      (= "false" (str/lower-case value)) false
+      :else value)))
+
+(defn format-scalar [value]
+  (cond
+    (true? value) "true"
+    (false? value) "false"
+    :else
+    (let [s (str value)]
+      (if (or (empty? s)
+              (not= s (str/trim s))
+              (re-find #"\s|[:#{}\[\]]" s))
+        (str "\"" (str/replace s #"\"" "\\\"") "\"")
+        s))))
+
+(defn read-file [path]
+  (try
+    (slurp (str path))
+    (catch java.io.FileNotFoundException _
+      (fail (str "missing file: " path)))))
+
+(defn write-file [path text]
+  (spit (str path) text))
+
+(defn data-keys [text]
+  (map second (re-seq #"(?m)^  ([A-Za-z0-9_.-]+): \|$" text)))
+
+(defn index-of [s needle from]
+  (.indexOf ^String s ^String needle (int from)))
+
+(defn block-range [text key next-keys]
+  (let [marker (str "  " key ": |\n")
+        start (.indexOf ^String text marker)]
+    (when (neg? start)
+      (fail (str "missing ConfigMap data key: " key)))
+    (let [content-start (+ start (count marker))
+          candidates (keep #(let [idx (index-of text (str "  " % ": |\n") content-start)]
+                               (when-not (neg? idx) idx))
+                           next-keys)
+          content-end (if (seq candidates) (apply min candidates) (count text))]
+      [content-start content-end])))
+
+(defn get-block [text key next-keys]
+  (let [[content-start content-end] (block-range text key next-keys)
+        block (subs text content-start content-end)
+        lines (for [line (str/split-lines block)]
+                (cond
+                  (str/starts-with? line "    ") (subs line 4)
+                  (= line "") ""
+                  :else (fail (str "unexpected indentation in " key ": " line))))]
+    (str/replace (str/join "\n" lines) #"\n+$" "")))
+
+(defn render-block [value]
+  (apply str
+         (for [line (str/split-lines (str/replace (or value "") #"\n+$" ""))]
+           (if (empty? line) "\n" (str "    " line "\n")))))
+
+(defn set-block [text key value next-keys]
+  (let [[content-start content-end] (block-range text key next-keys)]
+    (str (subs text 0 content-start)
+         (render-block value)
+         (subs text content-end))))
+
+(defn parse-jobs [jobs-text]
+  (loop [lines (str/split-lines jobs-text)
+         jobs []
+         current nil]
+    (if-not (seq lines)
+      (cond-> jobs current (conj current))
+      (let [raw (first lines)
+            stripped (str/trim raw)]
+        (cond
+          (or (empty? stripped) (= stripped "jobs:") (str/starts-with? stripped "#"))
+          (recur (rest lines) jobs current)
+
+          (str/starts-with? stripped "- ")
+          (let [jobs (cond-> jobs current (conj current))
+                stripped (str/trim (subs stripped 2))
+                current {}]
+            (if (empty? stripped)
+              (recur (rest lines) jobs current)
+              (recur (cons stripped (rest lines)) jobs current)))
+
+          (nil? current)
+          (fail (str "property outside job: " raw))
+
+          (not (str/includes? stripped ":"))
+          (fail (str "unsupported jobs.yaml line: " raw))
+
+          :else
+          (let [[k v] (str/split stripped #":" 2)
+                k (str/trim k)]
+            (when-not (re-matches #"[A-Za-z][A-Za-z0-9]*" k)
+              (fail (str "unsupported key: " k)))
+            (recur (rest lines) jobs (assoc current k (parse-scalar v)))))))))
+
+(defn render-jobs [jobs]
+  (str/join
+   "\n"
+   (concat
+    ["jobs:"]
+    (mapcat
+     (fn [job]
+       (let [known (set job-key-order)
+             extra (sort (remove known (keys job)))]
+         (concat
+          [(str "  - id: " (format-scalar (get job "id")))]
+          (for [k (rest job-key-order)
+                :when (contains? job k)
+                :let [v (get job k)]
+                :when (not (or (nil? v) (= "" v)))]
+            (str "    " k ": " (format-scalar v)))
+          (for [k extra]
+            (str "    " k ": " (format-scalar (get job k)))))))
+     jobs))))
+
+(defn load-state [repo]
+  (let [cm-path (fs/path repo configmap-path)
+        cm-text (read-file cm-path)
+        keys (data-keys cm-text)
+        jobs-text (get-block cm-text "jobs.yaml" (remove #{"jobs.yaml"} keys))]
+    {:cm-path cm-path
+     :cronjob-path (fs/path repo cronjob-path)
+     :cm-text cm-text
+     :jobs (parse-jobs jobs-text)}))
+
+(defn save-jobs! [{:keys [cm-path cm-text jobs]}]
+  (let [keys (data-keys cm-text)
+        new-text (set-block cm-text "jobs.yaml" (render-jobs jobs) (remove #{"jobs.yaml"} keys))]
+    (write-file cm-path new-text)))
+
+(defn find-job [jobs job-id]
+  (or (first (filter #(= job-id (get % "id")) jobs))
+      (fail (str "job not found: " job-id))))
+
+(defn prompt-key [prompt-file]
+  (let [key (fs/file-name prompt-file)]
+    (when-not (and (str/starts-with? key "prompt-") (str/ends-with? key ".md"))
+      (fail "prompt file must look like prompt-<name>.md"))
+    key))
+
+(defn set-prompt [cm-text prompt-file prompt]
+  (let [key (prompt-key prompt-file)
+        keys (data-keys cm-text)]
+    (if (some #{key} keys)
+      (set-block cm-text key prompt (remove #{key} keys))
+      (str (str/replace cm-text #"\n+$" "")
+           "\n  " key ": |\n"
+           (render-block prompt)))))
+
+(defn delete-prompt [cm-text prompt-file]
+  (let [key (prompt-key prompt-file)
+        marker (str "  " key ": |\n")
+        start (.indexOf ^String cm-text marker)]
+    (if (neg? start)
+      cm-text
+      (let [keys (data-keys cm-text)
+            [_ content-end] (block-range cm-text key (remove #{key} keys))]
+        (str (subs cm-text 0 start) (subs cm-text content-end))))))
+
+(defn cron-name [job-id]
+  (str "codex-cron-" job-id))
+
+(defn cronjob-doc [job]
+  (let [job-id (get job "id")
+        enabled? (true? (get job "enabled"))
+        schedule (get job "schedule" "0 0 * * *")
+        tz (get job "timeZone" "Etc/UTC")]
+    (format "apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: %s
+  namespace: codex-workspace
+  labels:
+    app: codex-workspace-cron
+    codex-workspace.boxp.io/cron: %s
+spec:
+  # Keep this in sync with jobs.yaml entry schedule/timeZone/enabled.
+  suspend: %s
+  schedule: \"%s\"
+  timeZone: %s
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 900
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: codex-workspace-cron
+            codex-workspace.boxp.io/cron: %s
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app: codex-workspace
+                  topologyKey: kubernetes.io/hostname
+          containers:
+            - name: codex
+              image: ghcr.io/boxp/arch/codex-workspace:latest
+              imagePullPolicy: Always
+              command:
+                - /opt/codex-cron/run-codex-cron.sh
+              env:
+                - name: HOME
+                  value: /home/boxp
+                - name: CODEX_HOME
+                  value: /home/boxp/.codex
+                - name: CODEX_CRON_JOB_ID
+                  value: %s
+                - name: CODEX_CRON_JOBS_FILE
+                  value: /opt/codex-cron/jobs.yaml
+                - name: GRAFANA_URL
+                  value: http://grafana.monitoring.svc.cluster.local:3000
+                - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: codex-workspace-grafana
+                      key: service-account-token
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [\"ALL\"]
+                readOnlyRootFilesystem: false
+              resources:
+                requests:
+                  cpu: \"250m\"
+                  memory: \"512Mi\"
+                limits:
+                  cpu: \"4\"
+                  memory: \"8Gi\"
+              volumeMounts:
+                - name: home
+                  mountPath: /home/boxp
+                - name: cron-config
+                  mountPath: /opt/codex-cron
+                  readOnly: true
+          volumes:
+            - name: home
+              persistentVolumeClaim:
+                claimName: codex-workspace-home
+            - name: cron-config
+              configMap:
+                name: codex-workspace-cron
+                defaultMode: 0555
+"
+            (cron-name job-id) job-id (if enabled? "false" "true") schedule tz job-id job-id)))
+
+(defn save-cronjobs! [path jobs]
+  (write-file path (str (str/join "\n---\n" (map #(str/replace % #"\n+$" "") (map cronjob-doc jobs))) "\n")))
+
+(defn parse-global [args]
+  (loop [args args repo "."]
+    (if (= "--repo" (first args))
+      (recur (drop 2 args) (second args))
+      {:repo (fs/absolutize repo) :args (vec args)})))
+
+(defn opts-map [args]
+  (loop [args args opts {} positional []]
+    (cond
+      (empty? args) {:opts opts :positional positional}
+      (str/starts-with? (first args) "--")
+      (if (second args)
+        (recur (drop 2 args) (assoc opts (subs (first args) 2) (second args)) positional)
+        (fail (str "missing value for " (first args))))
+      :else
+      (recur (rest args) opts (conj positional (first args))))))
+
+(defn require-opt [opts k]
+  (or (get opts k) (fail (str "--" k " is required"))))
+
+(defn cmd-list [repo]
+  (doseq [job (:jobs (load-state repo))]
+    (println (str/join "\t" [(get job "id")
+                             (if (true? (get job "enabled")) "enabled" "disabled")
+                             (get job "schedule" "")
+                             (get job "promptFile" "")]))))
+
+(defn cmd-show [repo job-id]
+  (doseq [[k v] (find-job (:jobs (load-state repo)) job-id)]
+    (println (str k ": " v))))
+
+(defn new-job [opts]
+  (let [id (require-opt opts "id")
+        prompt-file (or (get opts "prompt-file") (str "prompt-" id ".md"))]
+    {"id" id
+     "name" (or (get opts "name") id)
+     "enabled" (= "true" (get opts "enabled" "false"))
+     "schedule" (require-opt opts "schedule")
+     "timeZone" (get opts "time-zone" "Etc/UTC")
+     "session" "isolated"
+     "promptFile" (str "/opt/codex-cron/" (prompt-key prompt-file))
+     "workdir" (get opts "workdir" "/home/boxp")
+     "outputRoot" (get opts "output-root" "/home/boxp/.codex-cron/runs")
+     "bypassApprovals" (= "true" (get opts "bypass-approvals" "true"))}))
+
+(defn save-state! [state]
+  (save-jobs! state)
+  (save-cronjobs! (:cronjob-path state) (:jobs state)))
+
+(defn cmd-add [repo opts]
+  (let [state (load-state repo)
+        job (new-job opts)
+        prompt (require-opt opts "prompt")]
+    (when (some #(= (get job "id") (get % "id")) (:jobs state))
+      (fail (str "job already exists: " (get job "id"))))
+    (save-state! (-> state
+                     (update :cm-text set-prompt (get job "promptFile") prompt)
+                     (update :jobs conj job)))))
+
+(defn cmd-update [repo job-id opts]
+  (let [state (load-state repo)
+        prompt (get opts "prompt")
+        jobs (mapv (fn [job]
+                     (if (= job-id (get job "id"))
+                       (cond-> job
+                         (contains? opts "name") (assoc "name" (get opts "name"))
+                         (contains? opts "schedule") (assoc "schedule" (get opts "schedule"))
+                         (contains? opts "time-zone") (assoc "timeZone" (get opts "time-zone"))
+                         (contains? opts "workdir") (assoc "workdir" (get opts "workdir"))
+                         (contains? opts "model") (as-> j (if (empty? (get opts "model"))
+                                                             (dissoc j "model")
+                                                             (assoc j "model" (get opts "model")))))
+                       job))
+                   (:jobs state))
+        job (find-job jobs job-id)]
+    (save-state! (cond-> (assoc state :jobs jobs)
+                   prompt (update :cm-text set-prompt (get job "promptFile") prompt)))))
+
+(defn cmd-set-enabled [repo job-id enabled?]
+  (let [state (load-state repo)
+        jobs (mapv #(if (= job-id (get % "id")) (assoc % "enabled" enabled?) %) (:jobs state))]
+    (find-job jobs job-id)
+    (save-state! (assoc state :jobs jobs))))
+
+(defn cmd-delete [repo job-id]
+  (let [state (load-state repo)
+        job (find-job (:jobs state) job-id)
+        jobs (vec (remove #(= job-id (get % "id")) (:jobs state)))]
+    (save-state! (-> state
+                     (assoc :jobs jobs)
+                     (update :cm-text delete-prompt (get job "promptFile"))))))
+
+(defn -main [& argv]
+  (let [{:keys [repo args]} (parse-global argv)
+        command (first args)
+        rest-args (vec (rest args))]
+    (case command
+      "list" (cmd-list repo)
+      "show" (cmd-show repo (or (first rest-args) (fail "job id is required")))
+      "add" (cmd-add repo (:opts (opts-map rest-args)))
+      "update" (let [{:keys [opts positional]} (opts-map rest-args)]
+                 (cmd-update repo (or (first positional) (fail "job id is required")) opts))
+      "enable" (cmd-set-enabled repo (or (first rest-args) (fail "job id is required")) true)
+      "disable" (cmd-set-enabled repo (or (first rest-args) (fail "job id is required")) false)
+      "delete" (cmd-delete repo (or (first rest-args) (fail "job id is required")))
+      (usage))))
+
+(apply -main *command-line-args*)

--- a/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
+++ b/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
@@ -1,299 +1,36 @@
 #!/usr/bin/env bb
 
 (require '[babashka.fs :as fs]
+         '[babashka.process :as p]
          '[clojure.string :as str])
 
-(def configmap-path "argoproj/codex-workspace/cron-configmap.yaml")
-(def cronjob-path "argoproj/codex-workspace/cronjob.yaml")
-(def job-key-order
-  ["id" "name" "enabled" "schedule" "timeZone" "session" "promptFile"
-   "workdir" "outputRoot" "model" "profile" "bypassApprovals" "extraArgs"])
+(let [local-lib (fs/path (fs/parent *file*) "../../.." "cron" "codex_cron_lib.bb")
+      image-lib "/opt/codex-workspace/cron/codex_cron_lib.bb"]
+  (load-file (or (System/getenv "CODEX_CRON_LIB")
+                 (when (fs/exists? local-lib) (str (fs/normalize local-lib)))
+                 image-lib)))
+(require '[codex-cron-lib :as lib])
 
-(defn fail [message]
-  (binding [*out* *err*]
-    (println (str "error: " message)))
-  (System/exit 1))
+(def key-order
+  [:id :name :enabled :schedule :time-zone :prompt-file :workdir :output-root
+   :model :profile :bypass-approvals :extra-args])
 
 (defn usage []
-  (println "usage: codex_cron_jobs.bb [--repo PATH] <list|show|add|update|enable|disable|delete> ...")
+  (println "usage: codex_cron_jobs.bb [--root PATH] <list|show|add|update|enable|disable|delete|run> ...")
   (System/exit 2))
 
-(defn parse-scalar [raw]
-  (let [value (str/trim (or raw ""))]
-    (cond
-      (and (>= (count value) 2)
-           (= (first value) (last value))
-           (#{\" \'} (first value)))
-      (subs value 1 (dec (count value)))
-
-      (= "true" (str/lower-case value)) true
-      (= "false" (str/lower-case value)) false
-      :else value)))
-
-(defn format-scalar [value]
-  (cond
-    (true? value) "true"
-    (false? value) "false"
-    :else
-    (let [s (str value)]
-      (if (or (empty? s)
-              (not= s (str/trim s))
-              (re-find #"\s|[:#{}\[\]]" s))
-        (str "\"" (str/replace s #"\"" "\\\"") "\"")
-        s))))
-
-(defn read-file [path]
-  (try
-    (slurp (str path))
-    (catch java.io.FileNotFoundException _
-      (fail (str "missing file: " path)))))
-
-(defn write-file [path text]
-  (spit (str path) text))
-
-(defn data-keys [text]
-  (map second (re-seq #"(?m)^  ([A-Za-z0-9_.-]+): \|$" text)))
-
-(defn index-of [s needle from]
-  (.indexOf ^String s ^String needle (int from)))
-
-(defn block-range [text key next-keys]
-  (let [marker (str "  " key ": |\n")
-        start (.indexOf ^String text marker)]
-    (when (neg? start)
-      (fail (str "missing ConfigMap data key: " key)))
-    (let [content-start (+ start (count marker))
-          candidates (keep #(let [idx (index-of text (str "  " % ": |\n") content-start)]
-                               (when-not (neg? idx) idx))
-                           next-keys)
-          content-end (if (seq candidates) (apply min candidates) (count text))]
-      [content-start content-end])))
-
-(defn get-block [text key next-keys]
-  (let [[content-start content-end] (block-range text key next-keys)
-        block (subs text content-start content-end)
-        lines (for [line (str/split-lines block)]
-                (cond
-                  (str/starts-with? line "    ") (subs line 4)
-                  (= line "") ""
-                  :else (fail (str "unexpected indentation in " key ": " line))))]
-    (str/replace (str/join "\n" lines) #"\n+$" "")))
-
-(defn render-block [value]
-  (apply str
-         (for [line (str/split-lines (str/replace (or value "") #"\n+$" ""))]
-           (if (empty? line) "\n" (str "    " line "\n")))))
-
-(defn set-block [text key value next-keys]
-  (let [[content-start content-end] (block-range text key next-keys)]
-    (str (subs text 0 content-start)
-         (render-block value)
-         (subs text content-end))))
-
-(defn parse-jobs [jobs-text]
-  (loop [lines (str/split-lines jobs-text)
-         jobs []
-         current nil]
-    (if-not (seq lines)
-      (cond-> jobs current (conj current))
-      (let [raw (first lines)
-            stripped (str/trim raw)]
-        (cond
-          (or (empty? stripped) (= stripped "jobs:") (str/starts-with? stripped "#"))
-          (recur (rest lines) jobs current)
-
-          (str/starts-with? stripped "- ")
-          (let [jobs (cond-> jobs current (conj current))
-                stripped (str/trim (subs stripped 2))
-                current {}]
-            (if (empty? stripped)
-              (recur (rest lines) jobs current)
-              (recur (cons stripped (rest lines)) jobs current)))
-
-          (nil? current)
-          (fail (str "property outside job: " raw))
-
-          (not (str/includes? stripped ":"))
-          (fail (str "unsupported jobs.yaml line: " raw))
-
-          :else
-          (let [[k v] (str/split stripped #":" 2)
-                k (str/trim k)]
-            (when-not (re-matches #"[A-Za-z][A-Za-z0-9]*" k)
-              (fail (str "unsupported key: " k)))
-            (recur (rest lines) jobs (assoc current k (parse-scalar v)))))))))
-
-(defn render-jobs [jobs]
-  (str/join
-   "\n"
-   (concat
-    ["jobs:"]
-    (mapcat
-     (fn [job]
-       (let [known (set job-key-order)
-             extra (sort (remove known (keys job)))]
-         (concat
-          [(str "  - id: " (format-scalar (get job "id")))]
-          (for [k (rest job-key-order)
-                :when (contains? job k)
-                :let [v (get job k)]
-                :when (not (or (nil? v) (= "" v)))]
-            (str "    " k ": " (format-scalar v)))
-          (for [k extra]
-            (str "    " k ": " (format-scalar (get job k)))))))
-     jobs))))
-
-(defn load-state [repo]
-  (let [cm-path (fs/path repo configmap-path)
-        cm-text (read-file cm-path)
-        keys (data-keys cm-text)
-        jobs-text (get-block cm-text "jobs.yaml" (remove #{"jobs.yaml"} keys))]
-    {:cm-path cm-path
-     :cronjob-path (fs/path repo cronjob-path)
-     :cm-text cm-text
-     :jobs (parse-jobs jobs-text)}))
-
-(defn save-jobs! [{:keys [cm-path cm-text jobs]}]
-  (let [keys (data-keys cm-text)
-        new-text (set-block cm-text "jobs.yaml" (render-jobs jobs) (remove #{"jobs.yaml"} keys))]
-    (write-file cm-path new-text)))
-
-(defn find-job [jobs job-id]
-  (or (first (filter #(= job-id (get % "id")) jobs))
-      (fail (str "job not found: " job-id))))
-
-(defn prompt-key [prompt-file]
-  (let [key (fs/file-name prompt-file)]
-    (when-not (and (str/starts-with? key "prompt-") (str/ends-with? key ".md"))
-      (fail "prompt file must look like prompt-<name>.md"))
-    key))
-
-(defn set-prompt [cm-text prompt-file prompt]
-  (let [key (prompt-key prompt-file)
-        keys (data-keys cm-text)]
-    (if (some #{key} keys)
-      (set-block cm-text key prompt (remove #{key} keys))
-      (str (str/replace cm-text #"\n+$" "")
-           "\n  " key ": |\n"
-           (render-block prompt)))))
-
-(defn delete-prompt [cm-text prompt-file]
-  (let [key (prompt-key prompt-file)
-        marker (str "  " key ": |\n")
-        start (.indexOf ^String cm-text marker)]
-    (if (neg? start)
-      cm-text
-      (let [keys (data-keys cm-text)
-            [_ content-end] (block-range cm-text key (remove #{key} keys))]
-        (str (subs cm-text 0 start) (subs cm-text content-end))))))
-
-(defn cron-name [job-id]
-  (str "codex-cron-" job-id))
-
-(defn cronjob-doc [job]
-  (let [job-id (get job "id")
-        enabled? (true? (get job "enabled"))
-        schedule (get job "schedule" "0 0 * * *")
-        tz (get job "timeZone" "Etc/UTC")]
-    (format "apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: %s
-  namespace: codex-workspace
-  labels:
-    app: codex-workspace-cron
-    codex-workspace.boxp.io/cron: %s
-spec:
-  # Keep this in sync with jobs.yaml entry schedule/timeZone/enabled.
-  suspend: %s
-  schedule: \"%s\"
-  timeZone: %s
-  concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 900
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
-  jobTemplate:
-    spec:
-      backoffLimit: 0
-      template:
-        metadata:
-          labels:
-            app: codex-workspace-cron
-            codex-workspace.boxp.io/cron: %s
-        spec:
-          restartPolicy: Never
-          automountServiceAccountToken: false
-          nodeSelector:
-            kubernetes.io/arch: amd64
-          affinity:
-            podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      app: codex-workspace
-                  topologyKey: kubernetes.io/hostname
-          containers:
-            - name: codex
-              image: ghcr.io/boxp/arch/codex-workspace:latest
-              imagePullPolicy: Always
-              command:
-                - /opt/codex-cron/run-codex-cron.sh
-              env:
-                - name: HOME
-                  value: /home/boxp
-                - name: CODEX_HOME
-                  value: /home/boxp/.codex
-                - name: CODEX_CRON_JOB_ID
-                  value: %s
-                - name: CODEX_CRON_JOBS_FILE
-                  value: /opt/codex-cron/jobs.yaml
-                - name: GRAFANA_URL
-                  value: http://grafana.monitoring.svc.cluster.local:3000
-                - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: codex-workspace-grafana
-                      key: service-account-token
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: [\"ALL\"]
-                readOnlyRootFilesystem: false
-              resources:
-                requests:
-                  cpu: \"250m\"
-                  memory: \"512Mi\"
-                limits:
-                  cpu: \"4\"
-                  memory: \"8Gi\"
-              volumeMounts:
-                - name: home
-                  mountPath: /home/boxp
-                - name: cron-config
-                  mountPath: /opt/codex-cron
-                  readOnly: true
-          volumes:
-            - name: home
-              persistentVolumeClaim:
-                claimName: codex-workspace-home
-            - name: cron-config
-              configMap:
-                name: codex-workspace-cron
-                defaultMode: 0555
-"
-            (cron-name job-id) job-id (if enabled? "false" "true") schedule tz job-id job-id)))
-
-(defn save-cronjobs! [path jobs]
-  (write-file path (str (str/join "\n---\n" (map #(str/replace % #"\n+$" "") (map cronjob-doc jobs))) "\n")))
-
 (defn parse-global [args]
-  (loop [args args repo "."]
-    (if (= "--repo" (first args))
-      (recur (drop 2 args) (second args))
-      {:repo (fs/absolutize repo) :args (vec args)})))
+  (loop [args args]
+    (cond
+      (= "--root" (first args))
+      (do
+        (System/setProperty "codex.cron.root" (second args))
+        (recur (drop 2 args)))
+
+      :else (vec args))))
+
+(defn root []
+  (or (System/getProperty "codex.cron.root") (lib/root)))
 
 (defn opts-map [args]
   (loop [args args opts {} positional []]
@@ -302,98 +39,146 @@ spec:
       (str/starts-with? (first args) "--")
       (if (second args)
         (recur (drop 2 args) (assoc opts (subs (first args) 2) (second args)) positional)
-        (fail (str "missing value for " (first args))))
+        (lib/fail (str "missing value for " (first args))))
       :else
       (recur (rest args) opts (conj positional (first args))))))
 
 (defn require-opt [opts k]
-  (or (get opts k) (fail (str "--" k " is required"))))
+  (or (get opts k) (lib/fail (str "--" k " is required"))))
 
-(defn cmd-list [repo]
-  (doseq [job (:jobs (load-state repo))]
-    (println (str/join "\t" [(get job "id")
-                             (if (true? (get job "enabled")) "enabled" "disabled")
-                             (get job "schedule" "")
-                             (get job "promptFile" "")]))))
+(defn bool-opt [opts k default]
+  (case (str/lower-case (get opts k (str default)))
+    "true" true
+    "false" false
+    (lib/fail (str "--" k " must be true or false"))))
 
-(defn cmd-show [repo job-id]
-  (doseq [[k v] (find-job (:jobs (load-state repo)) job-id)]
-    (println (str k ": " v))))
+(defn registry []
+  (lib/registry))
+
+(defn save-registry! [value]
+  (lib/save-registry! value))
+
+(defn prompts-dir []
+  (fs/path (root) "prompts"))
+
+(defn prompt-path [job]
+  (lib/prompt-path job))
+
+(defn find-job [jobs job-id]
+  (or (first (filter #(= job-id (:id %)) jobs))
+      (lib/fail (str "job not found: " job-id))))
+
+(defn assoc-some [m k v]
+  (if (or (nil? v) (= "" v)) m (assoc m k v)))
+
+(defn ordered-job [job]
+  (let [known (set key-order)]
+    (merge
+     (select-keys job key-order)
+     (into (sorted-map) (remove (comp known key) job)))))
+
+(defn cmd-list []
+  (doseq [job (:jobs (registry))]
+    (println (str/join "\t" [(:id job)
+                             (if (true? (:enabled job)) "enabled" "disabled")
+                             (or (:schedule job) "")
+                             (str (prompt-path job))]))))
+
+(defn cmd-show [job-id]
+  (let [job (find-job (:jobs (registry)) job-id)]
+    (doseq [[k v] (ordered-job job)]
+      (println (str (name k) ": " v)))))
+
+(defn write-prompt! [job opts]
+  (let [target (prompt-path job)]
+    (fs/create-dirs (fs/parent target))
+    (cond
+      (contains? opts "prompt") (spit (str target) (str (get opts "prompt") "\n"))
+      (contains? opts "prompt-source") (spit (str target) (slurp (get opts "prompt-source")))
+      :else nil)))
 
 (defn new-job [opts]
   (let [id (require-opt opts "id")
-        prompt-file (or (get opts "prompt-file") (str "prompt-" id ".md"))]
-    {"id" id
-     "name" (or (get opts "name") id)
-     "enabled" (= "true" (get opts "enabled" "false"))
-     "schedule" (require-opt opts "schedule")
-     "timeZone" (get opts "time-zone" "Etc/UTC")
-     "session" "isolated"
-     "promptFile" (str "/opt/codex-cron/" (prompt-key prompt-file))
-     "workdir" (get opts "workdir" "/home/boxp")
-     "outputRoot" (get opts "output-root" "/home/boxp/.codex-cron/runs")
-     "bypassApprovals" (= "true" (get opts "bypass-approvals" "true"))}))
+        prompt-rel (or (get opts "prompt-file") (str "prompts/" id ".md"))]
+    (-> {:id id
+         :name (or (get opts "name") id)
+         :enabled (bool-opt opts "enabled" false)
+         :schedule (require-opt opts "schedule")
+         :time-zone (get opts "time-zone" "Etc/UTC")
+         :prompt-file prompt-rel
+         :workdir (get opts "workdir" "/home/boxp")
+         :output-root (get opts "output-root" (str (root) "/runs"))
+         :bypass-approvals (bool-opt opts "bypass-approvals" true)}
+        (assoc-some :model (get opts "model"))
+        (assoc-some :profile (get opts "profile"))
+        (assoc-some :extra-args (get opts "extra-args")))))
 
-(defn save-state! [state]
-  (save-jobs! state)
-  (save-cronjobs! (:cronjob-path state) (:jobs state)))
+(defn cmd-add [opts]
+  (let [state (registry)
+        job (new-job opts)]
+    (when (some #(= (:id job) (:id %)) (:jobs state))
+      (lib/fail (str "job already exists: " (:id job))))
+    (when-not (or (contains? opts "prompt") (contains? opts "prompt-source"))
+      (lib/fail "--prompt or --prompt-source is required"))
+    (write-prompt! job opts)
+    (save-registry! (update state :jobs conj job))))
 
-(defn cmd-add [repo opts]
-  (let [state (load-state repo)
-        job (new-job opts)
-        prompt (require-opt opts "prompt")]
-    (when (some #(= (get job "id") (get % "id")) (:jobs state))
-      (fail (str "job already exists: " (get job "id"))))
-    (save-state! (-> state
-                     (update :cm-text set-prompt (get job "promptFile") prompt)
-                     (update :jobs conj job)))))
+(defn patch-job [job opts]
+  (cond-> job
+    (contains? opts "name") (assoc :name (get opts "name"))
+    (contains? opts "schedule") (assoc :schedule (get opts "schedule"))
+    (contains? opts "time-zone") (assoc :time-zone (get opts "time-zone"))
+    (contains? opts "prompt-file") (assoc :prompt-file (get opts "prompt-file"))
+    (contains? opts "workdir") (assoc :workdir (get opts "workdir"))
+    (contains? opts "output-root") (assoc :output-root (get opts "output-root"))
+    (contains? opts "model") (assoc-some :model (get opts "model"))
+    (contains? opts "profile") (assoc-some :profile (get opts "profile"))
+    (contains? opts "extra-args") (assoc-some :extra-args (get opts "extra-args"))
+    (contains? opts "bypass-approvals") (assoc :bypass-approvals (bool-opt opts "bypass-approvals" true))))
 
-(defn cmd-update [repo job-id opts]
-  (let [state (load-state repo)
-        prompt (get opts "prompt")
-        jobs (mapv (fn [job]
-                     (if (= job-id (get job "id"))
-                       (cond-> job
-                         (contains? opts "name") (assoc "name" (get opts "name"))
-                         (contains? opts "schedule") (assoc "schedule" (get opts "schedule"))
-                         (contains? opts "time-zone") (assoc "timeZone" (get opts "time-zone"))
-                         (contains? opts "workdir") (assoc "workdir" (get opts "workdir"))
-                         (contains? opts "model") (as-> j (if (empty? (get opts "model"))
-                                                             (dissoc j "model")
-                                                             (assoc j "model" (get opts "model")))))
-                       job))
-                   (:jobs state))
+(defn cmd-update [job-id opts]
+  (let [state (registry)
+        jobs (mapv #(if (= job-id (:id %)) (patch-job % opts) %) (:jobs state))
         job (find-job jobs job-id)]
-    (save-state! (cond-> (assoc state :jobs jobs)
-                   prompt (update :cm-text set-prompt (get job "promptFile") prompt)))))
+    (when (or (contains? opts "prompt") (contains? opts "prompt-source"))
+      (write-prompt! job opts))
+    (save-registry! (assoc state :jobs jobs))))
 
-(defn cmd-set-enabled [repo job-id enabled?]
-  (let [state (load-state repo)
-        jobs (mapv #(if (= job-id (get % "id")) (assoc % "enabled" enabled?) %) (:jobs state))]
+(defn cmd-set-enabled [job-id enabled?]
+  (let [state (registry)
+        jobs (mapv #(if (= job-id (:id %)) (assoc % :enabled enabled?) %) (:jobs state))]
     (find-job jobs job-id)
-    (save-state! (assoc state :jobs jobs))))
+    (save-registry! (assoc state :jobs jobs))))
 
-(defn cmd-delete [repo job-id]
-  (let [state (load-state repo)
+(defn cmd-delete [job-id]
+  (let [state (registry)
         job (find-job (:jobs state) job-id)
-        jobs (vec (remove #(= job-id (get % "id")) (:jobs state)))]
-    (save-state! (-> state
-                     (assoc :jobs jobs)
-                     (update :cm-text delete-prompt (get job "promptFile"))))))
+        prompt (str (fs/normalize (prompt-path job)))
+        prompt-root (str (fs/normalize (prompts-dir)))]
+    (when (and (not= "false" (System/getenv "CODEX_CRON_DELETE_PROMPT"))
+               (str/starts-with? prompt prompt-root))
+      (fs/delete-if-exists prompt))
+    (save-registry! (assoc state :jobs (vec (remove #(= job-id (:id %)) (:jobs state)))))))
+
+(defn cmd-run [job-id]
+  (find-job (:jobs (registry)) job-id)
+  @(p/process ["/opt/codex-workspace/cron/run-codex-cron.sh" job-id]
+              {:out :inherit :err :inherit}))
 
 (defn -main [& argv]
-  (let [{:keys [repo args]} (parse-global argv)
+  (let [args (parse-global argv)
         command (first args)
         rest-args (vec (rest args))]
     (case command
-      "list" (cmd-list repo)
-      "show" (cmd-show repo (or (first rest-args) (fail "job id is required")))
-      "add" (cmd-add repo (:opts (opts-map rest-args)))
+      "list" (cmd-list)
+      "show" (cmd-show (or (first rest-args) (lib/fail "job id is required")))
+      "add" (cmd-add (:opts (opts-map rest-args)))
       "update" (let [{:keys [opts positional]} (opts-map rest-args)]
-                 (cmd-update repo (or (first positional) (fail "job id is required")) opts))
-      "enable" (cmd-set-enabled repo (or (first rest-args) (fail "job id is required")) true)
-      "disable" (cmd-set-enabled repo (or (first rest-args) (fail "job id is required")) false)
-      "delete" (cmd-delete repo (or (first rest-args) (fail "job id is required")))
+                 (cmd-update (or (first positional) (lib/fail "job id is required")) opts))
+      "enable" (cmd-set-enabled (or (first rest-args) (lib/fail "job id is required")) true)
+      "disable" (cmd-set-enabled (or (first rest-args) (lib/fail "job id is required")) false)
+      "delete" (cmd-delete (or (first rest-args) (lib/fail "job id is required")))
+      "run" (cmd-run (or (first rest-args) (lib/fail "job id is required")))
       (usage))))
 
 (apply -main *command-line-args*)

--- a/docs/project_docs/BOXP-16-codex-cron-skill/plan.md
+++ b/docs/project_docs/BOXP-16-codex-cron-skill/plan.md
@@ -1,0 +1,18 @@
+# BOXP-16: Codex workspace cron CRUD skill
+
+## Context
+
+`boxp/lolice` PR #594 adds Codex workspace scheduled prompts through `argoproj/codex-workspace/cron-configmap.yaml` and `cronjob.yaml`. Operators need a Codex skill inside the workspace that can inspect and edit those GitOps manifests safely.
+
+## Design
+
+- Bundle a `codex-workspace-cron` skill into the Codex workspace image.
+- Sync image-provided skills from `/opt/codex-workspace/skills` into `/home/boxp/.codex/skills` at container startup so the existing Longhorn home PVC receives updates.
+- Include a deterministic Babashka helper for `list`, `show`, `add`, `update`, `enable`, `disable`, and `delete`.
+- Keep operations GitOps-only. The skill does not mutate the live Kubernetes cluster unless the user separately asks for a manual live run.
+
+## Validation
+
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb --help` exits with usage
+- Helper smoke test against a copied `boxp/lolice` cron manifest.

--- a/docs/project_docs/BOXP-16-codex-cron-skill/plan.md
+++ b/docs/project_docs/BOXP-16-codex-cron-skill/plan.md
@@ -1,18 +1,23 @@
-# BOXP-16: Codex workspace cron CRUD skill
+# BOXP-16: Codex workspace cron skill and scheduler
 
 ## Context
 
-`boxp/lolice` PR #594 adds Codex workspace scheduled prompts through `argoproj/codex-workspace/cron-configmap.yaml` and `cronjob.yaml`. Operators need a Codex skill inside the workspace that can inspect and edit those GitOps manifests safely.
+`boxp/lolice` now runs Codex workspace cron through a resident sidecar scheduler. Operators need the Codex workspace image to provide that scheduler, its runner, and a skill helper that edits the live home registry instead of GitOps CronJob manifests.
 
 ## Design
 
-- Bundle a `codex-workspace-cron` skill into the Codex workspace image.
-- Sync image-provided skills from `/opt/codex-workspace/skills` into `/home/boxp/.codex/skills` at container startup so the existing Longhorn home PVC receives updates.
-- Include a deterministic Babashka helper for `list`, `show`, `add`, `update`, `enable`, `disable`, and `delete`.
-- Keep operations GitOps-only. The skill does not mutate the live Kubernetes cluster unless the user separately asks for a manual live run.
+- Bundle `/opt/codex-workspace/cron/scheduler.bb`.
+- Bundle `/opt/codex-workspace/cron/run-codex-cron.sh`.
+- Keep scheduler state under `/home/boxp/.codex-cron/jobs-state.edn`.
+- Keep jobs and prompts under `/home/boxp/.codex-cron/jobs.edn` and `/home/boxp/.codex-cron/prompts`.
+- Bundle a `codex-workspace-cron` skill into `/home/boxp/.codex/skills` at container startup.
+- Include a Babashka helper for `list`, `show`, `add`, `update`, `enable`, `disable`, `delete`, and `run`.
+- Keep scripting in Babashka and shell, not Python/Ruby.
 
 ## Validation
 
 - `bash -n docker/codex-workspace/entrypoint.sh`
-- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb --help` exits with usage
-- Helper smoke test against a copied `boxp/lolice` cron manifest.
+- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
+- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb --root <tmp> list`
+- Smoke-test helper CRUD against a temporary home registry.
+- `git diff --check`


### PR DESCRIPTION
## Summary

- bundle Codex workspace cron runtime scripts in the image under `/opt/codex-workspace/cron`
- add a resident Babashka scheduler that reads `/home/boxp/.codex-cron/jobs.edn`
- change the `codex-workspace-cron` skill/helper to CRUD the live home registry instead of `boxp/lolice` ConfigMap/CronJob manifests
- keep scripting in Babashka and shell

## Related

- Supports boxp/lolice PR #595, which runs the scheduler as a workspace sidecar.
- BOXP-16

## Validation

- `bash -n docker/codex-workspace/entrypoint.sh`
- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb --root <tmp> list`
- smoke-tested helper `add/show/update/enable/disable/delete` against a temporary home registry
- `CODEX_CRON_ROOT=<tmp> timeout 2s bb docker/codex-workspace/cron/scheduler.bb`
- `git diff --check`