### PR TITLE
Skip kubeadm etcd phase during k8s upgrade

### DIFF
--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -13,6 +13,7 @@ crio_previous_version: ""
 upgrade_drain_timeout: 300           # seconds
 upgrade_health_check_retries: 30
 upgrade_health_check_delay: 10       # seconds
+kubeadm_upgrade_etcd: false          # skip kubeadm's etcd static pod phase unless explicitly enabled
 
 # etcd snapshot
 etcd_snapshot_dir: /var/lib/etcd-snapshots

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -207,6 +207,7 @@
       - rm
       - -f
       - "{{ _etcd_snapshot_pod_path }}"
+      - "{{ _etcd_snapshot_pod_path }}.part"
   become: true
   changed_when: false
   when:

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
@@ -38,7 +38,9 @@
   tags: [upgrade]
 
 - name: Run kubeadm upgrade apply
-  ansible.builtin.command: "kubeadm upgrade apply v{{ kubernetes_upgrade_version }} --yes"
+  ansible.builtin.command: >-
+    kubeadm upgrade apply v{{ kubernetes_upgrade_version }} --yes
+    --etcd-upgrade={{ kubeadm_upgrade_etcd | bool | ternary('true', 'false') }}
   become: true
   register: upgrade_result
   changed_when: upgrade_result.rc == 0

--- a/docs/project_docs/lolice-k8s-135-skip-etcd-phase/plan.md
+++ b/docs/project_docs/lolice-k8s-135-skip-etcd-phase/plan.md
@@ -1,0 +1,25 @@
+# lolice k8s 1.35 skip kubeadm etcd phase plan
+
+## Context
+
+The production shanghai-1 Kubernetes 1.35.6 upgrade reached `kubeadm upgrade apply`, but kubeadm failed during the etcd static pod phase:
+
+- kubeadm moved a temporary etcd manifest into `/etc/kubernetes/manifests/etcd.yaml`.
+- kubelet restarted etcd, but kubeadm did not observe the static pod hash change within its 5 minute timeout.
+- kubeadm rolled etcd back to the pre-upgrade state.
+- The cluster remained on Kubernetes v1.34.0 and etcd recovered healthy.
+
+The lolice cluster already takes a pre-upgrade etcd snapshot and stores it in a Longhorn PVC, with S3 backup delegated to Longhorn BackupTarget/recurring backup. The current etcd image is already `registry.k8s.io/etcd:3.6.4-0`, so retrying kubeadm's etcd static pod phase adds risk without being necessary for the Kubernetes component upgrade.
+
+## Plan
+
+1. Add a role variable `kubeadm_upgrade_etcd`, defaulting to `false`.
+2. Pass `--etcd-upgrade=false` to `kubeadm upgrade apply` by default for the first control plane upgrade.
+3. Keep the option configurable so a future explicit etcd upgrade can set `kubeadm_upgrade_etcd=true`.
+4. Remove leftover `*.db.part` files from the etcd data directory after snapshot creation, so kubeadm's internal etcd backup does not copy temporary snapshot fragments.
+5. Validate Ansible syntax and lint locally.
+6. Merge, wait for main CI/apply, then rerun shanghai-1 only.
+
+## Rollback
+
+If the change causes issues, revert this PR. The cluster state remains protected by the pre-upgrade etcd snapshot stored in the `etcd-snapshots` Longhorn PVC and by Longhorn's BackupTarget/recurring backup path.


### PR DESCRIPTION
## Summary
- add `kubeadm_upgrade_etcd` and default kubeadm apply to `--etcd-upgrade=false`
- keep the etcd phase explicitly re-enableable via role variable
- remove leftover `.db.part` snapshot fragments from the etcd data dir
- include project plan docs

## Validation
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && uv run ansible-lint roles/kubernetes_upgrade playbooks/upgrade-k8s.yml`
- `cd ansible/roles/kubernetes_upgrade && uv run molecule test`