### PR TITLE
[codex] Reduce Renovate scan scope for Mend OOM

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,11 @@
   prHourlyLimit: 10,
   prConcurrentLimit: 10,
   branchConcurrentLimit: 20,
+  ignorePaths: [
+    // Mend-hosted Renovate currently runs with a 3GB memory limit.
+    // Terraform aqua imports are high-cardinality and make scheduled jobs OOM.
+    'terraform/**/aqua/imports/**',
+  ],
   customManagers: [
     // Kubernetes version (playbooks)
     {


### PR DESCRIPTION
## Summary

- Exclude `terraform/**/aqua/imports/**` from Mend-hosted Renovate scans.
- Keep the change scoped to Renovate config only.

## Why

Mend-hosted Renovate is still failing with `kernel-out-of-memory` under its 3GB memory limit. The repository has a high-cardinality Terraform aqua imports tree, and previous Renovate logs showed heavy custom regex/file scanning before the job was killed.

This is a mitigation to reduce scheduled job memory pressure so Renovate can complete again. Terraform aqua import updates can be revisited separately once Renovate is split or run in an environment with more memory.

## Validation

- `npx --yes --package renovate renovate-config-validator renovate.json5`