### PR TITLE
[codex] Prepare Kubernetes 1.35 upgrade automation

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -57,6 +57,18 @@ jobs:
             | awk -F'"' '{print $2}')
           CRIO_VER=$(grep -m1 'crio_version:' ansible/playbooks/control-plane.yml \
             | awk -F'"' '{print $2}')
+          if [ -z "$K8S_VER" ] || [ -z "$K8S_PKG" ] || [ -z "$CRIO_VER" ]; then
+            echo "::error::Failed to extract Kubernetes/CRI-O versions from ansible/playbooks/control-plane.yml"
+            exit 1
+          fi
+          if [ "${K8S_PKG%%-*}" != "$K8S_VER" ]; then
+            echo "::error::kubernetes_package_version ($K8S_PKG) must match kubernetes_version ($K8S_VER)"
+            exit 1
+          fi
+          if [ "${K8S_VER%.*}" != "${CRIO_VER%.*}" ]; then
+            echo "::error::crio_version ($CRIO_VER) must use the same major.minor as kubernetes_version ($K8S_VER)"
+            exit 1
+          fi
           {
             echo "k8s_version=$K8S_VER"
             echo "k8s_package=$K8S_PKG"
@@ -191,8 +203,6 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          ETCD_SNAPSHOT_ARTIFACT_DIR="/tmp/etcd-snapshots"
-          mkdir -p "${ETCD_SNAPSHOT_ARTIFACT_DIR}"
           cd ansible
           source .venv/bin/activate
           echo "Running pre-upgrade checks with K8S_VERSION=${K8S_VERSION}"
@@ -204,20 +214,42 @@ jobs:
             -e "kubernetes_upgrade_version=${K8S_VERSION}" \
             -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
             -e "crio_upgrade_version=${CRIO_VERSION}" \
+            -vv 2>&1 | tee /tmp/pre-check-ansible.log
+
+      - name: Take etcd snapshot
+        if: inputs.dry_run == false
+        shell: bash
+        run: |
+          set -eo pipefail
+          ETCD_SNAPSHOT_ARTIFACT_DIR="/tmp/etcd-snapshots"
+          mkdir -p "${ETCD_SNAPSHOT_ARTIFACT_DIR}"
+          cd ansible
+          source .venv/bin/activate
+          echo "Taking etcd snapshot before production upgrade"
+          ansible-playbook \
+            -i inventories/production/hosts.yml \
+            playbooks/upgrade-k8s.yml \
+            --tags etcd_snapshot \
+            -e "ansible_ssh_common_args=''" \
+            -e "kubernetes_upgrade_version=${K8S_VERSION}" \
+            -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
+            -e "crio_upgrade_version=${CRIO_VERSION}" \
             -e "etcd_snapshot_local_dir=${ETCD_SNAPSHOT_ARTIFACT_DIR}" \
             -e "etcd_snapshot_force=true" \
-            -vv 2>&1 | tee /tmp/pre-check-ansible.log
+            -vv 2>&1 | tee /tmp/etcd-snapshot-ansible.log
 
       - name: Upload pre-check logs
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pre-check-ansible-log
-          path: /tmp/pre-check-ansible.log
+          path: |
+            /tmp/pre-check-ansible.log
+            /tmp/etcd-snapshot-ansible.log
           retention-days: 14
 
       - name: Upload etcd snapshot to S3
-        if: always()
+        if: inputs.dry_run == false
         shell: bash
         run: |
           set -euo pipefail

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,9 +93,9 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "1.36.1"
-        kubernetes_package_version: "1.34.0-1.1"
-        crio_version: "1.36.0"
+        kubernetes_version: "1.35.6"
+        kubernetes_package_version: "1.35.6-1.1"
+        crio_version: "1.35.4"
         kubelet_cluster_dns: "{{ cluster_dns }}"
         kubelet_cluster_domain: "{{ cluster_domain }}"
         kubelet_node_ip: "{{ node_ip }}"

--- a/ansible/playbooks/node-shanghai-1.yml
+++ b/ansible/playbooks/node-shanghai-1.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.36.1"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.36.0"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-2.yml
+++ b/ansible/playbooks/node-shanghai-2.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.36.1"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.36.0"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-3.yml
+++ b/ansible/playbooks/node-shanghai-3.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.36.1"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.36.0"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/upgrade-k8s.yml
+++ b/ansible/playbooks/upgrade-k8s.yml
@@ -6,10 +6,9 @@
 #          -e crio_upgrade_version=1.35.0
 
 # Pre-upgrade cluster-wide checks + etcd snapshot
-- name: Pre-upgrade validation and etcd snapshot
+- name: Pre-upgrade validation and optional etcd snapshot
   hosts: control_plane[0]
   gather_facts: true
-  tags: [pre_checks]
   tasks:
     - name: Verify cluster health
       ansible.builtin.include_role:
@@ -20,7 +19,7 @@
       ansible.builtin.include_role:
         name: kubernetes_upgrade
         tasks_from: etcd_snapshot.yml
-      tags: [pre_checks, etcd_snapshot]
+      tags: [etcd_snapshot]
 
 # Upgrade first control plane
 - name: Upgrade first control plane (shanghai-1)

--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -32,6 +32,8 @@ snapshot_timestamp: ""
 
 # kubectl configuration
 kubeconfig_path: /etc/kubernetes/admin.conf
+kubectl_api_server: "https://{{ node_ip | default(cluster_vip) }}:6443"
+kubectl_api_server_arg: "{{ '--server=' ~ kubectl_api_server if (kubectl_api_server | length) > 0 else '' }}"
 
 # Role detection
 node_role: "control_plane"           # "control_plane" or "worker"

--- a/ansible/roles/kubernetes_upgrade/molecule/default/molecule.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/molecule.yml
@@ -7,6 +7,7 @@ platforms:
   - name: control-plane-test
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"
     platform: "${MOLECULE_DOCKER_PLATFORM:-linux/amd64}"
+    pull: true
     pre_build_image: true
     privileged: true
     volumes:
@@ -32,9 +33,11 @@ provisioner:
         crio_upgrade_version: "1.35.0"
         node_role: "control_plane"
         is_first_control_plane: true
+        cluster_vip: "127.0.0.1"
     host_vars:
       control-plane-test:
         ansible_python_interpreter: /usr/bin/python3
+        ansible_remote_tmp: /tmp/.ansible/tmp
         hardware_type: orange_pi_zero3
         architecture: arm64
 verifier:

--- a/ansible/roles/kubernetes_upgrade/molecule/default/verify.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/verify.yml
@@ -49,28 +49,17 @@
           - "'v1.35' in (crio_apt_content.content | b64decode)"
         fail_msg: "CRI-O apt source does not contain the correct version (v1.35)"
 
-    # Verify CRI-O version-specific apt source was updated
+    # Verify duplicate CRI-O version-specific apt source was removed
     - name: Check CRI-O version-specific apt source file exists
       ansible.builtin.stat:
         path: /etc/apt/sources.list.d/crio-version.list
       register: crio_version_apt_source
 
-    - name: Assert CRI-O version-specific apt source exists
+    - name: Assert duplicate CRI-O version-specific apt source is removed
       ansible.builtin.assert:
         that:
-          - crio_version_apt_source.stat.exists
-        fail_msg: "CRI-O version-specific apt source file does not exist"
-
-    - name: Read CRI-O version-specific apt source content
-      ansible.builtin.slurp:
-        src: /etc/apt/sources.list.d/crio-version.list
-      register: crio_version_apt_content
-
-    - name: Assert CRI-O version-specific apt source contains correct version
-      ansible.builtin.assert:
-        that:
-          - "'v1.35' in (crio_version_apt_content.content | b64decode)"
-        fail_msg: "CRI-O version-specific apt source does not contain the correct version (v1.35)"
+          - not crio_version_apt_source.stat.exists
+        fail_msg: "Duplicate CRI-O version-specific apt source file still exists"
 
     # Verify etcd snapshot directory was created
     - name: Check etcd snapshot directory exists

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -5,7 +5,7 @@
     state: directory
     mode: '0700'
   become: true
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Check if etcd snapshot already exists for today
   ansible.builtin.find:
@@ -13,14 +13,14 @@
     patterns: "pre-upgrade-{{ ansible_facts['date_time']['date'] | replace('-', '') }}*.db"
   become: true
   register: existing_snapshots
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Set etcd snapshot paths
   ansible.builtin.set_fact:
     _etcd_snapshot_filename: "pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_pod_path: "{{ etcd_snapshot_pod_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_remote_path: "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Reuse existing etcd snapshot for today
   ansible.builtin.set_fact:
@@ -29,13 +29,14 @@
   when:
     - not (etcd_snapshot_force | bool)
     - existing_snapshots.matched > 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Take etcd snapshot inside etcd pod
   ansible.builtin.command:
     argv:
       - kubectl
       - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
       - -n
       - kube-system
       - exec
@@ -51,13 +52,14 @@
   become: true
   changed_when: true
   when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Verify etcd snapshot integrity inside etcd pod
   ansible.builtin.command:
     argv:
       - kubectl
       - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
       - -n
       - kube-system
       - exec
@@ -71,7 +73,7 @@
   become: true
   changed_when: false
   when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Move etcd snapshot from host-mounted etcd data directory
   ansible.builtin.command:
@@ -82,7 +84,7 @@
   become: true
   changed_when: true
   when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Create local etcd snapshot artifact directory
   ansible.builtin.file:
@@ -92,7 +94,7 @@
   delegate_to: localhost
   become: false
   when: etcd_snapshot_local_dir | length > 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Fetch etcd snapshot to local artifact directory
   ansible.builtin.fetch:
@@ -101,7 +103,7 @@
     flat: true
   become: true
   when: etcd_snapshot_local_dir | length > 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]
 
 - name: Remove temporary etcd snapshot from host-mounted etcd data directory
   ansible.builtin.command:
@@ -114,4 +116,4 @@
   when:
     - etcd_snapshot_cleanup_pod_file | bool
     - (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
-  tags: [etcd_snapshot, pre_checks]
+  tags: [etcd_snapshot]

--- a/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
@@ -1,9 +1,10 @@
 ---
 - name: Wait for node to be Ready
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: node_ready
+  check_mode: false
   until: node_ready.stdout == "True"
   retries: "{{ upgrade_health_check_retries }}"
   delay: "{{ upgrade_health_check_delay }}"
@@ -14,20 +15,24 @@
 
 - name: Verify kubelet version on node
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{.status.nodeInfo.kubeletVersion}'
   register: node_kubelet_version
+  check_mode: false
   delegate_to: "{{ groups['control_plane'][0] }}"
   changed_when: false
-  failed_when: "kubernetes_upgrade_version not in node_kubelet_version.stdout"
+  failed_when:
+    - not ansible_check_mode
+    - kubernetes_upgrade_version not in node_kubelet_version.stdout
   become: true
   tags: [health_check]
 
 - name: Verify node conditions (no pressure)
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
   register: node_conditions
+  check_mode: false
   delegate_to: "{{ groups['control_plane'][0] }}"
   changed_when: false
   failed_when: >
@@ -42,6 +47,7 @@
     argv:
       - kubectl
       - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
       - -n
       - kube-system
       - exec
@@ -54,6 +60,7 @@
       - "--cacert={{ etcd_cacert }}"
       - "--cert={{ etcd_cert }}"
       - "--key={{ etcd_key }}"
+  check_mode: false
   changed_when: false
   become: true
   when: node_role == "control_plane"

--- a/ansible/roles/kubernetes_upgrade/tasks/main.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/main.yml
@@ -6,14 +6,6 @@
       tags: [pre_checks]
   tags: [pre_checks, upgrade]
 
-- name: Take etcd snapshot before upgrade
-  ansible.builtin.include_tasks:
-    file: etcd_snapshot.yml
-    apply:
-      tags: [etcd_snapshot, pre_checks]
-  tags: [etcd_snapshot, pre_checks, upgrade]
-  when: node_role == "control_plane" and (is_first_control_plane | bool)
-
 - name: Upgrade first control plane
   ansible.builtin.include_tasks:
     file: upgrade_control_plane_first.yml

--- a/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
@@ -2,6 +2,7 @@
 - name: Verify current kubernetes version
   ansible.builtin.command: kubelet --version
   register: current_kubelet_version
+  check_mode: false
   changed_when: false
   tags: [pre_checks]
 
@@ -10,6 +11,7 @@
     argv:
       - kubectl
       - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
       - -n
       - kube-system
       - exec
@@ -23,14 +25,16 @@
       - "--cert={{ etcd_cert }}"
       - "--key={{ etcd_key }}"
   register: etcd_health
+  check_mode: false
   changed_when: false
   when: node_role == "control_plane"
   become: true
   tags: [pre_checks]
 
 - name: Verify all nodes are Ready
-  ansible.builtin.command: kubectl --kubeconfig={{ kubeconfig_path }} get nodes --no-headers
+  ansible.builtin.command: kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get nodes --no-headers
   register: node_status
+  check_mode: false
   changed_when: false
   failed_when: "'NotReady' in node_status.stdout"
   delegate_to: "{{ groups['control_plane'][0] }}"

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_apt_source.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_apt_source.yml
@@ -1,46 +1,27 @@
 ---
-- name: Update kubernetes apt repository version
-  ansible.builtin.replace:
-    path: /etc/apt/sources.list.d/kubernetes.list
-    regexp: 'stable:/v[0-9]+\.[0-9]+/'
-    replace: "stable:/v{{ kubernetes_upgrade_version.split('.')[:2] | join('.') }}/"
+- name: Configure Kubernetes apt repository for target version
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/kubernetes.list
+    content: "deb https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_upgrade_version.split('.')[:2] | join('.') }}/deb/ /\n"
+    mode: '0644'
   become: true
   tags: [upgrade]
 
-- name: Check CRI-O apt source file exists
-  ansible.builtin.stat:
-    path: /etc/apt/sources.list.d/crio.list
-  register: crio_list_stat
+- name: Configure CRI-O apt repository for target version
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/crio.list
+    content: "deb https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_upgrade_version.split('.')[:2] | join('.') }}/deb/ /\n"
+    mode: '0644'
+  become: true
   when: crio_upgrade_version is defined and crio_upgrade_version != ""
   tags: [upgrade]
 
-- name: Update CRI-O apt repository version (crio.list)
-  ansible.builtin.replace:
-    path: /etc/apt/sources.list.d/crio.list
-    regexp: 'stable:/v[0-9]+\.[0-9]+/'
-    replace: "stable:/v{{ crio_upgrade_version.split('.')[:2] | join('.') }}/"
-  become: true
-  when: >
-    crio_upgrade_version is defined and crio_upgrade_version != ""
-    and crio_list_stat.stat.exists | default(false)
-  tags: [upgrade]
-
-- name: Check CRI-O version-specific apt source file exists
-  ansible.builtin.stat:
+- name: Remove duplicate CRI-O version-specific apt repository
+  ansible.builtin.file:
     path: /etc/apt/sources.list.d/crio-version.list
-  register: crio_version_list_stat
+    state: absent
+  become: true
   when: crio_upgrade_version is defined and crio_upgrade_version != ""
-  tags: [upgrade]
-
-- name: Update CRI-O version-specific apt repository (crio-version.list)
-  ansible.builtin.replace:
-    path: /etc/apt/sources.list.d/crio-version.list
-    regexp: 'stable:/v[0-9]+\.[0-9]+/'
-    replace: "stable:/v{{ crio_upgrade_version.split('.')[:2] | join('.') }}/"
-  become: true
-  when: >
-    crio_upgrade_version is defined and crio_upgrade_version != ""
-    and crio_version_list_stat.stat.exists | default(false)
   tags: [upgrade]
 
 - name: Import Kubernetes apt repository GPG key for target version
@@ -70,6 +51,8 @@
     state: present
     update_cache: false
   become: true
-  when: crio_upgrade_version is defined and crio_upgrade_version != ""
+  when:
+    - crio_upgrade_version is defined and crio_upgrade_version != ""
+    - not ansible_check_mode
   notify: Restart crio
   tags: [upgrade]

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
@@ -1,7 +1,7 @@
 ---
 - name: Drain control plane node
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} drain {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} drain {{ inventory_hostname }}
     --ignore-daemonsets --delete-emptydir-data
     --timeout={{ upgrade_drain_timeout }}s
   become: true
@@ -17,6 +17,7 @@
     name: kubeadm
     selection: install
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Install target kubeadm version
@@ -25,6 +26,7 @@
     state: present
     allow_downgrade: false
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Hold kubeadm
@@ -32,6 +34,7 @@
     name: kubeadm
     selection: hold
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Run kubeadm upgrade apply
@@ -39,6 +42,7 @@
   become: true
   register: upgrade_result
   changed_when: upgrade_result.rc == 0
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Upgrade kubelet and kubectl
@@ -51,12 +55,14 @@
     state: restarted
     daemon_reload: true
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Uncordon control plane node
-  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} uncordon {{ inventory_hostname }}"
+  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} uncordon {{ inventory_hostname }}"
   become: true
   changed_when: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Wait for node to become Ready

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
@@ -1,7 +1,7 @@
 ---
 - name: Drain control plane node
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} drain {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} drain {{ inventory_hostname }}
     --ignore-daemonsets --delete-emptydir-data
     --timeout={{ upgrade_drain_timeout }}s
   delegate_to: "{{ groups['control_plane'][0] }}"
