### PR TITLE
Clean up tfaction v2 aqua leftovers

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -61,31 +61,6 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/int128/ghcp/v1.15.3/ghcp_darwin_amd64.zip",
-      "checksum": "5553FBA0E479EC6AE55A479399E64FE78A1B0242E85B8BE2C65E2BA6A1D4AEF9",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/int128/ghcp/v1.15.3/ghcp_darwin_arm64.zip",
-      "checksum": "83C8FB1E167ADBFBE767288E9679D1A34B8A59241E56F84379FF9B9E1AE709F2",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/int128/ghcp/v1.15.3/ghcp_linux_amd64.zip",
-      "checksum": "537B71C1382FC95C73702D4BA0FC1A2465842A1C20F9987D75B5C7581BA115EA",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/int128/ghcp/v1.15.3/ghcp_linux_arm64.zip",
-      "checksum": "4E4A750EAE73F3C63084E9E4A97B93FFC44DD60B64FF587DF98F7BFA85199901",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/int128/ghcp/v1.15.3/ghcp_windows_amd64.zip",
-      "checksum": "42B101DFAA7E7A66585ECBF262C2C2111BBD00E7CDB063B554BC7DF467744CB1",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/koalaman/shellcheck/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz",
       "checksum": "56AFFDD8DE5527894DCA6DC3D7E0A99A873B0F004D7AABC30AE407D3F48B0A79",
       "algorithm": "sha256"
