### PR TITLE
[codex] Allow Even G2 image workflow to read ECR manifests

### DIFF
--- a/terraform/aws/even-g2-lab/iam.tf
+++ b/terraform/aws/even-g2-lab/iam.tf
@@ -36,6 +36,8 @@ resource "aws_iam_policy" "even_g2_lab_main_gha_policy" {
     Statement = [
       {
         Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
           "ecr:CompleteLayerUpload",
           "ecr:InitiateLayerUpload",
@@ -60,4 +62,3 @@ resource "aws_iam_role_policy_attachment" "even_g2_lab_main_gha_policy_attachmen
   role       = aws_iam_role.even_g2_lab_main_gha_role.name
   policy_arn = aws_iam_policy.even_g2_lab_main_gha_policy.arn
 }
-


### PR DESCRIPTION
## Summary

- Add the missing ECR read actions used by Docker Buildx/ECR during image push manifest checks.
- Align the Even G2 main image GitHub Actions role with the existing ECR push policies used by other services.

## Context

After `boxp/even-g2-lab` PR #7 fixed the invalid `amazon-ecr-login` action ref, the main image workflow reached ECR push but failed with:

```text
unexpected status from HEAD request ... /manifests/sha256:...: 403 Forbidden
```

The role currently allowed upload and `ecr:PutImage`, but not `ecr:BatchGetImage` / `ecr:GetDownloadUrlForLayer`, which are present in the comparable ECR push policies in this repo.

## Validation

- `git diff --check`

Local Terraform validation was not run because this Codex workspace does not currently have `terraform` or `aqua` installed. The tfaction plan should validate the target.