@@ -18,6 +18,7 @@
     name: kubeadm
     selection: install
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Install target kubeadm version
@@ -26,6 +27,7 @@
     state: present
     allow_downgrade: false
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Hold kubeadm
@@ -33,12 +35,14 @@
     name: kubeadm
     selection: hold
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Run kubeadm upgrade node
   ansible.builtin.command: kubeadm upgrade node
   become: true
   changed_when: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Upgrade kubelet and kubectl
@@ -51,13 +55,15 @@
     state: restarted
     daemon_reload: true
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Uncordon control plane node
-  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} uncordon {{ inventory_hostname }}"
+  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} uncordon {{ inventory_hostname }}"
   delegate_to: "{{ groups['control_plane'][0] }}"
   become: true
   changed_when: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Verify node health

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_kubelet_kubectl.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_kubelet_kubectl.yml
@@ -4,6 +4,7 @@
     name: kubelet
     selection: install
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Unhold kubectl
@@ -11,6 +12,7 @@
     name: kubectl
     selection: install
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Install target kubelet version
@@ -19,6 +21,7 @@
     state: present
     allow_downgrade: false
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Install target kubectl version
@@ -27,6 +30,7 @@
     state: present
     allow_downgrade: false
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Hold kubelet
@@ -34,6 +38,7 @@
     name: kubelet
     selection: hold
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Hold kubectl
@@ -41,4 +46,5 @@
     name: kubectl
     selection: hold
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]

