### PR TITLE
[codex] Propagate codex workspace env to SSH sessions

### DIFF
--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -18,6 +18,39 @@ if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
     /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys
 fi
 
+write_session_env() {
+  local env_dir=/run/codex-workspace
+  local env_file="${env_dir}/session-env"
+  local env_tmp="${env_file}.tmp"
+  local profile_file=/etc/profile.d/codex-workspace-env.sh
+  local name
+
+  install -d -o boxp -g boxp -m 0700 "${env_dir}"
+  : >"${env_tmp}"
+  chmod 0600 "${env_tmp}"
+
+  for name in \
+    DOCKER_HOST \
+    DOCKER_BUILDKIT \
+    GRAFANA_URL \
+    GRAFANA_SERVICE_ACCOUNT_TOKEN \
+    GEMINI_API_KEY; do
+    if [[ -n "${!name:-}" ]]; then
+      printf 'export %s=%q\n' "${name}" "${!name}" >>"${env_tmp}"
+    fi
+  done
+
+  chown boxp:boxp "${env_tmp}"
+  mv "${env_tmp}" "${env_file}"
+
+  cat >"${profile_file}" <<'EOF'
+if [ -r /run/codex-workspace/session-env ]; then
+  . /run/codex-workspace/session-env
+fi
+EOF
+  chmod 0644 "${profile_file}"
+}
+
 start_cloudflare_warp() {
   if [[ "${CLOUDFLARE_WARP_ENABLED:-false}" != "true" ]]; then
     return 0
@@ -105,6 +138,7 @@ EOF
 }
 
 start_cloudflare_warp
+write_session_env
 
 ssh-keygen -A
 /usr/sbin/sshd -D -e -p "${SSHD_PORT:-2222}" &
@@ -116,7 +150,9 @@ if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then
   token_args=(--token "${EVEN_TERMINAL_TOKEN}")
 fi
 
-exec /usr/sbin/runuser -u boxp -- env HOME=/home/boxp even-terminal \
+exec /usr/sbin/runuser -u boxp \
+  --whitelist-environment=DOCKER_HOST,DOCKER_BUILDKIT,GRAFANA_URL,GRAFANA_SERVICE_ACCOUNT_TOKEN,GEMINI_API_KEY \
+  -- env HOME=/home/boxp even-terminal \
   --port "${EVEN_TERMINAL_PORT:-3456}" \
   --cwd "${EVEN_TERMINAL_CWD:-/home/boxp}" \
   --provider "${EVEN_TERMINAL_PROVIDER:-codex}" \

--- a/docs/project_docs/codex-workspace-ssh-env/plan.md
+++ b/docs/project_docs/codex-workspace-ssh-env/plan.md
@@ -1,0 +1,21 @@
+# Codex workspace SSH environment propagation
+
+## Problem
+
+Kubernetes injects `GRAFANA_URL`, `GRAFANA_SERVICE_ACCOUNT_TOKEN`, `DOCKER_HOST`,
+and related variables into the codex-workspace container, but SSH login sessions
+started by `sshd` do not automatically inherit the container process
+environment. As a result, Codex sessions started over SSH cannot see the
+Grafana MCP token or Docker daemon endpoint.
+
+## Plan
+
+- Write selected runtime environment variables to a boxp-owned session env file
+  under `/run/codex-workspace`.
+- Install a profile snippet that sources that file for SSH login shells.
+- Preserve the container environment when starting `even-terminal` so non-SSH
+  sessions keep the same runtime values.
+
+## Validation
+
+- `bash -n docker/codex-workspace/entrypoint.sh`


### PR DESCRIPTION
## Summary

- Write selected codex-workspace runtime env vars to a boxp-owned `/run/codex-workspace/session-env` file.
- Source that file from `/etc/profile.d/codex-workspace-env.sh` so SSH login shells can see Docker/Grafana/Gemini env values injected by Kubernetes.
- Whitelist the same runtime env vars when launching `even-terminal` so non-SSH sessions keep them without preserving the full root environment.
- Add a short project plan under `docs/project_docs/codex-workspace-ssh-env/plan.md`.

## Root cause

Kubernetes injects these values into the container process environment, but SSH login sessions created by `sshd` do not automatically inherit that container environment. Codex sessions started over SSH therefore missed `DOCKER_HOST` and `GRAFANA_SERVICE_ACCOUNT_TOKEN`, breaking Docker-backed Grafana MCP startup and authentication.

## Validation

- `bash -n docker/codex-workspace/entrypoint.sh`