### PR TITLE
fix: align shanghai-2 k8s 1.35 baseline

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,13 +93,13 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "{{ '1.35.6' if node_name == 'shanghai-1' else '1.34.0' }}"
-        kubernetes_package_version: "{{ '1.35.6-1.1' if node_name == 'shanghai-1' else '1.34.0-1.1' }}"
+        kubernetes_version: "{{ '1.35.6' if node_name in ['shanghai-1', 'shanghai-2'] else '1.34.0' }}"
+        kubernetes_package_version: "{{ '1.35.6-1.1' if node_name in ['shanghai-1', 'shanghai-2'] else '1.34.0-1.1' }}"
         crio_version: >-
           {{
             {
               'shanghai-1': '1.35.4',
-              'shanghai-2': '1.34.4',
+              'shanghai-2': '1.35.4',
               'shanghai-3': '1.35.3'
             }[node_name]
           }}

--- a/ansible/playbooks/node-shanghai-2.yml
+++ b/ansible/playbooks/node-shanghai-2.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.34.0"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.34.4"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
@@ -66,7 +66,7 @@
   register: kube_apiserver_ready
   until:
     - kube_apiserver_ready.rc == 0
-    - "'readyz check passed' in kube_apiserver_ready.stdout"
+    - kube_apiserver_ready.stdout in ["ok", "readyz check passed"]
   retries: "{{ upgrade_uncordon_retries }}"
   delay: "{{ upgrade_uncordon_delay }}"
   changed_when: false

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
@@ -65,7 +65,7 @@
   register: kube_apiserver_ready
   until:
     - kube_apiserver_ready.rc == 0
-    - "'readyz check passed' in kube_apiserver_ready.stdout"
+    - kube_apiserver_ready.stdout in ["ok", "readyz check passed"]
   retries: "{{ upgrade_uncordon_retries }}"
   delay: "{{ upgrade_uncordon_delay }}"
   changed_when: false

--- a/docs/project_docs/lolice-k8s-135-shanghai-2-baseline/plan.md
+++ b/docs/project_docs/lolice-k8s-135-shanghai-2-baseline/plan.md
@@ -1,0 +1,37 @@
+# lolice Kubernetes 1.35 shanghai-2 baseline alignment
+
+## Context
+
+`shanghai-2` was upgraded to Kubernetes 1.35.6 by the `Kubernetes Upgrade` workflow run `27911856475`.
+The workflow itself failed after the upgrade because the local apiserver `/readyz` endpoint returned `ok`, while the Ansible task only accepted `readyz check passed`.
+
+Manual verification after the run:
+
+- `shanghai-2` node is `Ready` on kubelet `v1.35.6`.
+- `cri-o`, `kubeadm`, `kubectl`, and `kubelet` packages are at the 1.35 target versions.
+- control-plane static pod manifests use Kubernetes `v1.35.6` images.
+- local etcd endpoint is healthy.
+- the node was manually uncordoned.
+
+## Decision
+
+1. Align the normal Apply Ansible baseline for `shanghai-2` with the live 1.35 state before proceeding to `shanghai-3`.
+2. Keep `shanghai-3` at its current 1.34 Kubernetes baseline until it is upgraded.
+3. Accept both `/readyz` success responses observed in the rollout:
+   - `readyz check passed`
+   - `ok`
+
+## Implementation
+
+1. Update `ansible/playbooks/control-plane.yml` so `shanghai-1` and `shanghai-2` use:
+   - `kubernetes_version=1.35.6`
+   - `kubernetes_package_version=1.35.6-1.1`
+   - `crio_version=1.35.4`
+2. Update `ansible/playbooks/node-shanghai-2.yml` to the same versions.
+3. Update the control-plane upgrade ready wait tasks to accept `/readyz` output `ok`.
+
+## Rollout
+
+1. Merge this PR after CI passes.
+2. Confirm the post-merge `Apply Ansible` workflow succeeds.
+3. Start `shanghai-3` upgrade only after that apply succeeds.


### PR DESCRIPTION
## Summary
- align normal Apply Ansible baseline for `shanghai-2` with live Kubernetes 1.35.6 state
- keep `shanghai-3` on the current 1.34 Kubernetes baseline until its own one-node upgrade
- accept `/readyz` output `ok` as successful in addition to `readyz check passed`
- add `docs/project_docs/lolice-k8s-135-shanghai-2-baseline/plan.md`

## Why
`shanghai-2` was upgraded by run `27911856475` and is now Ready on kubelet/static pod/package 1.35.6. The workflow failed after the upgrade because `/readyz` returned `ok`, so the node was manually uncordoned after static pod and etcd health checks passed. The normal apply baseline must now move to 1.35 for `shanghai-2` before continuing to `shanghai-3`, otherwise main Apply can attempt a downgrade.

## Validation
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check`
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/node-shanghai-2.yml --syntax-check`
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && uv run ansible-lint playbooks/control-plane.yml playbooks/node-shanghai-2.yml roles/kubernetes_upgrade`
- `kubectl get nodes -o wide`
- `kubectl -n kube-system get pod kube-apiserver-shanghai-2 kube-controller-manager-shanghai-2 kube-scheduler-shanghai-2 etcd-shanghai-2 -o wide`