--- a/docs/project_docs/lolice-k8s-135-upgrade-phase2/plan.md
+++ b/docs/project_docs/lolice-k8s-135-upgrade-phase2/plan.md
@@ -1,0 +1,71 @@
+# lolice Kubernetes 1.35 upgrade Phase 2 plan
+
+作成日: 2026-06-21
+
+## 目的
+
+lolice cluster の Kubernetes 1.35 系アップグレードに進む前に、`boxp/arch` の upgrade automation を安全に使える状態へ戻す。
+
+## 背景
+
+2026-06-21 時点で、cluster は手動収束により Kubernetes v1.34.0 へ揃った。一方、`ansible/playbooks/control-plane.yml` と `node-shanghai-*.yml` では `kubernetes_version: "1.36.1"` / `crio_version: "1.36.0"` と `kubernetes_package_version: "1.34.0-1.1"` が混在していた。
+
+また、`.github/workflows/upgrade-k8s.yml` の pre-check は `--tags pre_checks` で etcd snapshot まで実行しており、dry-run でも cluster に副作用が出る構造だった。
+
+## 方針
+
+1. Orange Pi control-plane 用 Ansible playbook の Kubernetes/CRI-O version を 1.35 系へ揃える。
+   - Kubernetes: `1.35.6`
+   - Kubernetes package: `1.35.6-1.1`
+   - CRI-O: `1.35.4`
+2. workflow の version extraction で以下を検査する。
+   - `kubernetes_version` / `kubernetes_package_version` / `crio_version` が抽出できる。
+   - `kubernetes_package_version` の upstream version が `kubernetes_version` と一致する。
+   - `crio_version` の major.minor が `kubernetes_version` と一致する。
+3. dry-run の pre-check では health check のみを実行し、etcd snapshot は取得しない。
+4. `dry_run=false` の本番実行前だけ、明示的な `etcd_snapshot` step で snapshot を取得し、S3 upload する。
+5. check-mode でも health check が実際に状態確認できるよう、状態確認 command に `check_mode: false` を明示する。
+6. kube-vip/VIP の一時的な揺れに影響されないよう、upgrade automation の `kubectl` は control-plane node の direct API server endpoint を使う。
+7. upgrade 時の apt source は既存ファイルの文字列置換ではなく、target version の単一行へ正規化する。
+
+## 変更対象
+
+- `.github/workflows/upgrade-k8s.yml`
+- `ansible/playbooks/control-plane.yml`
+- `ansible/playbooks/node-shanghai-1.yml`
+- `ansible/playbooks/node-shanghai-2.yml`
+- `ansible/playbooks/node-shanghai-3.yml`
+- `ansible/playbooks/upgrade-k8s.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/main.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/health_check.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/upgrade_apt_source.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml`
+- `ansible/roles/kubernetes_upgrade/tasks/upgrade_kubelet_kubectl.yml`
+
+## 検証
+
+- `actionlint .github/workflows/upgrade-k8s.yml`
+- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
+- `cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/tasks/pre_checks.yml roles/kubernetes_upgrade/tasks/health_check.yml roles/kubernetes_upgrade/tasks/etcd_snapshot.yml`
+- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags pre_checks -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4`
+- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags upgrade --check -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4`
+
+## 検証結果
+
+- `actionlint` 成功。
+- `ansible-playbook --syntax-check` 成功。
+- `ansible-lint` 成功。
+- 実 cluster に対する `--tags pre_checks` 成功。snapshot task は実行されないことを確認。
+- 実 cluster に対する `--tags upgrade --check` 成功。snapshot task は task list から除外され、package install / kubeadm / restart / uncordon は check-mode で skip される。
+- `kubectl get --raw /version` は `v1.34.0` を返す。
+- 全 control-plane の apiserver static pod は `v1.34.0`、etcd は `3.6.4-0`。
+
+## 完了条件
+
+- 1.36 系と 1.34 package の混在が解消されている。
+- dry-run pre-check が etcd snapshot を取得しない構造になっている。
+- 本番実行時の etcd snapshot 取得タイミングが workflow に明示されている。
+- workflow/playbook の静的検証が通る。


