### PR TITLE
Polish video rotator clipping UI

### DIFF
--- a/apps/video-rotator/index.html
+++ b/apps/video-rotator/index.html
@@ -7,70 +7,103 @@
   </head>
   <body>
     <main id="app">
-      <section class="toolbar" aria-label="Video controls">
-        <label class="file-picker">
-          <input id="file-input" type="file" accept="video/*" />
-          <span>動画を選択</span>
-        </label>
-
-        <div class="control-group">
-          <span class="group-label">回転</span>
-          <div class="segmented" role="radiogroup" aria-label="Rotation direction">
-            <label>
-              <input type="radio" name="rotation" value="cw" checked />
-              <span>時計回り</span>
-            </label>
-            <label>
-              <input type="radio" name="rotation" value="ccw" />
-              <span>反時計回り</span>
-            </label>
-          </div>
+      <header class="topbar">
+        <div>
+          <h1>Video Rotator</h1>
+          <p id="file-meta">動画を選択してください</p>
         </div>
-
-        <label class="field">
-          <span>開始</span>
-          <input id="start-input" type="number" min="0" step="0.1" value="0" />
-        </label>
-        <label class="field">
-          <span>終了</span>
-          <input id="end-input" type="number" min="0" step="0.1" value="0" />
-        </label>
-        <label class="field">
-          <span>出力</span>
-          <select id="size-select">
-            <option value="source">元解像度</option>
-            <option value="1080">高さ1080</option>
-            <option value="720">高さ720</option>
-          </select>
-        </label>
-        <label class="field">
-          <span>形式</span>
-          <select id="format-select">
-            <option value="mp4">MP4</option>
-            <option value="webm">WebM</option>
-          </select>
-        </label>
-
-        <button id="mark-start" type="button">現在位置を開始に</button>
-        <button id="mark-end" type="button">現在位置を終了に</button>
-        <button id="export-button" type="button" disabled>書き出し</button>
-      </section>
+        <div class="topbar-actions">
+          <label class="file-picker">
+            <input id="file-input" type="file" accept="video/*" />
+            <span>動画を選択</span>
+          </label>
+          <button id="export-button" type="button" disabled>書き出し</button>
+        </div>
+      </header>
 
       <section class="workspace" aria-label="Video workspace">
         <div class="source-pane">
-          <video id="source-video" controls playsinline></video>
-          <input id="timeline" type="range" min="0" max="0" step="0.01" value="0" />
-          <div class="meta-row">
-            <span id="file-meta">動画を選択してください</span>
-            <span id="time-meta">00:00.0 / 00:00.0</span>
+          <button id="drop-zone" class="drop-zone" type="button">
+            <span class="drop-zone-icon">+</span>
+            <span>
+              <strong>動画をドロップ</strong>
+              <small id="drop-zone-meta">MP4 / WebM / MOV</small>
+            </span>
+          </button>
+
+          <div class="video-shell">
+            <video id="source-video" controls playsinline></video>
+          </div>
+
+          <div class="trim-panel" aria-label="Clip range">
+            <div class="trim-header">
+              <span id="time-meta">00:00.0 / 00:00.0</span>
+              <span id="clip-duration">00:00.0</span>
+            </div>
+
+            <div id="trim-bar" class="trim-bar">
+              <div class="trim-track"></div>
+              <div id="range-fill" class="range-fill"></div>
+              <div id="playhead" class="playhead"></div>
+              <input id="range-start" class="range-handle" type="range" min="0" max="0" step="0.01" value="0" aria-label="開始位置" disabled />
+              <input id="range-end" class="range-handle" type="range" min="0" max="0" step="0.01" value="0" aria-label="終了位置" disabled />
+              <input id="timeline" class="timeline-hit" type="range" min="0" max="0" step="0.01" value="0" aria-label="再生位置" disabled />
+            </div>
+
+            <div class="trim-fields">
+              <label class="field">
+                <span>開始</span>
+                <input id="start-input" type="number" min="0" step="0.1" value="0" />
+              </label>
+              <button id="mark-start" type="button">現在位置</button>
+              <label class="field">
+                <span>終了</span>
+                <input id="end-input" type="number" min="0" step="0.1" value="0" />
+              </label>
+              <button id="mark-end" type="button">現在位置</button>
+            </div>
           </div>
         </div>
 
