### PR TITLE
Retry control plane uncordon after kubelet restart

### DIFF
--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -13,6 +13,8 @@ crio_previous_version: ""
 upgrade_drain_timeout: 300           # seconds
 upgrade_health_check_retries: 30
 upgrade_health_check_delay: 10       # seconds
+upgrade_uncordon_retries: 18
+upgrade_uncordon_delay: 10           # seconds
 kubeadm_upgrade_etcd: false          # skip kubeadm's etcd static pod phase unless explicitly enabled
 
 # etcd snapshot

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
@@ -60,10 +60,27 @@
   when: not ansible_check_mode
   tags: [upgrade]
 
+- name: Wait for kube-apiserver before uncordon
+  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get --raw=/readyz"
+  become: true
+  register: kube_apiserver_ready
+  until:
+    - kube_apiserver_ready.rc == 0
+    - "'readyz check passed' in kube_apiserver_ready.stdout"
+  retries: "{{ upgrade_uncordon_retries }}"
+  delay: "{{ upgrade_uncordon_delay }}"
+  changed_when: false
+  when: not ansible_check_mode
+  tags: [upgrade]
+
 - name: Uncordon control plane node
   ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} uncordon {{ inventory_hostname }}"
   become: true
-  changed_when: true
+  register: uncordon_result
+  until: uncordon_result.rc == 0
+  retries: "{{ upgrade_uncordon_retries }}"
+  delay: "{{ upgrade_uncordon_delay }}"
+  changed_when: uncordon_result.rc == 0
   when: not ansible_check_mode
   tags: [upgrade]
 

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
@@ -57,10 +57,27 @@
   when: not ansible_check_mode
   tags: [upgrade]
 
+- name: Wait for kube-apiserver before uncordon
+  ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get --raw=/readyz"
+  become: true
+  register: kube_apiserver_ready
+  until:
+    - kube_apiserver_ready.rc == 0
+    - "'readyz check passed' in kube_apiserver_ready.stdout"
+  retries: "{{ upgrade_uncordon_retries }}"
+  delay: "{{ upgrade_uncordon_delay }}"
+  changed_when: false
+  when: not ansible_check_mode
+  tags: [upgrade]
+
 - name: Uncordon control plane node
   ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} uncordon {{ inventory_hostname }}"
   become: true
-  changed_when: true
+  register: uncordon_result
+  until: uncordon_result.rc == 0
+  retries: "{{ upgrade_uncordon_retries }}"
+  delay: "{{ upgrade_uncordon_delay }}"
+  changed_when: uncordon_result.rc == 0
   when: not ansible_check_mode
   tags: [upgrade]
 

--- a/docs/project_docs/lolice-k8s-135-uncordon-retry/plan.md
+++ b/docs/project_docs/lolice-k8s-135-uncordon-retry/plan.md
@@ -1,0 +1,29 @@
+# lolice Kubernetes 1.35 uncordon retry plan
+
+## Context
+
+Production run `27908896441` upgraded `shanghai-1` to Kubernetes `v1.35.6`, but the workflow failed after kubelet restart because `kubectl uncordon shanghai-1` hit a transient local API server refusal on `https://192.168.10.102:6443`.
+
+Manual recovery succeeded after the API server became ready:
+
+- `shanghai-1` is `Ready` and uncordoned.
+- kubelet reports `v1.35.6`.
+- control plane static pods are running.
+- etcd endpoint health passed.
+
+## Plan
+
+1. Add an explicit `/readyz` wait after kubelet restart and before control-plane uncordon.
+2. Retry the uncordon command to absorb short API restart windows.
+3. Apply the same guard to first and secondary control-plane upgrade tasks.
+4. Validate with syntax check, ansible-lint, and the `kubernetes_upgrade` Molecule scenario.
+5. Merge before starting the next one-node production upgrade run.
+
+## Rollout
+
+After merge, continue Phase 3 one node at a time:
+
+1. Run `Kubernetes Upgrade` for `target_node=shanghai-2`.
+2. Verify `shanghai-2` is `Ready`, uncordoned, and on `v1.35.6`.
+3. Verify static pods and etcd health.
+4. Only then run `target_node=shanghai-3`.


### PR DESCRIPTION
## Summary
- wait for the target control-plane API `/readyz` after kubelet restart before uncordon
- retry `kubectl uncordon` for first and secondary control-plane upgrades
- document the production shanghai-1 failure/recovery plan

## Why
Production run `27908896441` upgraded `shanghai-1` to `v1.35.6`, but failed at uncordon because the local API server briefly refused connections immediately after kubelet restart. The node recovered and was manually uncordoned after readyz passed.

## Validation
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && uv run ansible-lint roles/kubernetes_upgrade playbooks/upgrade-k8s.yml`
- `cd ansible/roles/kubernetes_upgrade && uv run molecule test`
- verified `shanghai-1` is Ready on `v1.35.6` and etcd endpoint health passes
