### PR TITLE
[codex] Point codex cron at Obsidian root

### DIFF
--- a/docker/codex-workspace/cron/codex_cron_lib.bb
+++ b/docker/codex-workspace/cron/codex_cron_lib.bb
@@ -3,7 +3,7 @@
             [clojure.edn :as edn]
             [clojure.string :as str]))
 
-(def default-root "/home/boxp/.codex-cron")
+(def default-root "/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron")
 (def default-registry "jobs.edn")
 (def default-state "jobs-state.edn")
 

--- a/docker/codex-workspace/cron/run-codex-cron.sh
+++ b/docker/codex-workspace/cron/run-codex-cron.sh
@@ -7,7 +7,7 @@ if [[ -z "${job_id}" ]]; then
   exit 2
 fi
 
-cron_root="${CODEX_CRON_ROOT:-/home/boxp/.codex-cron}"
+cron_root="${CODEX_CRON_ROOT:-/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron}"
 
 eval "$(
   bb /opt/codex-workspace/cron/select-codex-cron-job.bb "${job_id}"

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -5,7 +5,7 @@ install -d -m 0755 /run/sshd
 install -d -o boxp -g boxp -m 0755 /home/boxp
 /usr/sbin/runuser -u boxp -- install -d -m 0700 /home/boxp/.ssh
 /usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex/skills
-/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex-cron
+/usr/sbin/runuser -u boxp -- install -d -m 0755 "/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron"
 /usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/ghq
 
 if [[ -d /opt/codex-workspace/skills ]]; then

--- a/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
+++ b/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: codex-workspace-cron
-description: Manage Codex workspace scheduled prompt jobs stored under ~/.codex-cron. Use when the user asks to list, show, add, edit, enable, disable, delete, or manually run Codex cron jobs.
+description: Manage Codex workspace scheduled prompt jobs stored in the Obsidian vault. Use when the user asks to list, show, add, edit, enable, disable, delete, or manually run Codex cron jobs.
 ---
 
 # Codex Workspace Cron
 
 Use this skill to operate the Codex workspace prompt scheduler from inside the Codex workspace.
 
-The live scheduler reads and writes only the workspace home PVC:
+The live scheduler reads and writes only the Obsidian vault path on the workspace home PVC:
 
-- `/home/boxp/.codex-cron/jobs.edn`: job registry.
-- `/home/boxp/.codex-cron/prompts/*.md`: prompt bodies.
-- `/home/boxp/.codex-cron/jobs-state.edn`: scheduler bookkeeping.
-- `/home/boxp/.codex-cron/runs/<job>/<run-id>/`: run logs.
+- `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron/jobs.edn`: job registry.
+- `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron/prompts/*.md`: prompt bodies.
+- `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron/jobs-state.edn`: scheduler bookkeeping.
+- `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron/runs/<job>/<run-id>/`: run logs.
 
 ## Workflow
 
@@ -80,4 +80,4 @@ bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb run daily-rep
 
 - Confirm schedule, prompt, and enabled state before turning a job on.
 - The scheduler supports standard 5-field cron expressions and polls every 30 seconds by default.
-- Do not edit Kubernetes CronJobs for individual schedules; the resident scheduler sidecar reads `~/.codex-cron/jobs.edn`.
+- Do not edit Kubernetes CronJobs for individual schedules; the resident scheduler sidecar reads the Obsidian vault `Codex Cron/jobs.edn`.

--- a/docs/project_docs/codex-cron-obsidian-root/plan.md
+++ b/docs/project_docs/codex-cron-obsidian-root/plan.md
@@ -1,0 +1,17 @@
+# codex-cron-obsidian-root: Codex cron root を Obsidian vault に寄せる
+
+## Goal
+
+Codex workspace cron の source of truth を `~/.codex-cron` symlink ではなく、Obsidian vault 上の実体 `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron` にする。
+
+## Plan
+
+1. `docker/codex-workspace/cron/codex_cron_lib.bb` の default root を Obsidian vault path に変更する。
+2. `docker/codex-workspace/cron/run-codex-cron.sh` の fallback root も同じ path に変更する。
+3. `docker/codex-workspace/entrypoint.sh` では `~/.codex-cron` を作らず、Obsidian vault path を作成する。
+4. bundled `codex-workspace-cron` skill の説明を vault path 前提に更新する。
+
+## Validation
+
+- `bash -n docker/codex-workspace/entrypoint.sh docker/codex-workspace/cron/run-codex-cron.sh`
+- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb list`


### PR DESCRIPTION
## Summary

- Change Codex cron's default root from `~/.codex-cron` to the Obsidian vault path `/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron`.
- Update the runner fallback, entrypoint directory creation, and bundled `codex-workspace-cron` skill docs to match the new source of truth.
- Add the project plan under `docs/project_docs/codex-cron-obsidian-root/plan.md`.

## Why

The current workspace uses `~/.codex-cron` as a symlink into Obsidian. That makes newly added cron jobs more fragile because the scheduler and helper are still conceptually anchored on the symlink. This PR makes the Obsidian vault directory the direct default path.

## Validation

- `bash -n docker/codex-workspace/entrypoint.sh docker/codex-workspace/cron/run-codex-cron.sh`
- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb list`