### PR TITLE
fix: align shanghai-3 k8s 1.35 baseline

### DIFF
--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,14 +93,14 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "{{ '1.35.6' if node_name in ['shanghai-1', 'shanghai-2'] else '1.34.0' }}"
-        kubernetes_package_version: "{{ '1.35.6-1.1' if node_name in ['shanghai-1', 'shanghai-2'] else '1.34.0-1.1' }}"
+        kubernetes_version: "1.35.6"
+        kubernetes_package_version: "1.35.6-1.1"
         crio_version: >-
           {{
             {
               'shanghai-1': '1.35.4',
               'shanghai-2': '1.35.4',
-              'shanghai-3': '1.35.3'
+              'shanghai-3': '1.35.4'
             }[node_name]
           }}
         kubelet_cluster_dns: "{{ cluster_dns }}"

--- a/ansible/playbooks/node-shanghai-3.yml
+++ b/ansible/playbooks/node-shanghai-3.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.34.0"
-    kubernetes_package_version: "1.34.0-1.1"
-    crio_version: "1.35.3"
+    kubernetes_version: "1.35.6"
+    kubernetes_package_version: "1.35.6-1.1"
+    crio_version: "1.35.4"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/docs/project_docs/lolice-k8s-135-shanghai-3-baseline/plan.md
+++ b/docs/project_docs/lolice-k8s-135-shanghai-3-baseline/plan.md
@@ -1,0 +1,32 @@
+# lolice Kubernetes 1.35 shanghai-3 baseline alignment
+
+## Context
+
+`shanghai-3` was upgraded to Kubernetes 1.35.6 by the `Kubernetes Upgrade` workflow run `27913594139`.
+The run completed successfully, including post-upgrade validation.
+
+Current control-plane state after the run:
+
+- `shanghai-1`: kubelet `v1.35.6`, CRI-O `1.35.4`
+- `shanghai-2`: kubelet `v1.35.6`, CRI-O `1.35.4`
+- `shanghai-3`: kubelet `v1.35.6`, CRI-O `1.35.4`
+
+All nodes returned to `Ready`.
+
+## Decision
+
+Align the normal Apply Ansible desired state for all control-plane nodes with the live 1.35 state before starting worker upgrades.
+
+## Implementation
+
+1. Update `ansible/playbooks/control-plane.yml` so all control-plane nodes use:
+   - `kubernetes_version=1.35.6`
+   - `kubernetes_package_version=1.35.6-1.1`
+   - `crio_version=1.35.4`
+2. Update `ansible/playbooks/node-shanghai-3.yml` to the same versions.
+
+## Rollout
+
+1. Merge this PR after CI passes.
+2. Confirm the post-merge `Apply Ansible` workflow succeeds.
+3. Proceed to worker node upgrades one node at a time.


### PR DESCRIPTION
## Summary
- align normal Apply Ansible baseline for all control-plane nodes with Kubernetes 1.35.6
- update `node-shanghai-3.yml` to Kubernetes package 1.35.6-1.1 and CRI-O 1.35.4
- add `docs/project_docs/lolice-k8s-135-shanghai-3-baseline/plan.md`

## Why
`shanghai-3` upgrade run `27913594139` completed successfully and all control-plane nodes are now live on kubelet/static pod 1.35.6 with CRI-O 1.35.4. The normal Apply Ansible baseline must match that state before worker upgrades begin.

## Validation
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check`
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/node-shanghai-3.yml --syntax-check`
- `cd ansible && uv run ansible-lint playbooks/control-plane.yml playbooks/node-shanghai-3.yml`
- verified `shanghai-3` packages and control-plane static pod image versions on the node