### PR TITLE
[codex] Fix codex workspace startup permissions

### DIFF
--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -3,18 +3,19 @@ set -euo pipefail
 
 install -d -m 0755 /run/sshd
 install -d -o boxp -g boxp -m 0755 /home/boxp
-install -d -o boxp -g boxp -m 0700 /home/boxp/.ssh
-install -d -o boxp -g boxp -m 0755 /home/boxp/.codex/skills
-install -d -o boxp -g boxp -m 0755 /home/boxp/.codex-cron
-install -d -o boxp -g boxp -m 0755 /home/boxp/ghq
+/usr/sbin/runuser -u boxp -- install -d -m 0700 /home/boxp/.ssh
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex/skills
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex-cron
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/ghq
 
 if [[ -d /opt/codex-workspace/skills ]]; then
-  cp -a /opt/codex-workspace/skills/. /home/boxp/.codex/skills/
-  chown -R boxp:boxp /home/boxp/.codex/skills
+  /usr/sbin/runuser -u boxp -- cp -R --no-preserve=mode,ownership \
+    /opt/codex-workspace/skills/. /home/boxp/.codex/skills/
 fi
 
 if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
-  install -o boxp -g boxp -m 0600 /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys
+  /usr/sbin/runuser -u boxp -- install -m 0600 \
+    /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys
 fi
 
 ssh-keygen -A

--- a/docs/project_docs/fix-codex-workspace-backoff/plan.md
+++ b/docs/project_docs/fix-codex-workspace-backoff/plan.md
@@ -1,0 +1,25 @@
+# fix-codex-workspace-backoff: Codex workspace startup failure
+
+## Context
+
+`codex-workspace` Pod is in `CrashLoopBackOff`. The failing container is `workspace`, and its previous log shows the entrypoint exiting while copying bundled Codex skills into the persistent home directory:
+
+```text
+cp: cannot create directory '/home/boxp/.codex/skills/./codex-workspace-cron': Permission denied
+cp: failed to preserve ownership for '/home/boxp/.codex/skills/.': Permission denied
+```
+
+The workspace container runs as root but drops broad capabilities. The persistent `/home/boxp` tree is owned by `boxp`, so root without write override cannot create or copy files under the directory. `cp -a` also attempts to preserve ownership, which is unnecessary for bundled skills and fails in this restricted startup context.
+
+## Plan
+
+- Initialize home subdirectories as the `boxp` user instead of root.
+- Copy bundled skills as the `boxp` user instead of root.
+- Avoid preserving source ownership and mode when syncing the bundled skills.
+- Keep the entrypoint behavior otherwise unchanged.
+
+## Verification
+
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- Build the image locally enough to exercise entrypoint startup.
+- Run a container with a pre-created `boxp`-owned home directory to confirm the skill copy no longer fails.


### PR DESCRIPTION
## Summary

- Fix Codex workspace entrypoint home initialization under the restricted root capability set.
- Run home directory setup, authorized key install, and bundled skill sync as the `boxp` user.
- Stop preserving source ownership/mode when copying bundled Codex skills into the persistent home directory.
- Add the task plan under `docs/project_docs/fix-codex-workspace-backoff/plan.md`.

## Root Cause

The `workspace` container was in `CrashLoopBackOff` because the entrypoint copied bundled skills into `/home/boxp/.codex/skills` with `cp -a` as root. The container drops broad capabilities, and the persistent home tree is owned by `boxp`, so root could not write there or preserve ownership.

Observed previous log:

```text
cp: cannot create directory '/home/boxp/.codex/skills/./codex-workspace-cron': Permission denied
cp: failed to preserve ownership for '/home/boxp/.codex/skills/.': Permission denied
```

## Validation

- `bash -n docker/codex-workspace/entrypoint.sh`
- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
- `git diff --check`
- `docker build -t codex-workspace:backoff-test docker/codex-workspace`
- `docker run` smoke test with the same dropped-capability shape confirmed `codex-workspace-cron` is copied into the mounted home as UID/GID 1000 without permission errors.
