### PR TITLE
[codex] Prepare Kubernetes 1.35 phase 3 upgrade

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       kubernetes_version:
-        description: 'Target Kubernetes version (e.g., 1.35.1). Leave empty to auto-extract from playbook'
-        required: false
+        description: 'Target Kubernetes version (e.g., 1.35.6)'
+        required: true
       kubernetes_package:
-        description: 'Target package version (e.g., 1.35.1-1.1). Leave empty to auto-extract from playbook'
-        required: false
+        description: 'Target package version (e.g., 1.35.6-1.1)'
+        required: true
       crio_version:
-        description: 'Target CRI-O version (e.g., 1.35.0). Leave empty to auto-extract from playbook'
-        required: false
+        description: 'Target CRI-O version (e.g., 1.35.4)'
+        required: true
       dry_run:
         description: 'Dry run mode (--check)'
         type: boolean
@@ -32,62 +32,17 @@ env:
   ETCD_SNAPSHOT_S3_URI: s3://arch-etcd-snapshots/kubernetes-upgrade
 
 jobs:
-  extract-versions:
-    name: Extract Versions from Playbook
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    outputs:
-      k8s_version: ${{ steps.versions.outputs.k8s_version }}
-      k8s_package: ${{ steps.versions.outputs.k8s_package }}
-      crio_version: ${{ steps.versions.outputs.crio_version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Extract versions from playbook
-        id: versions
-        run: |
-          K8S_VER=$(grep -m1 'kubernetes_version:' ansible/playbooks/control-plane.yml \
-            | awk -F'"' '{print $2}')
-          K8S_PKG=$(grep -m1 'kubernetes_package_version:' ansible/playbooks/control-plane.yml \
-            | awk -F'"' '{print $2}')
-          CRIO_VER=$(grep -m1 'crio_version:' ansible/playbooks/control-plane.yml \
-            | awk -F'"' '{print $2}')
-          if [ -z "$K8S_VER" ] || [ -z "$K8S_PKG" ] || [ -z "$CRIO_VER" ]; then
-            echo "::error::Failed to extract Kubernetes/CRI-O versions from ansible/playbooks/control-plane.yml"
-            exit 1
-          fi
-          if [ "${K8S_PKG%%-*}" != "$K8S_VER" ]; then
-            echo "::error::kubernetes_package_version ($K8S_PKG) must match kubernetes_version ($K8S_VER)"
-            exit 1
-          fi
-          if [ "${K8S_VER%.*}" != "${CRIO_VER%.*}" ]; then
-            echo "::error::crio_version ($CRIO_VER) must use the same major.minor as kubernetes_version ($K8S_VER)"
-            exit 1
-          fi
-          {
-            echo "k8s_version=$K8S_VER"
-            echo "k8s_package=$K8S_PKG"
-            echo "crio_version=$CRIO_VER"
-          } >> "$GITHUB_OUTPUT"
-          echo "Extracted versions: k8s=$K8S_VER, pkg=$K8S_PKG, crio=$CRIO_VER"
-
   pre-check:
     name: Pre-upgrade Validation
-    needs: extract-versions
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
     env:
-      K8S_VERSION: ${{ inputs.kubernetes_version || needs.extract-versions.outputs.k8s_version }}
-      K8S_PACKAGE: ${{ inputs.kubernetes_package || needs.extract-versions.outputs.k8s_package }}
-      CRIO_VERSION: ${{ inputs.crio_version || needs.extract-versions.outputs.crio_version }}
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -269,7 +224,7 @@ jobs:
 
   upgrade-cp-1:
     name: Upgrade shanghai-1 (first CP)
-    needs: [extract-versions, pre-check]
+    needs: [pre-check]
     if: inputs.target_node == 'all' || inputs.target_node == 'shanghai-1'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -277,9 +232,9 @@ jobs:
       id-token: write
       contents: read
     env:
-      K8S_VERSION: ${{ inputs.kubernetes_version || needs.extract-versions.outputs.k8s_version }}
-      K8S_PACKAGE: ${{ inputs.kubernetes_package || needs.extract-versions.outputs.k8s_package }}
-      CRIO_VERSION: ${{ inputs.crio_version || needs.extract-versions.outputs.crio_version }}
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -400,17 +355,17 @@ jobs:
 
   upgrade-cp-2:
     name: Upgrade shanghai-2
-    needs: [extract-versions, pre-check, upgrade-cp-1]
-    if: always() && !cancelled() && needs.pre-check.result == 'success' && needs.extract-versions.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'shanghai-2')
+    needs: [pre-check, upgrade-cp-1]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'shanghai-2')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
     env:
-      K8S_VERSION: ${{ inputs.kubernetes_version || needs.extract-versions.outputs.k8s_version }}
-      K8S_PACKAGE: ${{ inputs.kubernetes_package || needs.extract-versions.outputs.k8s_package }}
-      CRIO_VERSION: ${{ inputs.crio_version || needs.extract-versions.outputs.crio_version }}
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -531,17 +486,17 @@ jobs:
 
   upgrade-cp-3:
     name: Upgrade shanghai-3
-    needs: [extract-versions, pre-check, upgrade-cp-1, upgrade-cp-2]
-    if: always() && !cancelled() && needs.pre-check.result == 'success' && needs.extract-versions.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'shanghai-3')
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'shanghai-3')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
     env:
