### PR TITLE
Store upgrade etcd snapshots in Longhorn PVC

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -29,7 +29,6 @@ on:
 env:
   NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104"}'
   ALL_NODE_IPS: "192.168.10.102 192.168.10.103 192.168.10.104"
-  ETCD_SNAPSHOT_S3_URI: s3://arch-etcd-snapshots/kubernetes-upgrade
 
 jobs:
   pre-check:
@@ -176,11 +175,9 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          ETCD_SNAPSHOT_ARTIFACT_DIR="/tmp/etcd-snapshots"
-          mkdir -p "${ETCD_SNAPSHOT_ARTIFACT_DIR}"
           cd ansible
           source .venv/bin/activate
-          echo "Taking etcd snapshot before production upgrade"
+          echo "Taking etcd snapshot before production upgrade and storing it in the Longhorn PVC"
           ansible-playbook \
             -i inventories/production/hosts.yml \
             playbooks/upgrade-k8s.yml \
@@ -189,7 +186,6 @@ jobs:
             -e "kubernetes_upgrade_version=${K8S_VERSION}" \
             -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
             -e "crio_upgrade_version=${CRIO_VERSION}" \
-            -e "etcd_snapshot_local_dir=${ETCD_SNAPSHOT_ARTIFACT_DIR}" \
             -e "etcd_snapshot_force=true" \
             -vv 2>&1 | tee /tmp/etcd-snapshot-ansible.log
 
@@ -202,25 +198,6 @@ jobs:
             /tmp/pre-check-ansible.log
             /tmp/etcd-snapshot-ansible.log
           retention-days: 14
