### PR TITLE
Fix per-node Kubernetes upgrade post-check

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -724,11 +724,21 @@ jobs:
         run: |
           cd ansible
           source .venv/bin/activate
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--check"
+          fi
+          POST_CHECK_LIMIT="control_plane"
+          if [ "${{ inputs.target_node }}" != "all" ]; then
+            POST_CHECK_LIMIT="${{ inputs.target_node }}"
+          fi
           echo "Running post-upgrade cluster health check"
           ansible-playbook \
             -i inventories/production/hosts.yml \
             playbooks/upgrade-k8s.yml \
             --tags health_check \
+            --limit "${POST_CHECK_LIMIT}" \
             -e "ansible_ssh_common_args=''" \
             -e "kubernetes_upgrade_version=${K8S_VERSION}" \
+            ${DRY_RUN_FLAG} \
             -v

--- a/docs/project_docs/lolice-k8s-135-per-node-postcheck/plan.md
+++ b/docs/project_docs/lolice-k8s-135-per-node-postcheck/plan.md
@@ -1,0 +1,18 @@
+# lolice k8s 1.35 per-node post-check plan
+
+## Goal
+
+- Make the Kubernetes Upgrade workflow safe for one-control-plane-at-a-time Phase 3 execution.
+
+## Context
+
+- Production upgrades should use separate workflow_dispatch runs for `shanghai-1`, `shanghai-2`, and `shanghai-3` instead of `target_node=all`.
+- Dry-run run `27903389682` for `target_node=shanghai-1` succeeded in the upgrade job but failed in post-check because post-check expected kubelet `1.35.6` while dry-run leaves the node on `v1.34.0`.
+- Per-node production runs would also fail if post-check validated all control planes before the later nodes are upgraded.
+
+## Plan
+
+1. In post-check, derive an Ansible limit from `inputs.target_node`: `control_plane` for `all`, otherwise the selected node.
+2. Pass the derived limit to the post-check playbook.
+3. Pass `--check` to post-check when `dry_run=true` so version assertions do not fail on an intentionally unchanged node.
+4. Validate with actionlint and a PR CI run before rerunning per-node dry-runs.


### PR DESCRIPTION
## Summary
- limit post-upgrade health checks to the selected target node for per-node upgrade runs
- keep full control-plane post-check behavior for target_node=all
- run post-check in check mode when dry_run=true so dry-runs do not require kubelet to already be at the target version
- add the Phase 3 post-check fix plan under docs/project_docs

## Validation
- actionlint .github/workflows/upgrade-k8s.yml

## Context
- dry-run run 27903389682 succeeded for Upgrade shanghai-1 but failed in Post-upgrade Validation because dry-run intentionally leaves kubelet at v1.34.0
- Phase 3 production execution will use separate workflow_dispatch runs for shanghai-1, shanghai-2, and shanghai-3