### PR TITLE
[codex] Add codex cron runner selection

### DIFF
--- a/docker/codex-workspace/cron/run-codex-cron.sh
+++ b/docker/codex-workspace/cron/run-codex-cron.sh
@@ -8,9 +8,10 @@ if [[ -z "${job_id}" ]]; then
 fi
 
 cron_root="${CODEX_CRON_ROOT:-/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron}"
+selector="${CODEX_CRON_SELECTOR:-/opt/codex-workspace/cron/select-codex-cron-job.bb}"
 
 eval "$(
-  bb /opt/codex-workspace/cron/select-codex-cron-job.bb "${job_id}"
+  bb "${selector}" "${job_id}"
 )"
 
 job_name="${CODEX_CRON_NAME:-${job_id}}"
@@ -18,6 +19,7 @@ prompt_file="${CODEX_CRON_PROMPT_FILE:?CODEX_CRON_PROMPT_FILE is required}"
 workdir="${CODEX_CRON_WORKDIR:-/home/boxp}"
 output_root="${CODEX_CRON_OUTPUT_ROOT:-${cron_root}/runs}"
 lock_root="${CODEX_CRON_LOCK_ROOT:-${cron_root}/locks}"
+runner="${CODEX_CRON_RUNNER:-codex}"
 run_id="${CODEX_CRON_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 run_dir="${output_root}/${job_id}/${run_id}"
 lock_dir="${lock_root}/${job_id}.lock"
@@ -43,47 +45,93 @@ cleanup() {
 }
 trap cleanup EXIT
 
+runner="$(printf '%s' "${runner}" | tr '[:upper:]' '[:lower:]')"
+case "${runner}" in
+  codex | cursor) ;;
+  *)
+    echo "unsupported codex cron runner '${runner}' for job '${job_name}'" >&2
+    exit 2
+    ;;
+esac
+
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-stdout_log="${run_dir}/events.jsonl"
+if [[ "${runner}" == "cursor" ]]; then
+  stdout_log="${run_dir}/stdout.log"
+else
+  stdout_log="${run_dir}/events.jsonl"
+fi
 stderr_log="${run_dir}/stderr.log"
 last_message="${run_dir}/last-message.md"
 summary_file="${run_dir}/summary.edn"
 
-codex_args=(exec --json --cd "${workdir}" --output-last-message "${last_message}")
+args=()
 
-if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
-  codex_args+=(--dangerously-bypass-approvals-and-sandbox)
+if [[ "${runner}" == "codex" ]]; then
+  args=(exec --json --cd "${workdir}" --output-last-message "${last_message}")
+
+  if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
+    args+=(--dangerously-bypass-approvals-and-sandbox)
+  else
+    args+=(--sandbox "${CODEX_CRON_SANDBOX:-workspace-write}")
+  fi
+
+  if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
+    args+=(--model "${CODEX_CRON_MODEL}")
+  fi
+
+  if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
+    args+=(--profile "${CODEX_CRON_PROFILE}")
+  fi
 else
-  codex_args+=(--sandbox "${CODEX_CRON_SANDBOX:-workspace-write}")
-fi
+  args=(--print --output-format text --trust --workspace "${workdir}")
 
-if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
-  codex_args+=(--model "${CODEX_CRON_MODEL}")
-fi
+  if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
+    args+=(--force --sandbox disabled)
+  else
+    args+=(--sandbox "${CODEX_CRON_CURSOR_SANDBOX:-enabled}")
+  fi
 
-if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
-  codex_args+=(--profile "${CODEX_CRON_PROFILE}")
+  if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
+    args+=(--model "${CODEX_CRON_MODEL}")
+  fi
+
+  if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
+    echo "CODEX_CRON_PROFILE is only supported by the codex runner" >&2
+    exit 2
+  fi
 fi
 
 if [[ -n "${CODEX_CRON_EXTRA_ARGS:-}" ]]; then
   read -r -a extra_args <<< "${CODEX_CRON_EXTRA_ARGS}"
-  codex_args+=("${extra_args[@]}")
+  args+=("${extra_args[@]}")
 fi
 
 {
   echo "job=${job_name}"
   echo "job_id=${job_id}"
+  echo "runner=${runner}"
+  echo "model=${CODEX_CRON_MODEL:-}"
   echo "run_id=${run_id}"
   echo "started_at=${started_at}"
   echo "workdir=${workdir}"
   echo "prompt_file=${prompt_file}"
-  echo "codex_args=${codex_args[*]}"
+  echo "stdout_log=${stdout_log}"
+  echo "stderr_log=${stderr_log}"
+  echo "${runner}_args=${args[*]}"
 } > "${run_dir}/metadata.env"
 
 set +e
-codex "${codex_args[@]}" - < "${prompt_file}" > "${stdout_log}" 2> "${stderr_log}"
+if [[ "${runner}" == "codex" ]]; then
+  codex "${args[@]}" - < "${prompt_file}" > "${stdout_log}" 2> "${stderr_log}"
+else
+  cursor-agent "${args[@]}" "$(< "${prompt_file}")" > "${stdout_log}" 2> "${stderr_log}"
+fi
 exit_code=$?
 set -e
+
+if [[ "${runner}" == "cursor" && -f "${stdout_log}" ]]; then
+  cp "${stdout_log}" "${last_message}"
+fi
 
 finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 status="ok"