@@ -108,26 +83,6 @@
     {
       "id": "github_release/github.com/koalaman/shellcheck/v0.11.0/shellcheck-v0.11.0.zip",
       "checksum": "8A4E35AB0B331C85D73567B12F2A444DF187F483E5079CEFFA6BDA1FAA2E740E",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.4.5/tfmigrate_0.4.5_darwin_amd64.tar.gz",
-      "checksum": "351217E5FAA1789187ED9DC209D063279817E8E54C4B6A2E7DE22BFD9B2A6027",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.4.5/tfmigrate_0.4.5_darwin_arm64.tar.gz",
-      "checksum": "8EE985EE9443940D1702D9069CBD81B05D8A4C039BF5AA2EAF49DA04E790D263",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.4.5/tfmigrate_0.4.5_linux_amd64.tar.gz",
-      "checksum": "91CEEC5BCCA1C927DCCE53F1C99C1B62EE12D06CE7FCE145AA552181E6929CAB",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/minamijoyo/tfmigrate/v0.4.5/tfmigrate_0.4.5_linux_arm64.tar.gz",
-      "checksum": "030FA51A46EA1A37D5B65F89F2EE95C327E8E20B29448492B9BB2C3B5DB2BCE0",
       "algorithm": "sha256"
     },
     {
@@ -246,36 +201,6 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_darwin_amd64.tar.gz",
-      "checksum": "C692B725E6FF6400EDB0DB26C82510020144F15FD264531B538D29A777596E9F",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_darwin_arm64.tar.gz",
-      "checksum": "4D0C55F836F5D851982483CCC02B2C08C659B672344FCD945EF6ED0553B3052F",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_linux_amd64.tar.gz",
-      "checksum": "93B73DC07BCFF1F05A067582A82437CD7F44B835E8056CE7DC2C83B9855544A7",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_linux_arm64.tar.gz",
-      "checksum": "FA8CE260B8943E5E80D7F52A92A4736B609159A00F29C00EB6162EF6F1416CDB",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_windows_amd64.tar.gz",
-      "checksum": "59B80EA467F37C6C62DA0129A0CAC1C058A2BC31A1602CF5FC01C6C117B0C99A",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/ci-info/v2.4.3/ci-info_2.4.3_windows_arm64.tar.gz",
-      "checksum": "A6360716B99ADD91BF6D0ADE7AE56DEC9DC7770469EF2E4BD7C528B9F995B693",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/suzuki-shunsuke/ghalint/v1.5.6/ghalint_1.5.6_darwin_amd64.tar.gz",
       "checksum": "D2A0E8605333068065DCF4C9B7B7A24891EDA1750AC01FB755DFBA426A390883",
       "algorithm": "sha256"
@@ -336,66 +261,6 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_darwin_amd64.tar.gz",
-      "checksum": "A8117CEA55EFFFD2468FA81B856A447634F0D1A72FE81254765F08270A282A7D",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_darwin_arm64.tar.gz",
-      "checksum": "54383EAACAE249CEBB5587B3B0883DDA8DCE2130982B24BA54DD284D983297DF",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_linux_amd64.tar.gz",
-      "checksum": "AEACB544B8A338E845AED69F0B702DF42994EC932099D90B5BCD7801ADF5DF82",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_linux_arm64.tar.gz",
-      "checksum": "570EFD8E3D5B47B675864A805C03603A5233FE21CB766FE3E065852CB8CA112F",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_windows_amd64.tar.gz",
-      "checksum": "903E49D08ECC5ADB86BB143F6F76DEBBDF7A41CADA1FB9AFCAF2D2AC1C9939AE",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfaction-go/v0.2.3/tfaction_windows_arm64.tar.gz",
-      "checksum": "916C06F5444C84CCE95D7F8CA05E68F657E80224B24CF21B49996B27744448A9",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_darwin_amd64.tar.gz",
-      "checksum": "AD8AEA123E6998B2AF42BF351AAC7A74B835F6ECCAD7E1354E6E7DA94A4E1FFF",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_darwin_arm64.tar.gz",
-      "checksum": "B33CA934A7F2A35D1729963EF84A02B72EBFD4FE2B32406295265307CD7E96F0",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_linux_amd64.tar.gz",
-      "checksum": "40B37FA7CA201856759D2FE85EC571368B7DBFED6FF32A79FFF0DE3D355F84AA",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_linux_arm64.tar.gz",
-      "checksum": "AF482AA30F8E2AE5BFAD5492DDD707D329C1801EAC247A6FF6613C08F3B338C4",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_windows_amd64.tar.gz",
-      "checksum": "3DD936F59D888A4EEFCE850615AA22E2AD27F6AA58E03A19EBFC0E4D5EB4E2AB",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/suzuki-shunsuke/tfcmt/v4.14.15/tfcmt_windows_arm64.tar.gz",
-      "checksum": "8A88BAAFCBD8E3DF229E6BE3F362A5537E4C99B5D72359A9C63FCE8348C908DB",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/suzuki-shunsuke/tfprovidercheck/v1.0.7/tfprovidercheck_darwin_amd64.tar.gz",
       "checksum": "A72CD3322E3BCA105752E43C61D7B3A88C1C7A5436451D02B45AAD4AFEEE98BF",
       "algorithm": "sha256"
@@ -423,36 +288,6 @@
     {
       "id": "github_release/github.com/suzuki-shunsuke/tfprovidercheck/v1.0.7/tfprovidercheck_windows_arm64.zip",
       "checksum": "B42850199F3E5D4087A77928326F24C75D74370BBE771AE03CEAE178805E80E5",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-darwin-amd64.tar.gz",
-      "checksum": "3C3F7F18F908457FD1209CBE341418F7F6BAE78C08126CFBE8DE0D1B06AA8781",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-darwin-arm64.tar.gz",
-      "checksum": "F6B114F4B032F3F9202AB6C23BFD28C3C8E68AEEB8A8F12FC118BF2073081D71",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-linux-amd64.tar.gz",
-      "checksum": "9005DAF969DE0B50134493A2C00078B49F5F5B39D021CDA7C89BF4D4F3D776D3",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-linux-arm64.tar.gz",
-      "checksum": "D12BD7B73C1FC9C64EFC79F8157DD713DABD559F1ECF3CFC0F42E32279A155FD",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-windows-amd64.zip",
-      "checksum": "AFC02CBDF63726D3E5FB26A077CA1F24ACD4820D7E44C21B03A3E030F9266490",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/terraform-docs/terraform-docs/v0.24.0/terraform-docs-v0.24.0-windows-arm64.zip",
-      "checksum": "1168C12929531AC9132C97FFF794EF531EBB2A5B54C41870B9E19911950B6FD4",
       "algorithm": "sha256"
     },
     {

--- a/aqua/imports/ci-info.yaml
+++ b/aqua/imports/ci-info.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: suzuki-shunsuke/ci-info@v2.4.3

--- a/aqua/imports/ghcp.yaml
+++ b/aqua/imports/ghcp.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: int128/ghcp@v1.15.3

--- a/aqua/imports/terraform-docs.yaml
+++ b/aqua/imports/terraform-docs.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: terraform-docs/terraform-docs@v0.24.0

--- a/aqua/imports/tfaction-go.yaml
+++ b/aqua/imports/tfaction-go.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: suzuki-shunsuke/tfaction-go@v0.2.3

--- a/aqua/imports/tfcmt.yaml
+++ b/aqua/imports/tfcmt.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: suzuki-shunsuke/tfcmt@v4.14.15

--- a/aqua/imports/tfmigrate.yaml
+++ b/aqua/imports/tfmigrate.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: minamijoyo/tfmigrate@v0.4.5

--- a/docs/project_docs/tfaction-v2-aqua-cleanup/plan.md
+++ b/docs/project_docs/tfaction-v2-aqua-cleanup/plan.md
@@ -1,0 +1,20 @@
+# tfaction v2 aqua cleanup plan
+
+## Goal
+
+Remove top-level aqua tools that are no longer directly used after the tfaction v2 migration, while keeping tools still invoked by repository workflows.
+
+## Findings
+
+- tfaction v2 is a single action and its setup/plan/apply actions manage tfaction-specific helper tools such as `ci-info`, `tfcmt`, `tfmigrate`, `tfaction-go`, and `terraform-docs`.
+- `github-comment`, `tfprovidercheck`, `conftest`, `ghalint`, `opa`, `actionlint`, `gh`, `cloudflared`, and `ansible-plan-formatter` are still invoked directly by repository workflows or actions and should remain in top-level aqua.
+- `reviewdog` and `shellcheck` are runtime dependencies of `suzuki-shunsuke/github-action-actionlint` and should remain in top-level aqua.
+- `ghcp` has no direct workflow or script usage in this repository.
+
+## Steps
+
+- [x] Audit workflow and script references for top-level aqua packages.
+- [x] Remove unused or tfaction-managed top-level aqua imports.
+- [x] Prune matching entries from `aqua/aqua-checksums.json`.
+- [x] Keep the checksum workflow checkout ref fix for remaining standalone aqua update PRs.
+- [x] Validate JSON and check for stale references.


### PR DESCRIPTION
## Summary

- Remove top-level aqua imports that are no longer directly used after the tfaction v2 migration: ci-info, ghcp, terraform-docs, tfaction-go, tfcmt, and tfmigrate.
- Prune the corresponding entries from `aqua/aqua-checksums.json`.
- Add `docs/project_docs/tfaction-v2-aqua-cleanup/plan.md` with the cleanup rationale.

## Rationale

`tfaction@v2.0.2` ships its own install/aqua set for tfaction-managed tools such as tfmigrate, tfcmt, tfaction-go, and terraform-docs. The repository workflows still directly invoke tools such as github-comment, tfprovidercheck, conftest, ghalint, opa, actionlint, gh, cloudflared, and ansible-plan-formatter, so those remain in top-level aqua. `reviewdog` and `shellcheck` also remain because `suzuki-shunsuke/github-action-actionlint` invokes them at runtime.

## Validation

- `jq empty aqua/aqua-checksums.json`
- checked that removed imports and checksum IDs have no stale references
- `git diff --check`

Note: local `aqua`, `actionlint`, and `go` are not installed in this worktree environment, so actionlint was not rerun locally.