-        <div class="preview-pane">
-          <canvas id="preview-canvas"></canvas>
-          <div id="status" role="status">待機中</div>
-          <a id="download-link" hidden>download</a>
-        </div>
+        <aside class="settings-pane" aria-label="Export settings">
+          <div class="control-group">
+            <span class="group-label">回転</span>
+            <div class="segmented" role="radiogroup" aria-label="Rotation direction">
+              <label>
+                <input type="radio" name="rotation" value="cw" checked />
+                <span>時計回り</span>
+              </label>
+              <label>
+                <input type="radio" name="rotation" value="ccw" />
+                <span>反時計回り</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="settings-grid">
+            <label class="field">
+              <span>出力</span>
+              <select id="size-select">
+                <option value="source">元解像度</option>
+                <option value="1080">高さ1080</option>
+                <option value="720">高さ720</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>形式</span>
+              <select id="format-select">
+                <option value="mp4">MP4</option>
+                <option value="webm">WebM</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="preview-pane">
+            <canvas id="preview-canvas"></canvas>
+            <div id="status" role="status">待機中</div>
+            <a id="download-link" hidden>download</a>
+          </div>
+        </aside>
       </section>
     </main>
 

--- a/apps/video-rotator/src/main.ts
+++ b/apps/video-rotator/src/main.ts
@@ -18,9 +18,15 @@ function getElement<T extends Element>(selector: string): T {
 }
 
 const fileInput = getElement<HTMLInputElement>('#file-input')
+const dropZone = getElement<HTMLButtonElement>('#drop-zone')
+const dropZoneMeta = getElement<HTMLElement>('#drop-zone-meta')
 const video = getElement<HTMLVideoElement>('#source-video')
 const canvas = getElement<HTMLCanvasElement>('#preview-canvas')
 const timeline = getElement<HTMLInputElement>('#timeline')
+const rangeStart = getElement<HTMLInputElement>('#range-start')
+const rangeEnd = getElement<HTMLInputElement>('#range-end')
+const rangeFill = getElement<HTMLDivElement>('#range-fill')
+const playhead = getElement<HTMLDivElement>('#playhead')
 const startInput = getElement<HTMLInputElement>('#start-input')
 const endInput = getElement<HTMLInputElement>('#end-input')
 const sizeSelect = getElement<HTMLSelectElement>('#size-select')
@@ -28,8 +34,9 @@ const formatSelect = getElement<HTMLSelectElement>('#format-select')
 const markStartButton = getElement<HTMLButtonElement>('#mark-start')
 const markEndButton = getElement<HTMLButtonElement>('#mark-end')
 const exportButton = getElement<HTMLButtonElement>('#export-button')
-const fileMeta = getElement<HTMLSpanElement>('#file-meta')
+const fileMeta = getElement<HTMLElement>('#file-meta')
 const timeMeta = getElement<HTMLSpanElement>('#time-meta')
+const clipDuration = getElement<HTMLSpanElement>('#clip-duration')
 const statusLine = getElement<HTMLDivElement>('#status')
 const downloadLink = getElement<HTMLAnchorElement>('#download-link')
 
@@ -50,6 +57,7 @@ let fetchFileForFfmpeg: FetchFile | null = null
 let lastFfmpegLog = ''
 
 const ffmpegCoreBaseUrl = 'https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd'
