### PR TITLE
Add Chromium to Codex workspace image

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       bash-completion \
       ca-certificates \
+      chromium \
       curl \
       fzf \
       g++ \
@@ -100,6 +101,8 @@ RUN locale-gen en_US.UTF-8 \
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
+    CHROME_BIN=/usr/bin/chromium \
+    PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
     PATH=/home/boxp/.local/bin:/home/boxp/go/bin:/usr/local/bin:/usr/bin:/bin
 
 COPY entrypoint.sh /usr/local/bin/codex-workspace-entrypoint


### PR DESCRIPTION
## Summary\n- install Ubuntu's chromium package in the Codex workspace image\n- expose CHROME_BIN and PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH for tools that need a system browser\n\n## Why\nPlaywright's bundled Chromium is not available for the current Ubuntu 26.04 workspace environment, so browser-based checks need a system Chromium in the image.\n\n## Verification\n- local Docker build could not run because this workspace Docker CLI is missing buildx\n- CI image build should validate the Dockerfile on this PR\n