### PR TITLE
Use etcdctl for etcd snapshot status

### DIFF
--- a/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
@@ -146,7 +146,7 @@
               printf "mock snapshot\n" > "$snapshot_path"
               echo "Snapshot saved at $snapshot_path"
               ;;
-            *"exec etcd-"*"etcdutl snapshot status"*)
+            *"exec etcd-"*"etcdctl snapshot status"*)
               echo "+----------+----------+------------+------------+"
               echo "|   HASH   | REVISION | TOTAL KEYS | TOTAL SIZE |"
               echo "+----------+----------+------------+------------+"

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -113,7 +113,7 @@
       - exec
       - "etcd-{{ inventory_hostname }}"
       - --
-      - etcdutl
+      - etcdctl
       - snapshot
       - status
       - "{{ _etcd_snapshot_pod_path }}"

--- a/docs/project_docs/lolice-k8s-135-snapshot-etcdctl/plan.md
+++ b/docs/project_docs/lolice-k8s-135-snapshot-etcdctl/plan.md
@@ -1,0 +1,19 @@
+# lolice k8s 1.35 snapshot etcdctl plan
+
+## Context
+
+The first production run after switching etcd snapshots to the Longhorn PVC failed before the upgrade started. Snapshot creation succeeded, but integrity verification used `etcdutl`, which is not present in the running etcd container image.
+
+The previous `etcdctl snapshot status` command is available in the etcd container and had already worked in the earlier production attempt.
+
+## Plan
+
+- Change snapshot integrity verification from `etcdutl snapshot status` back to `etcdctl snapshot status`.
+- Update the Molecule kubectl mock to match the production command.
+- Keep the Longhorn PVC storage path unchanged.
+
+## Validation
+
+- Run Ansible syntax check for the upgrade playbook.
+- Run `ansible-lint` for the changed role files.
+- Run the `kubernetes_upgrade` Molecule scenario if local Docker support is available.


### PR DESCRIPTION
## Summary
- use `etcdctl snapshot status` for the upgrade etcd snapshot integrity check
- keep the Longhorn PVC snapshot storage path unchanged
- update the Molecule kubectl mock to match production

## Validation
- `cd ansible && source .venv/bin/activate && ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && source .venv/bin/activate && ansible-lint roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/molecule/default/prepare.yml playbooks/upgrade-k8s.yml`
- `cd ansible/roles/kubernetes_upgrade && PATH=/home/boxp/ghq/github.com/boxp/arch=fix-lolice-k8s-135-longhorn-snapshot/ansible/.venv/bin:$PATH ../../.venv/bin/molecule test`

## Notes
- Production run `27905428228` failed before upgrade because the etcd container did not have `etcdutl` in PATH.
- The temporary snapshot file from that failed run was removed from `shanghai-1`; the node is Ready.