@@ -94,6 +142,8 @@ fi
 cat > "${summary_file}" <<EOF
 {:job "${job_id}"
  :name "${job_name}"
+ :runner "${runner}"
+ :model "${CODEX_CRON_MODEL:-}"
  :run-id "${run_id}"
  :status :${status}
  :exit-code ${exit_code}
@@ -103,5 +153,5 @@ cat > "${summary_file}" <<EOF
  :prompt-file "${prompt_file}"}
 EOF
 
-echo "Codex cron ${job_id}/${run_id}: ${status} (exit ${exit_code})"
+echo "Codex cron ${job_id}/${run_id} [${runner}]: ${status} (exit ${exit_code})"
 exit "${exit_code}"

--- a/docker/codex-workspace/cron/select-codex-cron-job.bb
+++ b/docker/codex-workspace/cron/select-codex-cron-job.bb
@@ -18,6 +18,7 @@
     (lib/emit "CODEX_CRON_PROMPT_FILE" (str prompt-file))
     (lib/emit "CODEX_CRON_WORKDIR" (:workdir job))
     (lib/emit "CODEX_CRON_OUTPUT_ROOT" (:output-root job))
+    (lib/emit "CODEX_CRON_RUNNER" (:runner job))
     (lib/emit "CODEX_CRON_MODEL" (:model job))
     (lib/emit "CODEX_CRON_PROFILE" (:profile job))
     (lib/emit "CODEX_CRON_BYPASS_APPROVALS" (str (get job :bypass-approvals true)))

--- a/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
+++ b/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
@@ -49,6 +49,14 @@ bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb add \
   --prompt "調査して日本語で報告してください。"
 ```
 
+Use Cursor Agent or a specific model:
+
+```bash
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-report \
+  --runner cursor \
+  --model claude-opus-4-8-high
+```
+
 Update metadata or prompt:
 
 ```bash

--- a/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
+++ b/docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb
@@ -13,7 +13,7 @@
 
 (def key-order
   [:id :name :enabled :schedule :time-zone :prompt-file :workdir :output-root
-   :model :profile :bypass-approvals :extra-args])
+   :runner :model :profile :bypass-approvals :extra-args])
 
 (defn usage []
   (println "usage: codex_cron_jobs.bb [--root PATH] <list|show|add|update|enable|disable|delete|run> ...")
@@ -109,6 +109,7 @@
          :workdir (get opts "workdir" "/home/boxp")
          :output-root (get opts "output-root" (str (root) "/runs"))
          :bypass-approvals (bool-opt opts "bypass-approvals" true)}
+        (assoc-some :runner (get opts "runner"))
         (assoc-some :model (get opts "model"))
         (assoc-some :profile (get opts "profile"))
         (assoc-some :extra-args (get opts "extra-args")))))
@@ -131,6 +132,7 @@
     (contains? opts "prompt-file") (assoc :prompt-file (get opts "prompt-file"))
     (contains? opts "workdir") (assoc :workdir (get opts "workdir"))
     (contains? opts "output-root") (assoc :output-root (get opts "output-root"))
+    (contains? opts "runner") (assoc-some :runner (get opts "runner"))
     (contains? opts "model") (assoc-some :model (get opts "model"))
     (contains? opts "profile") (assoc-some :profile (get opts "profile"))
     (contains? opts "extra-args") (assoc-some :extra-args (get opts "extra-args"))

--- a/docs/project_docs/codex-cron-runner-switch/plan.md
+++ b/docs/project_docs/codex-cron-runner-switch/plan.md
@@ -1,0 +1,21 @@
+# Codex Cron Runner Switch Plan
+
+## Goal
+
+Allow each Codex workspace cron job to choose the CLI runner and model independently, so jobs can run with either `codex` or `cursor-agent`.
+
+## Implementation
+
+- Add optional `:runner` job metadata, defaulting to `codex` for existing jobs.
+- Emit `CODEX_CRON_RUNNER` from job selection.
+- Teach `run-codex-cron.sh` to dispatch:
+  - `codex`: current `codex exec --json` behavior, preserving `events.jsonl` and `last-message.md`.
+  - `cursor`: `cursor-agent --print --output-format text --trust --workspace ...`, writing `stdout.log` and copying it to `last-message.md`.
+- Keep `:model` runner-neutral and pass it as `--model` to either CLI.
+- Update the bundled `codex-workspace-cron` helper and skill docs with `--runner`.
+
+## Validation
+
+- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
+- `bb docker/codex-workspace/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb --root <tmp> add ... --runner cursor --model claude-opus-4-8-high`
+- `bb docker/codex-workspace/cron/select-codex-cron-job.bb <job-id>` with `CODEX_CRON_ROOT=<tmp>`


### PR DESCRIPTION
## Summary

- Add optional `:runner` metadata for Codex workspace cron jobs, defaulting to the existing `codex` runner.
- Dispatch cron runs to either `codex exec` or `cursor-agent --print`, while keeping `:model` as a runner-neutral `--model` setting.
- Expose `--runner` through the bundled `codex-workspace-cron` helper and document the Cursor Agent Opus configuration.
- Add the project plan under `docs/project_docs/codex-cron-runner-switch/plan.md`.

## Impact

Existing jobs without `:runner` continue to use Codex. Jobs can now opt into Cursor Agent with a model such as `claude-opus-4-8-high`, which lets the daily Hitohako cron run through Cursor Opus after the workspace image is deployed.

## Validation

- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
- Temp registry add/enable/select with `--runner cursor --model claude-opus-4-8-high`
- Stubbed local run covered both `codex` and `cursor` runner branches before commit