-
-      - name: Upload etcd snapshot to S3
-        if: inputs.dry_run == false
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-
-          snapshots=(/tmp/etcd-snapshots/*.db)
-          if [ "${#snapshots[@]}" -eq 0 ]; then
-            echo "No etcd snapshots found to upload"
-            exit 0
-          fi
-
-          for snapshot in "${snapshots[@]}"; do
-            aws s3 cp "${snapshot}" \
-              "${ETCD_SNAPSHOT_S3_URI}/run-${GITHUB_RUN_ID}/$(basename "${snapshot}")" \
-              --sse AES256
-          done
 
   upgrade-cp-1:
     name: Upgrade shanghai-1 (first CP)

--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -17,9 +17,13 @@ upgrade_health_check_delay: 10       # seconds
 # etcd snapshot
 etcd_snapshot_dir: /var/lib/etcd-snapshots
 etcd_snapshot_pod_dir: /var/lib/etcd
-etcd_snapshot_local_dir: ""
 etcd_snapshot_cleanup_pod_file: true
+etcd_snapshot_cleanup_host_file: false
 etcd_snapshot_force: false
+etcd_snapshot_store_namespace: etcd-snapshots
+etcd_snapshot_store_pod_selector: app.kubernetes.io/name=etcd-snapshot-store
+etcd_snapshot_store_mount_path: /snapshots
+etcd_snapshot_store_retention_count: 3
 etcd_cacert: /etc/kubernetes/pki/etcd/ca.crt
 etcd_cert: /etc/kubernetes/pki/etcd/healthcheck-client.crt
 etcd_key: /etc/kubernetes/pki/etcd/healthcheck-client.key

--- a/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
@@ -119,6 +119,12 @@
             *"get node"*"conditions"*)
               printf "MemoryPressure=False\nDiskPressure=False\nPIDPressure=False\nReady=True\n"
               ;;
+            *"wait"*"app.kubernetes.io/name=etcd-snapshot-store"*)
+              echo "pod/etcd-snapshot-store-test condition met"
+              ;;
+            *"get pod"*"app.kubernetes.io/name=etcd-snapshot-store"*"jsonpath"*)
+              echo -n "etcd-snapshot-store-test"
+              ;;
             *"drain"*)
               echo "node/control-plane-test cordoned"
               echo "node/control-plane-test drained"
@@ -140,12 +146,27 @@
               printf "mock snapshot\n" > "$snapshot_path"
               echo "Snapshot saved at $snapshot_path"
               ;;
-            *"exec etcd-"*"etcdctl snapshot status"*)
+            *"exec etcd-"*"etcdutl snapshot status"*)
               echo "+----------+----------+------------+------------+"
               echo "|   HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |"
               echo "+----------+----------+------------+------------+"
               echo "| abcd1234 |    12345 |       1000 |     5.0 MB |"
               echo "+----------+----------+------------+------------+"
+              ;;
+            *"exec -i "*" sh -c "*"cat > "*)
+              shell_command="${@: -1}"
+              snapshot_path="${shell_command#cat > }"
+              snapshot_path="${snapshot_path%\'}"
+              snapshot_path="${snapshot_path#\'}"
+              mkdir -p "$(dirname "$snapshot_path")"
+              cat > "$snapshot_path"
+              ;;
+            *"exec "*" test -s "*)
+              snapshot_path="${@: -1}"
+              test -s "$snapshot_path"
+              ;;
+            *"exec "*" sh -c "*"pre-upgrade-"*)
+              echo "mock prune"
               ;;
             *"exec etcd-"*" cat "*)
               snapshot_path="${@: -1}"

--- a/ansible/roles/kubernetes_upgrade/molecule/default/verify.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/verify.yml
@@ -81,6 +81,20 @@
           - etcd_snap_dir.stat.mode == '0700'
         fail_msg: "etcd snapshot directory does not have correct permissions (expected 0700)"
 
+    # Verify etcd snapshot was streamed into the Longhorn PVC mount
+    - name: Find etcd snapshots in PVC mount
+      ansible.builtin.find:
+        paths: /snapshots
+        patterns: "pre-upgrade-*.db"
+      register: pvc_snapshots
+
+    - name: Assert etcd snapshot exists in PVC mount
+      ansible.builtin.assert:
+        that:
+          - pvc_snapshots.matched > 0
+          - pvc_snapshots.files | selectattr('size', 'gt', 0) | list | length > 0
+        fail_msg: "etcd snapshot was not stored in the PVC mount"
+
     # Verify etcd certificate paths exist (mock)
     - name: Check etcd CA certificate exists
       ansible.builtin.stat:

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -15,20 +15,68 @@
   register: existing_snapshots
   tags: [etcd_snapshot]
 
+- name: Set valid existing etcd snapshots
+  ansible.builtin.set_fact:
+    _valid_existing_snapshots: "{{ existing_snapshots.files | selectattr('size', 'gt', 0) | list }}"
+  tags: [etcd_snapshot]
+
 - name: Set etcd snapshot paths
   ansible.builtin.set_fact:
     _etcd_snapshot_filename: "pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_pod_path: "{{ etcd_snapshot_pod_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_remote_path: "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+    _etcd_snapshot_needs_create: "{{ (etcd_snapshot_force | bool) or (_valid_existing_snapshots | length == 0) }}"
   tags: [etcd_snapshot]
 
 - name: Reuse existing etcd snapshot for today
   ansible.builtin.set_fact:
-    _etcd_snapshot_remote_path: "{{ (existing_snapshots.files | sort(attribute='mtime') | last).path }}"
-    _etcd_snapshot_filename: "{{ (existing_snapshots.files | sort(attribute='mtime') | last).path | basename }}"
+    _etcd_snapshot_remote_path: "{{ (_valid_existing_snapshots | sort(attribute='mtime') | last).path }}"
+    _etcd_snapshot_filename: "{{ (_valid_existing_snapshots | sort(attribute='mtime') | last).path | basename }}"
   when:
     - not (etcd_snapshot_force | bool)
-    - existing_snapshots.matched > 0
+    - _valid_existing_snapshots | length > 0
+  tags: [etcd_snapshot]
+
+- name: Wait for etcd snapshot store pod
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - wait
+      - "--for=condition=Ready"
+      - pod
+      - -l
+      - "{{ etcd_snapshot_store_pod_selector }}"
+      - --timeout=180s
+  become: true
+  changed_when: false
+  tags: [etcd_snapshot]
+
+- name: Get ready etcd snapshot store pod
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - get
+      - pod
+      - -l
+      - "{{ etcd_snapshot_store_pod_selector }}"
+      - -o
+      - "jsonpath={.items[0].metadata.name}"
+  become: true
+  changed_when: false
+  register: etcd_snapshot_store_pod_result
+  tags: [etcd_snapshot]
+
+- name: Set etcd snapshot store pod name
+  ansible.builtin.set_fact:
+    _etcd_snapshot_store_pod: "{{ etcd_snapshot_store_pod_result.stdout }}"
   tags: [etcd_snapshot]
 
 - name: Take etcd snapshot inside etcd pod
@@ -51,7 +99,7 @@
       - "--key={{ etcd_key }}"
   become: true
   changed_when: true
-  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+  when: _etcd_snapshot_needs_create | bool
   tags: [etcd_snapshot]
 
 - name: Verify etcd snapshot integrity inside etcd pod
@@ -65,14 +113,14 @@
       - exec
       - "etcd-{{ inventory_hostname }}"
       - --
-      - etcdctl
+      - etcdutl
       - snapshot
       - status
       - "{{ _etcd_snapshot_pod_path }}"
       - --write-out=table
   become: true
   changed_when: false
-  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+  when: _etcd_snapshot_needs_create | bool
   tags: [etcd_snapshot]
 
 - name: Move etcd snapshot from host-mounted etcd data directory
@@ -83,26 +131,74 @@
       - "{{ _etcd_snapshot_remote_path }}"
   become: true
   changed_when: true
-  when: (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+  when: _etcd_snapshot_needs_create | bool
   tags: [etcd_snapshot]
 
-- name: Create local etcd snapshot artifact directory
-  ansible.builtin.file:
-    path: "{{ etcd_snapshot_local_dir }}"
-    state: directory
-    mode: '0700'
-  delegate_to: localhost
-  become: false
-  when: etcd_snapshot_local_dir | length > 0
-  tags: [etcd_snapshot]
-
-- name: Fetch etcd snapshot to local artifact directory
-  ansible.builtin.fetch:
-    src: "{{ _etcd_snapshot_remote_path }}"
-    dest: "{{ etcd_snapshot_local_dir }}/{{ _etcd_snapshot_filename }}"
-    flat: true
+- name: Stream etcd snapshot into Longhorn PVC
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat {{ _etcd_snapshot_remote_path | quote }} | \
+      kubectl --kubeconfig={{ kubeconfig_path | quote }} {{ kubectl_api_server_arg }} \
+        -n {{ etcd_snapshot_store_namespace | quote }} \
+        exec -i {{ _etcd_snapshot_store_pod | quote }} -- \
+        sh -c "cat > {{ (etcd_snapshot_store_mount_path ~ "/" ~ _etcd_snapshot_filename) | quote }}"
+  args:
+    executable: /bin/bash
   become: true
-  when: etcd_snapshot_local_dir | length > 0
+  changed_when: true
+  when: _etcd_snapshot_needs_create | bool
+  tags: [etcd_snapshot]
+
+- name: Verify etcd snapshot exists in Longhorn PVC
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - exec
+      - "{{ _etcd_snapshot_store_pod }}"
+      - --
+      - test
+      - -s
+      - "{{ etcd_snapshot_store_mount_path }}/{{ _etcd_snapshot_filename }}"
+  become: true
+  changed_when: false
+  when: _etcd_snapshot_needs_create | bool
+  tags: [etcd_snapshot]
+
+- name: Prune old etcd snapshots from Longhorn PVC
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - exec
+      - "{{ _etcd_snapshot_store_pod }}"
+      - --
+      - sh
+      - -c
+      - |
+        set -eu
+        cd {{ etcd_snapshot_store_mount_path | quote }}
+        retention={{ etcd_snapshot_store_retention_count | int }}
+        index=0
+        for snapshot in $(ls -1t pre-upgrade-*.db 2>/dev/null || true); do
+          index=$((index + 1))
+          if [ "$index" -gt "$retention" ]; then
+            rm -f -- "$snapshot"
+            echo "deleted $snapshot"
+          fi
+        done
+  become: true
+  changed_when: "'deleted ' in prune_etcd_snapshots.stdout"
+  register: prune_etcd_snapshots
+  when:
+    - _etcd_snapshot_needs_create | bool
+    - (etcd_snapshot_store_retention_count | int) > 0
   tags: [etcd_snapshot]
 
 - name: Remove temporary etcd snapshot from host-mounted etcd data directory
@@ -115,5 +211,18 @@
   changed_when: false
   when:
     - etcd_snapshot_cleanup_pod_file | bool
-    - (etcd_snapshot_force | bool) or existing_snapshots.matched == 0
+    - _etcd_snapshot_needs_create | bool
+  tags: [etcd_snapshot]
+
+- name: Remove temporary etcd snapshot from control plane host
+  ansible.builtin.command:
+    argv:
+      - rm
+      - -f
+      - "{{ _etcd_snapshot_remote_path }}"
+  become: true
+  changed_when: false
+  when:
+    - etcd_snapshot_cleanup_host_file | bool
+    - _etcd_snapshot_needs_create | bool
   tags: [etcd_snapshot]

--- a/docs/project_docs/lolice-k8s-135-longhorn-snapshot/plan.md
+++ b/docs/project_docs/lolice-k8s-135-longhorn-snapshot/plan.md
@@ -1,0 +1,24 @@
+# lolice k8s 1.35 Longhorn snapshot plan
+
+## Context
+
+The first production phase 3 run failed before the Kubernetes upgrade because the workflow tried to fetch a 600MB+ etcd snapshot from the control-plane node to the GitHub Actions runner. That path is fragile and unnecessarily exports the snapshot from the cluster.
+
+The `lolice` GitOps manifests already provide an `etcd-snapshots` namespace, a Longhorn PVC, and a small storage pod. The PVC is backed by Longhorn, so durable off-cluster backup should be handled by Longhorn backup settings rather than a GitHub Actions artifact transfer.
+
+## Plan
+
+- Stop passing a local artifact directory to the etcd snapshot task.
+- Remove the direct GitHub Actions S3 upload of fetched snapshot files.
+- Keep creating and verifying the snapshot on the first control-plane node.
+- Stream the verified snapshot from the control-plane host into the `etcd-snapshots` Longhorn PVC through the storage pod.
+- Keep the host-side snapshot by default for the existing rollback task.
+- Prune old PVC snapshots by count so repeated upgrade attempts do not fill the volume.
+- Update Molecule mocks so CI exercises the PVC storage path.
+
+## Validation
+
+- Run Ansible syntax check for the upgrade playbook.
+- Run `ansible-lint` for the Ansible changes.
+- Run the `kubernetes_upgrade` Molecule scenario if the local container environment supports it.
+- After merge, run a production snapshot/pre-upgrade workflow before continuing with one-node-at-a-time upgrades.


### PR DESCRIPTION
## Summary
- stop fetching upgrade etcd snapshots back to the GitHub Actions runner
- stream verified etcd snapshots into the GitOps-managed Longhorn PVC
- remove the direct GHA S3 upload path; S3 backup is handled by Longhorn backup target/recurring backup
- add Molecule coverage for the PVC snapshot path

## Validation
- `actionlint .github/workflows/upgrade-k8s.yml`
- `cd ansible && source .venv/bin/activate && ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && source .venv/bin/activate && ansible-lint roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/molecule/default/prepare.yml roles/kubernetes_upgrade/molecule/default/verify.yml playbooks/upgrade-k8s.yml`
- `cd ansible/roles/kubernetes_upgrade && PATH=/home/boxp/ghq/github.com/boxp/arch=fix-lolice-k8s-135-longhorn-snapshot/ansible/.venv/bin:$PATH ../../.venv/bin/molecule test`

## Notes
- The existing open PR #9522 is stale against current Phase 3 workflow changes and is superseded by this narrower PR.
- The lolice `etcd-snapshot-store` Application is already Synced/Healthy and the PVC is Bound.
- Longhorn `BackupTarget/default` is available and points at `s3://boxp-longhorn-backup@ap-northeast-1/`.
