### PR TITLE
Fix secondary control-plane upgrade delegation

### DIFF
--- a/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
@@ -8,7 +8,6 @@
   until: node_ready.stdout == "True"
   retries: "{{ upgrade_health_check_retries }}"
   delay: "{{ upgrade_health_check_delay }}"
-  delegate_to: "{{ groups['control_plane'][0] }}"
   changed_when: false
   become: true
   tags: [health_check]
@@ -19,7 +18,6 @@
     -o jsonpath='{.status.nodeInfo.kubeletVersion}'
   register: node_kubelet_version
   check_mode: false
-  delegate_to: "{{ groups['control_plane'][0] }}"
   changed_when: false
   failed_when:
     - not ansible_check_mode
@@ -33,7 +31,6 @@
     -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
   register: node_conditions
   check_mode: false
-  delegate_to: "{{ groups['control_plane'][0] }}"
   changed_when: false
   failed_when: >
     'MemoryPressure=True' in node_conditions.stdout or

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
@@ -4,7 +4,6 @@
     kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} drain {{ inventory_hostname }}
     --ignore-daemonsets --delete-emptydir-data
     --timeout={{ upgrade_drain_timeout }}s
-  delegate_to: "{{ groups['control_plane'][0] }}"
   become: true
   changed_when: true
   tags: [upgrade]
@@ -60,7 +59,6 @@
 
 - name: Uncordon control plane node
   ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} uncordon {{ inventory_hostname }}"
-  delegate_to: "{{ groups['control_plane'][0] }}"
   become: true
   changed_when: true
   when: not ansible_check_mode

--- a/docs/project_docs/lolice-k8s-135-secondary-delegate/plan.md
+++ b/docs/project_docs/lolice-k8s-135-secondary-delegate/plan.md
@@ -1,0 +1,19 @@
+# lolice k8s 1.35 secondary delegate fix plan
+
+## Goal
+
+- Make the Kubernetes Upgrade workflow usable for Phase 3 control-plane upgrades when each per-node job only has SSH access to its target node.
+
+## Context
+
+- Dry-run run `27902028437` failed on `Upgrade shanghai-2` because secondary control-plane drain still delegated kubectl execution to `shanghai-1`.
+- The pre-check delegate issue was already fixed in `boxp/arch#10330`.
+- `upgrade_control_plane_first.yml` already runs drain/uncordon from the target node itself using `kubectl_api_server_arg`.
+
+## Plan
+
+1. Remove `delegate_to: groups[control_plane][0]` from secondary control-plane drain and uncordon tasks.
+2. Remove the same delegate from node health checks so post-upgrade per-node checks run from the target node.
+3. Keep worker drain/uncordon unchanged for now because worker Phase 4 may need separate SSH topology handling.
+4. Validate with ansible-lint and a shanghai-2 check-mode upgrade run that reproduces the GitHub Actions SSH topology.
+5. Open a PR, wait for CI, merge, then rerun Kubernetes Upgrade dry-run with explicit version inputs.


### PR DESCRIPTION
## Summary
- run secondary control-plane drain/uncordon from the target node instead of delegating to shanghai-1
- run node health checks from the target node so per-node upgrade jobs only need target-node SSH
- add the Phase 3 fix plan under docs/project_docs

## Validation
- cd ansible && uv run ansible-lint roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml roles/kubernetes_upgrade/tasks/health_check.yml
- cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags upgrade --limit shanghai-2 --check -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4 -e node_role=control_plane -e is_first_control_plane=false
- cd ansible && ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_ROLES_PATH=roles uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags upgrade --limit shanghai-3 --check -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4 -e node_role=control_plane -e is_first_control_plane=false