-      K8S_VERSION: ${{ inputs.kubernetes_version || needs.extract-versions.outputs.k8s_version }}
-      K8S_PACKAGE: ${{ inputs.kubernetes_package || needs.extract-versions.outputs.k8s_package }}
-      CRIO_VERSION: ${{ inputs.crio_version || needs.extract-versions.outputs.crio_version }}
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -662,7 +617,7 @@ jobs:
 
   post-check:
     name: Post-upgrade Validation
-    needs: [extract-versions, pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3]
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3]
     if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-3.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -670,9 +625,9 @@ jobs:
       id-token: write
       contents: read
     env:
-      K8S_VERSION: ${{ inputs.kubernetes_version || needs.extract-versions.outputs.k8s_version }}
-      K8S_PACKAGE: ${{ inputs.kubernetes_package || needs.extract-versions.outputs.k8s_package }}
-      CRIO_VERSION: ${{ inputs.crio_version || needs.extract-versions.outputs.crio_version }}
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,9 +93,9 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "1.35.6"
-        kubernetes_package_version: "1.35.6-1.1"
-        crio_version: "1.35.4"
+        kubernetes_version: "1.34.0"
+        kubernetes_package_version: "1.34.0-1.1"
+        crio_version: "{{ '1.34.4' if node_name == 'shanghai-2' else '1.35.3' }}"
         kubelet_cluster_dns: "{{ cluster_dns }}"
         kubelet_cluster_domain: "{{ cluster_domain }}"
         kubelet_node_ip: "{{ node_ip }}"

--- a/ansible/playbooks/node-shanghai-1.yml
+++ b/ansible/playbooks/node-shanghai-1.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.34.0"
+    kubernetes_package_version: "1.34.0-1.1"
+    crio_version: "1.35.3"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-2.yml
+++ b/ansible/playbooks/node-shanghai-2.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.34.0"
+    kubernetes_package_version: "1.34.0-1.1"
+    crio_version: "1.34.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-3.yml
+++ b/ansible/playbooks/node-shanghai-3.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.34.0"
+    kubernetes_package_version: "1.34.0-1.1"
+    crio_version: "1.35.3"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/roles/kubernetes_components/tasks/kubernetes.yml
+++ b/ansible/roles/kubernetes_components/tasks/kubernetes.yml
@@ -7,18 +7,18 @@
     state: present
   become: true
 
-- name: Add Kubernetes repository
-  ansible.builtin.apt_repository:
-    repo: "deb {{ kubernetes_apt_repository }} /"
-    state: present
-    filename: kubernetes
-    update_cache: true
+- name: Configure Kubernetes repository
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/kubernetes.list
+    content: "deb {{ kubernetes_apt_repository }} /\n"
+    mode: '0644'
   become: true
 
 - name: Install Kubernetes packages
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: "{{ kubernetes_packages }}"
     state: present
+    update_cache: true
     allow_downgrade: true
   become: true
   notify: Restart kubelet

--- a/docs/project_docs/lolice-k8s-135-phase3-prep/plan.md
+++ b/docs/project_docs/lolice-k8s-135-phase3-prep/plan.md
@@ -1,0 +1,37 @@
+# lolice Kubernetes 1.35 Phase 3 Prep Plan
+
+作成日: 2026-06-21
+
+## Goal
+
+Phase 3 の control plane upgrade 前に、通常の `Apply Ansible` と明示的な `Kubernetes Upgrade` workflow の責務を分離する。
+
+## Changes
+
+- `Kubernetes Upgrade` workflow の version input を必須にする。
+- `Kubernetes Upgrade` workflow が `control-plane.yml` から target version を自動抽出しないようにする。
+- 通常 apply 用の control plane playbook version を現在の cluster baseline に戻す。
+  - Kubernetes: `1.34.0`
+  - Kubernetes package: `1.34.0-1.1`
+  - CRI-O: node の現在値に合わせる
+- Kubernetes apt repository を単一行の canonical file として管理し、混入した `v1.35` repo 行を通常 apply で除去できるようにする。
+
+## Phase 3 Operation
+
+Phase 3 の upgrade は通常 apply では行わない。`Kubernetes Upgrade` workflow を手動実行し、以下の input を明示する。
+
+```text
+kubernetes_version=1.35.6
+kubernetes_package=1.35.6-1.1
+crio_version=1.35.4
+dry_run=true
+target_node=all
+```
+
+dry-run 成功後、同じ version input で `dry_run=false` を実行する。
+
+## Verification
+
+- `actionlint .github/workflows/upgrade-k8s.yml`
+- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check`
+- `cd ansible && uv run ansible-lint playbooks/control-plane.yml roles/kubernetes_components/tasks/kubernetes.yml`


### PR DESCRIPTION
## Summary
- make Kubernetes Upgrade workflow version inputs required
- stop deriving upgrade targets from the normal control-plane playbook
- restore normal apply Kubernetes package baseline to the current v1.34 cluster state
- canonicalize the Kubernetes apt source file so stray v1.35 repo lines are removed by normal apply

## Validation
- actionlint .github/workflows/upgrade-k8s.yml .github/workflows/apply-ansible.yml
- cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check
- cd ansible && uv run ansible-lint playbooks/control-plane.yml roles/kubernetes_components/tasks/kubernetes.yml
- check-mode against shanghai-1 full control-plane playbook
- check-mode against shanghai-2/3 k8s-components tags