### PR TITLE
Deploy video rotator dev to custom domain

### DIFF
--- a/.github/workflows/deploy-video-rotator-dev.yml
+++ b/.github/workflows/deploy-video-rotator-dev.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages dev
         working-directory: apps/video-rotator
-        run: npx wrangler pages deploy dist --project-name boxp-video-rotator-dev --branch dev
+        run: npx wrangler pages deploy dist --project-name boxp-video-rotator-dev --branch main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary\n- deploy the dev Pages project to its production branch so the custom domain works\n\n## Why\nThe first dev deployment used `--branch dev`, which created a Pages preview alias. The custom domain `video-rotator-dev.b0xp.io` points at the project production branch, so it returned Cloudflare's Deployment Not Found page.\n\n## Verification\n- npx --yes prettier --check .github/workflows/deploy-video-rotator-dev.yml\n