### PR DESCRIPTION
## Summary

- Align Orange Pi control-plane Ansible definitions to the Kubernetes 1.35 upgrade target.
- Split dry-run pre-checks from etcd snapshot creation so `dry_run=true` does not create backup artifacts.
- Run production etcd snapshots only from the explicit workflow step before upgrades.
- Make upgrade health checks use direct control-plane API endpoints instead of the kube-vip VIP.
- Normalize Kubernetes/CRI-O apt source files during upgrades and skip mutating package/kubeadm tasks in check mode.
- Add the Phase 2 plan at `docs/project_docs/lolice-k8s-135-upgrade-phase2/plan.md`.

## Validation

- `actionlint .github/workflows/upgrade-k8s.yml`
- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/tasks/pre_checks.yml roles/kubernetes_upgrade/tasks/health_check.yml roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml roles/kubernetes_upgrade/tasks/upgrade_kubelet_kubectl.yml roles/kubernetes_upgrade/tasks/upgrade_apt_source.yml`
- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags pre_checks -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4`
- `cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags upgrade --check -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4`

## Notes

Companion storage manifest PR: https://github.com/boxp/lolice/pull/587

The cluster has been manually converged to Kubernetes v1.34.0 before this PR. Remaining pre-Phase-3 operational issues are tracked in Obsidian: `golyat-3` kube-proxy CrashLoopBackOff and monitoring PVC mount issues.
