### PR TITLE
[codex] Add Gemini API key SSM parameter

### DIFF
--- a/terraform/aws/codex-workspace/ssm.tf
+++ b/terraform/aws/codex-workspace/ssm.tf
@@ -13,3 +13,19 @@ resource "aws_ssm_parameter" "even_terminal_token" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "gemini_api_key" {
+  name        = "/lolice/codex-workspace/gemini-api-key"
+  description = "Gemini API key for image generation in the lolice Codex workspace"
+  type        = "SecureString"
+  value       = "dummy-value-to-be-updated-manually"
+
+  tags = {
+    Project = "lolice"
+    Purpose = "codex-workspace"
+  }
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## Summary

- Add a Terraform-managed SecureString placeholder for `/lolice/codex-workspace/gemini-api-key`.
- Keep the value manually managed via `ignore_changes = [value]`, matching the existing Codex workspace secret pattern.

## Why

The Codex workspace image-generation skill expects `GEMINI_API_KEY` at runtime. The Kubernetes side will read this path through External Secrets, so the SSM parameter needs to exist in `boxp/arch`.

## Validation

- Ran `git diff --check`.
- Could not run local `terraform fmt`/`validate` because `terraform` and `aqua` are not installed in the current Codex workspace; CI should cover Terraform checks.