### PR TITLE
[codex] Add Cursor Agent to Codex workspace

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -10,6 +10,7 @@ ARG CEEKER_VERSION=0.3.7
 ARG BABASHKA_VERSION=1.12.218
 ARG LAZYGIT_VERSION=0.61.1
 ARG YAZI_VERSION=26.5.6
+ARG CURSOR_AGENT_VERSION=2026.06.12-19-59-36-f6aba9a
 ARG NODE_MAJOR=24
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -77,6 +78,18 @@ RUN set -eux; \
     unzip -q "$tmp/yazi.zip" -d "$tmp/yazi"; \
     install -m 0755 "$(find "$tmp/yazi" -type f -name yazi | head -n 1)" /usr/local/bin/yazi; \
     install -m 0755 "$(find "$tmp/yazi" -type f -name ya | head -n 1)" /usr/local/bin/ya; \
+    rm -rf "$tmp"
+
+RUN set -eux; \
+    tmp="$(mktemp -d)"; \
+    curl --retry 5 --retry-all-errors --connect-timeout 30 --max-time 300 -fsSL \
+      "https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/x64/agent-cli-package.tar.gz" \
+      -o "$tmp/cursor-agent.tar.gz"; \
+    rm -rf /opt/cursor-agent; \
+    mkdir -p /opt/cursor-agent; \
+    tar --strip-components=1 -xzf "$tmp/cursor-agent.tar.gz" -C /opt/cursor-agent; \
+    ln -sf /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent; \
+    ln -sf /opt/cursor-agent/cursor-agent /usr/local/bin/agent; \
     rm -rf "$tmp"
 
 RUN locale-gen en_US.UTF-8 \

--- a/docs/project_docs/add-cursor-agent-to-codex-workspace/plan.md
+++ b/docs/project_docs/add-cursor-agent-to-codex-workspace/plan.md
@@ -1,0 +1,31 @@
+# Add Cursor Agent to Codex workspace
+
+## Goal
+
+Make Cursor Agent available inside the `ghcr.io/boxp/arch/codex-workspace` image.
+
+## Design
+
+- Add `CURSOR_AGENT_VERSION` to `docker/codex-workspace/Dockerfile`.
+- Download the pinned Cursor Agent Linux x64 package from `downloads.cursor.com`.
+- Extract the full package into `/opt/cursor-agent` because the CLI depends on bundled runtime files.
+- Expose both commands expected by the installer:
+  - `/usr/local/bin/cursor-agent`
+  - `/usr/local/bin/agent`
+- Track `CURSOR_AGENT_VERSION` with Renovate by reading the current installer script from `https://cursor.com/install`.
+
+## Tasks
+
+- [x] Inspect the current Cursor Agent installer output and package layout.
+- [x] Add Cursor Agent to the Codex workspace image.
+- [x] Add Cursor Agent version tracking to Renovate.
+- [x] Add this project plan.
+- [x] Verify Dockerfile build and CLI availability.
+- [ ] Create PR.
+
+## Verification
+
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `docker build -t codex-workspace:cursor-agent docker/codex-workspace`
+- `docker run --rm --entrypoint /bin/bash codex-workspace:cursor-agent -lc 'agent --version && cursor-agent --version'`
+- `npx --yes --package renovate renovate-config-validator renovate.json5`

--- a/renovate.json5
+++ b/renovate.json5
@@ -149,6 +149,17 @@
       datasourceTemplate: "github-releases",
       extractVersionTemplate: "^v(?<version>.*)$"
     },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^docker/codex-workspace/Dockerfile$/"],
+      matchStrings: [
+        "ARG CURSOR_AGENT_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      depNameTemplate: "cursor-agent",
+      packageNameTemplate: "cursor-agent",
+      datasourceTemplate: "custom.cursor-agent",
+      versioningTemplate: "loose"
+    },
     // Codex workspace NodeSource major version
     {
       customType: "regex",
@@ -160,6 +171,12 @@
       datasourceTemplate: "node-version"
     }
   ],
+  customDatasources: {
+    "cursor-agent": {
+      defaultRegistryUrlTemplate: "https://cursor.com/install",
+      format: "plain"
+    }
+  },
   packageRules: [
     {
       additionalBranchPrefix: '{{packageFileDir}}-',
@@ -173,6 +190,10 @@
       matchPackageNames: ["cloudflare/cloudflare"],
       allowedVersions: "<5.0.0",
       description: "Allow v4.x updates only. Block v5.x until official migration tools are available (March 2026)"
+    },
+    {
+      matchDatasources: ["custom.cursor-agent"],
+      extractVersion: "downloads\\.cursor\\.com/lab/(?<version>[^/]+)/\\$\\{OS\\}/\\$\\{ARCH\\}/agent-cli-package\\.tar\\.gz"
     },
     // Kubernetes components (manual review required)
     {


### PR DESCRIPTION
## Summary

- Add Cursor Agent to the `docker/codex-workspace` image.
- Install the pinned Cursor Agent package under `/opt/cursor-agent` and expose both `agent` and `cursor-agent` commands.
- Add Renovate tracking for `CURSOR_AGENT_VERSION` by reading the current installer script from `https://cursor.com/install`.
- Add the project plan under `docs/project_docs/add-cursor-agent-to-codex-workspace/plan.md`.

## Validation

- `bash -n docker/codex-workspace/entrypoint.sh`
- `docker build -t codex-workspace:cursor-agent docker/codex-workspace`
- `docker run --rm --entrypoint /bin/bash codex-workspace:cursor-agent -lc 'set -eux; command -v agent; command -v cursor-agent; agent --version; cursor-agent --version'`
- `npx --yes --package renovate renovate-config-validator renovate.json5`
- Verified the Renovate extraction regex currently resolves `2026.06.12-19-59-36-f6aba9a` from `https://cursor.com/install`.