+const rangeInputs = [timeline, rangeStart, rangeEnd]
 
 function getRotation(): Rotation {
   const checked = document.querySelector<HTMLInputElement>('input[name="rotation"]:checked')
@@ -70,15 +78,23 @@ function formatTime(seconds: number): string {
   return `${minutes.toString().padStart(2, '0')}:${rest.toFixed(1).padStart(4, '0')}`
 }
 
+function getDuration(): number {
+  return Number.isFinite(video.duration) ? video.duration : 0
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max))
+}
+
 function setStatus(message: string): void {
   statusLine.textContent = message
 }
 
 function getClipRange(): { start: number; end: number } {
-  const duration = Number.isFinite(video.duration) ? video.duration : 0
-  const start = Math.max(0, Math.min(Number(startInput.value) || 0, duration))
+  const duration = getDuration()
+  const start = clamp(Number(startInput.value) || 0, 0, duration)
   const fallbackEnd = duration > 0 ? duration : start
-  const end = Math.max(start, Math.min(Number(endInput.value) || fallbackEnd, duration))
+  const end = clamp(Number(endInput.value) || fallbackEnd, start, duration)
   return { start, end }
 }
 
@@ -133,10 +149,10 @@ function drawFrame(): void {
 }
 
 function updateMeta(): void {
-  const duration = Number.isFinite(video.duration) ? video.duration : 0
-  timeline.max = duration.toString()
+  const duration = getDuration()
   timeline.value = video.currentTime.toString()
   timeMeta.textContent = `${formatTime(video.currentTime)} / ${formatTime(duration)}`
+  updateTrimVisuals()
 }
 
 function tick(): void {
@@ -146,16 +162,64 @@ function tick(): void {
 }
 
 function setDefaultRange(): void {
-  const duration = Number.isFinite(video.duration) ? video.duration : 0
+  const duration = getDuration()
   const end = Math.min(duration, 30)
   startInput.value = '0'
   endInput.value = end.toFixed(1)
+  rangeStart.value = '0'
+  rangeEnd.value = end.toString()
+  updateTrimVisuals()
 }
 
 function normalizeRangeInputs(): void {
   const { start, end } = getClipRange()
   startInput.value = start.toFixed(1)
   endInput.value = end.toFixed(1)
+  rangeStart.value = start.toString()
+  rangeEnd.value = end.toString()
+  updateTrimVisuals()
+}
+
+function updateRangeLimits(): void {
+  const duration = getDuration()
+
+  rangeInputs.forEach((input) => {
+    input.max = duration.toString()
+    input.disabled = duration <= 0
+  })
+}
+
+function updateTrimVisuals(): void {
+  const duration = getDuration()
+  const { start, end } = getClipRange()
+  const startPercent = duration > 0 ? (start / duration) * 100 : 0
+  const endPercent = duration > 0 ? (end / duration) * 100 : 0
+  const playheadPercent = duration > 0 ? (video.currentTime / duration) * 100 : 0
+
+  rangeFill.style.left = `${startPercent}%`
+  rangeFill.style.width = `${Math.max(0, endPercent - startPercent)}%`
+  playhead.style.left = `${clamp(playheadPercent, 0, 100)}%`
+  clipDuration.textContent = `${formatTime(end - start)} clip`
+}
+
+function updateRangeFromHandle(activeHandle: 'start' | 'end'): void {
+  const duration = getDuration()
+  const minGap = duration > 0 ? Math.min(0.1, duration) : 0
+  let start = Number(rangeStart.value) || 0
+  let end = Number(rangeEnd.value) || 0
+
+  if (activeHandle === 'start') {
+    start = clamp(start, 0, Math.max(0, end - minGap))
+  } else {
+    end = clamp(end, Math.min(duration, start + minGap), duration)
+  }
+
+  startInput.value = start.toFixed(1)
+  endInput.value = end.toFixed(1)
+  rangeStart.value = start.toString()
+  rangeEnd.value = end.toString()
+  video.currentTime = activeHandle === 'start' ? start : end
+  updateTrimVisuals()
 }
 
 function revokeDownload(): void {
@@ -166,6 +230,32 @@ function revokeDownload(): void {
 
   downloadLink.hidden = true
   downloadLink.removeAttribute('href')
+}
+
+function setSourceFile(file: File): void {
+  if (!file.type.startsWith('video/')) {
+    setStatus('動画ファイルを選択してください')
+    return
+  }
+
+  if (sourceUrl) {
+    URL.revokeObjectURL(sourceUrl)
+  }
+
+  revokeDownload()
+  sourceUrl = URL.createObjectURL(file)
+  sourceName = file.name.replace(/\.[^.]+$/, '') || 'rotated-video'
+  video.src = sourceUrl
+  fileMeta.textContent = `${file.name} / ${(file.size / 1024 / 1024).toFixed(1)} MB`
+  dropZoneMeta.textContent = file.name
+  document.body.classList.add('has-video')
+  exportButton.disabled = false
+  setStatus('読み込み中')
+}
+
+function getDroppedVideoFile(event: DragEvent): File | null {
+  const files = Array.from(event.dataTransfer?.files ?? [])
+  return files.find((file) => file.type.startsWith('video/')) ?? null
 }
 
 function getSupportedMimeType(format: ExportFormat): string {
@@ -397,20 +487,51 @@ fileInput.addEventListener('change', () => {
     return
   }
 
-  if (sourceUrl) {
-    URL.revokeObjectURL(sourceUrl)
+  setSourceFile(file)
+})
+
+dropZone.addEventListener('click', () => {
+  fileInput.click()
+})
+
+dropZone.addEventListener('dragenter', (event) => {
+  event.preventDefault()
+  dropZone.classList.add('is-dragging')
+})
+
+dropZone.addEventListener('dragover', (event) => {
+  event.preventDefault()
+  dropZone.classList.add('is-dragging')
+})
+
+dropZone.addEventListener('dragleave', () => {
+  dropZone.classList.remove('is-dragging')
+})
+
+dropZone.addEventListener('drop', (event) => {
+  event.preventDefault()
+  dropZone.classList.remove('is-dragging')
+
+  const file = getDroppedVideoFile(event)
+
+  if (!file) {
+    setStatus('動画ファイルをドロップしてください')
+    return
   }
 
-  revokeDownload()
-  sourceUrl = URL.createObjectURL(file)
-  sourceName = file.name.replace(/\.[^.]+$/, '') || 'rotated-video'
-  video.src = sourceUrl
-  fileMeta.textContent = `${file.name} / ${(file.size / 1024 / 1024).toFixed(1)} MB`
-  exportButton.disabled = false
-  setStatus('読み込み中')
+  setSourceFile(file)
+})
+
+window.addEventListener('dragover', (event) => {
+  event.preventDefault()
+})
+
+window.addEventListener('drop', (event) => {
+  event.preventDefault()
 })
 
 video.addEventListener('loadedmetadata', () => {
+  updateRangeLimits()
   setDefaultRange()
   normalizeRangeInputs()
   resizeCanvas()
@@ -420,10 +541,13 @@ video.addEventListener('loadedmetadata', () => {
 
 timeline.addEventListener('input', () => {
   video.currentTime = Number(timeline.value)
+  updateTrimVisuals()
 })
 
 startInput.addEventListener('change', normalizeRangeInputs)
 endInput.addEventListener('change', normalizeRangeInputs)
+rangeStart.addEventListener('input', () => updateRangeFromHandle('start'))
+rangeEnd.addEventListener('input', () => updateRangeFromHandle('end'))
 sizeSelect.addEventListener('change', drawFrame)
 document.querySelectorAll<HTMLInputElement>('input[name="rotation"]').forEach((input) => {
   input.addEventListener('change', drawFrame)

--- a/apps/video-rotator/src/styles.css
+++ b/apps/video-rotator/src/styles.css
@@ -1,6 +1,6 @@
 :root {
-  color: #eceff3;
-  background: #15171c;
+  color: #eef2f7;
+  background: #111317;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -29,10 +29,10 @@ button,
 .file-picker span,
 select,
 input[type='number'] {
-  border: 1px solid #3c414c;
-  border-radius: 6px;
-  color: #eceff3;
-  background: #20242c;
+  border: 1px solid #3b424e;
+  border-radius: 8px;
+  color: #eef2f7;
+  background: #20252d;
 }
 
 button,
@@ -40,6 +40,13 @@ button,
   min-height: 40px;
   padding: 0 14px;
   cursor: pointer;
+}
+
+button:hover,
+.file-picker span:hover,
+select:hover,
+input[type='number']:hover {
+  border-color: #607086;
 }
 
 button:disabled {
@@ -53,14 +60,37 @@ button:disabled {
   min-height: 100vh;
 }
 
-.toolbar {
+.topbar {
   display: flex;
-  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #272d36;
+  background: #171a20;
+}
+
+h1 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+#file-meta {
+  max-width: min(70vw, 720px);
+  margin: 5px 0 0;
+  overflow: hidden;
+  color: #aeb7c4;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topbar-actions {
+  display: flex;
   gap: 10px;
-  align-items: end;
-  padding: 14px;
-  border-bottom: 1px solid #2a2e37;
-  background: #181b21;
+  align-items: center;
 }
 
 .file-picker input {
@@ -70,9 +100,229 @@ button:disabled {
   opacity: 0;
 }
 
-.file-picker span {
+.file-picker span,
+#export-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+#export-button {
+  border-color: #54b38c;
+  color: #07100d;
+  background: #62d69f;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(320px, 430px);
+  gap: 18px;
+  min-height: 0;
+  padding: 18px;
+}
+
+.source-pane,
+.settings-pane,
+.preview-pane {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-width: 0;
+}
+
+.drop-zone {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  width: 100%;
+  min-height: 92px;
+  padding: 18px;
+  border: 1px dashed #526175;
+  color: #eef2f7;
+  background: #191e25;
+  text-align: left;
+}
+
+.drop-zone.is-dragging {
+  border-color: #62d69f;
+  background: #18251f;
+}
+
+.drop-zone-icon {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 8px;
+  color: #08110e;
+  background: #62d69f;
+  font-size: 26px;
+  line-height: 1;
+}
+
+.drop-zone strong,
+.drop-zone small {
+  display: block;
+}
+
+.drop-zone small {
+  margin-top: 4px;
+  overflow: hidden;
+  color: #aeb7c4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.has-video .drop-zone {
+  min-height: 64px;
+  padding: 12px 14px;
+  border-style: solid;
+}
+
+.has-video .drop-zone-icon {
+  width: 34px;
+  height: 34px;
+  font-size: 21px;
+}
+
+.video-shell {
+  overflow: hidden;
+  border: 1px solid #303844;
+  border-radius: 8px;
+  background: #090b0f;
+}
+
+video {
+  display: block;
+  width: 100%;
+  max-height: calc(100vh - 310px);
+  background: #090b0f;
+}
+
+.trim-panel,
+.settings-pane {
+  border: 1px solid #29303a;
+  border-radius: 8px;
+  background: #171b22;
+}
+
+.trim-panel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.trim-header {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  color: #aeb7c4;
+  font-size: 13px;
+}
+
+#clip-duration {
+  color: #f4bd64;
+}
+
+.trim-bar {
+  position: relative;
+  height: 42px;
+}
+
+.trim-track,
+.range-fill {
+  position: absolute;
+  top: 16px;
+  right: 0;
+  left: 0;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.trim-track {
+  background: #27313c;
+}
+
+.range-fill {
+  right: auto;
+  background: #62d69f;
+}
+
+.playhead {
+  position: absolute;
+  top: 6px;
+  z-index: 4;
+  width: 2px;
+  height: 30px;
+  border-radius: 999px;
+  background: #f4bd64;
+  transform: translateX(-1px);
+}
+
+.range-handle,
+.timeline-hit {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 42px;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+}
+
+.timeline-hit {
+  z-index: 2;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.range-handle {
+  z-index: 3;
+  pointer-events: none;
+}
+
+.range-handle::-webkit-slider-runnable-track,
+.timeline-hit::-webkit-slider-runnable-track {
+  height: 42px;
+  background: transparent;
+}
+
+.range-handle::-webkit-slider-thumb {
+  width: 18px;
+  height: 30px;
+  margin-top: 6px;
+  border: 2px solid #0d1411;
+  border-radius: 6px;
+  appearance: none;
+  background: #eef2f7;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+}
+
+.range-handle::-moz-range-track,
+.timeline-hit::-moz-range-track {
+  height: 42px;
+  background: transparent;
+}
+
+.range-handle::-moz-range-thumb {
+  width: 18px;
+  height: 30px;
+  border: 2px solid #0d1411;
+  border-radius: 6px;
+  background: #eef2f7;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+}
+
+.trim-fields,
+.settings-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: end;
 }
 
 .control-group,
@@ -83,17 +333,32 @@ button:disabled {
 
 .group-label,
 .field span {
-  color: #aab1bd;
+  color: #aeb7c4;
   font-size: 12px;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  height: 40px;
+  padding: 0 10px;
+}
+
+.trim-fields button {
+  min-width: 84px;
+}
+
+.settings-pane {
+  padding: 16px;
 }
 
 .segmented {
   display: inline-grid;
-  grid-template-columns: repeat(2, minmax(96px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   overflow: hidden;
-  border: 1px solid #3c414c;
-  border-radius: 6px;
-  background: #20242c;
+  border: 1px solid #3b424e;
+  border-radius: 8px;
+  background: #20252d;
 }
 
 .segmented label {
@@ -111,64 +376,23 @@ button:disabled {
   min-height: 40px;
   place-items: center;
   padding: 0 12px;
-  color: #c7ccd5;
+  color: #cbd3de;
 }
 
 .segmented input:checked + span {
-  color: #ffffff;
-  background: #2f6fdb;
+  color: #08100d;
+  background: #62d69f;
 }
 
-.field input,
-.field select {
-  width: 112px;
-  height: 40px;
-  padding: 0 10px;
-}
-
-.workspace {
-  display: grid;
-  grid-template-columns: minmax(320px, 1fr) minmax(280px, 520px);
-  gap: 18px;
-  min-height: 0;
-  padding: 18px;
-}
-
-.source-pane,
-.preview-pane {
-  display: grid;
-  align-content: start;
-  gap: 12px;
-  min-width: 0;
-}
-
-video {
-  width: 100%;
-  max-height: calc(100vh - 190px);
-  border: 1px solid #303640;
-  border-radius: 8px;
-  background: #0e1014;
-}
-
-#timeline {
-  width: 100%;
-  accent-color: #54b4a8;
-}
-
-.meta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 18px;
-  justify-content: space-between;
-  color: #aab1bd;
-  font-size: 13px;
+.settings-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 canvas {
-  width: min(100%, 420px);
-  max-height: calc(100vh - 160px);
+  width: min(100%, 330px);
+  max-height: calc(100vh - 310px);
   aspect-ratio: 9 / 16;
-  border: 1px solid #303640;
+  border: 1px solid #303844;
   border-radius: 8px;
   background: #101114;
   justify-self: center;
@@ -176,7 +400,7 @@ canvas {
 
 #status {
   min-height: 24px;
-  color: #c7ccd5;
+  color: #cbd3de;
   font-size: 14px;
   text-align: center;
 }
@@ -185,13 +409,13 @@ canvas {
   justify-self: center;
   min-height: 40px;
   padding: 9px 14px;
-  border-radius: 6px;
-  color: #09120f;
-  background: #67d7a5;
+  border-radius: 8px;
+  color: #07100d;
+  background: #f4bd64;
   text-decoration: none;
 }
 
-@media (max-width: 860px) {
+@media (max-width: 920px) {
   .workspace {
     grid-template-columns: 1fr;
   }
@@ -199,5 +423,33 @@ canvas {
   video,
   canvas {
     max-height: none;
+  }
+
+  canvas {
+    width: min(100%, 420px);
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .topbar-actions,
+  .trim-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar-actions {
+    display: grid;
+  }
+
+  .trim-fields {
+    display: grid;
+  }
+
+  .trim-fields button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary\n- replace the compact toolbar with a clearer workspace layout\n- add drag-and-drop video import with a dedicated drop zone\n- add graphical trim controls with start/end handles, playhead, and clip duration feedback\n- keep numeric start/end inputs and current-position buttons for precise adjustment\n\n## Verification\n- cd apps/video-rotator && npm run typecheck && npm run build\n\n## Notes\n- Playwright bundled Chromium could not be installed in the current Ubuntu 26.04 workspace, so screenshot verification was not run here. The Codex workspace image has since been updated to include system Chromium for future checks.\n