### PR TITLE
Align shanghai-1 apply baseline with k8s 1.35

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,9 +93,16 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "1.34.0"
-        kubernetes_package_version: "1.34.0-1.1"
-        crio_version: "{{ '1.34.4' if node_name == 'shanghai-2' else '1.35.3' }}"
+        kubernetes_version: "{{ '1.35.6' if node_name == 'shanghai-1' else '1.34.0' }}"
+        kubernetes_package_version: "{{ '1.35.6-1.1' if node_name == 'shanghai-1' else '1.34.0-1.1' }}"
+        crio_version: >-
+          {{
+            {
+              'shanghai-1': '1.35.4',
+              'shanghai-2': '1.34.4',
+              'shanghai-3': '1.35.3'
+            }[node_name]
+          }}
         kubelet_cluster_dns: "{{ cluster_dns }}"
         kubelet_cluster_domain: "{{ cluster_domain }}"
         kubelet_node_ip: "{{ node_ip }}"

--- a/ansible/playbooks/node-shanghai-1.yml
+++ b/ansible/playbooks/node-shanghai-1.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.34.0"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.35.3"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/docs/project_docs/lolice-k8s-135-apply-baseline/plan.md
+++ b/docs/project_docs/lolice-k8s-135-apply-baseline/plan.md
@@ -1,0 +1,25 @@
+# lolice Kubernetes 1.35 apply baseline plan
+
+## Context
+
+After `shanghai-1` was upgraded to Kubernetes `v1.35.6`, main `Apply Ansible` run `27909847239` still used the normal apply baseline `kubernetes_package_version=1.34.0-1.1` for every control-plane node.
+
+The run attempted to install:
+
+- `kubelet=1.34.0-1.1`
+- `kubeadm=1.34.0-1.1`
+- `kubectl=1.34.0-1.1`
+
+on `shanghai-1`. The held packages blocked the downgrade, so the node stayed on `v1.35.6`, but main apply failed.
+
+## Plan
+
+1. Update the normal control-plane apply baseline so `shanghai-1` uses Kubernetes `1.35.6` / package `1.35.6-1.1`.
+2. Keep `shanghai-2` and `shanghai-3` on Kubernetes `1.34.0` until their one-node Phase 3 upgrade runs complete.
+3. Update the `node-shanghai-1` playbook variables to match the actual upgraded state.
+4. Validate Ansible syntax and linting.
+5. Merge before dispatching `target_node=shanghai-2`.
+
+## Follow-up
+
+After each successful control-plane upgrade, move that node's normal apply baseline to `1.35.6` before continuing to the next node.


### PR DESCRIPTION
## Summary
- set the normal control-plane apply baseline for `shanghai-1` to Kubernetes `1.35.6` / package `1.35.6-1.1`
- keep `shanghai-2` and `shanghai-3` on the existing `1.34.0` baseline until their per-node upgrade runs complete
- update `node-shanghai-1` vars to match the actual upgraded package/runtime state

## Why
Main Apply Ansible run `27909847239` still used the old `1.34.0-1.1` package baseline and attempted to downgrade `shanghai-1` after it had been upgraded to `v1.35.6`. Held packages blocked the downgrade, so the node stayed healthy, but the main apply failed.

## Validation
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check`
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/node-shanghai-1.yml --syntax-check`
- `cd ansible && uv run ansible-lint playbooks/control-plane.yml playbooks/node-shanghai-1.yml`
- verified `shanghai-1` remains Ready on `v1.35.6` with packages `1.35.6-1.1`
