### PR TITLE
[codex] Enable lolice worker k8s upgrades

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
         default: true
       target_node:
-        description: 'Upgrade only the specified node. Select "all" to upgrade all CP nodes sequentially'
+        description: 'Upgrade only the specified node. Select "all" to upgrade all nodes sequentially'
         type: choice
         default: all
         options:
@@ -25,10 +25,13 @@ on:
           - shanghai-1
           - shanghai-2
           - shanghai-3
+          - golyat-1
+          - golyat-2
+          - golyat-3
 
 env:
-  NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104"}'
-  ALL_NODE_IPS: "192.168.10.102 192.168.10.103 192.168.10.104"
+  NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104","golyat-1":"192.168.10.101","golyat-2":"192.168.10.105","golyat-3":"192.168.10.106"}'
+  ALL_NODE_IPS: "192.168.10.102 192.168.10.103 192.168.10.104 192.168.10.101 192.168.10.105 192.168.10.106"
 
 jobs:
   pre-check:
@@ -592,10 +595,421 @@ jobs:
             ${DRY_RUN_FLAG} \
             -v
 
+  upgrade-worker-1:
+    name: Upgrade golyat-1
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'golyat-1')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::839695154978:role/GitHubActions_Ansible_Apply
+          aws-region: ap-northeast-1
+
+      - name: Setup Cloudflare credentials
+        run: |
+          CF_ID=""
+          for i in 1 2 3; do
+            CF_ID=$(aws ssm get-parameter --name "bastion-cf-access-client-id" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_ID"
+            sleep 5
+          done
+          if [ -z "$CF_ID" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_ID after 3 attempts"
+            exit 1
+          fi
+
+          CF_SECRET=""
+          for i in 1 2 3; do
+            CF_SECRET=$(aws ssm get-parameter --name "bastion-cf-access-client-secret" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_SECRET"
+            sleep 5
+          done
+          if [ -z "$CF_SECRET" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_SECRET"
+            exit 1
+          fi
+
+          echo "::add-mask::$CF_ID"
+          echo "::add-mask::$CF_SECRET"
+          echo "CF_ACCESS_CLIENT_ID=$CF_ID" >> "$GITHUB_ENV"
+          echo "CF_ACCESS_CLIENT_SECRET=$CF_SECRET" >> "$GITHUB_ENV"
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Install aqua
+        uses: aquaproj/aqua-installer@f6be09d5313d3af86e3ad665911c67b149a4498c # v4.0.4
+        with:
+          aqua_version: v2.60.1
+          working_directory: aqua
+
+      - name: Setup SSH config
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+
+          cat >> ~/.ssh/config << EOF
+          Host bastion
+            HostName bastion.b0xp.io
+            User ansible
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
+            StrictHostKeyChecking accept-new
+
+          Host ${NODE_IP}
+            HostName ${NODE_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+
+          Host ${CP_IP}
+            HostName ${CP_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+          EOF
+
+          chmod 600 ~/.ssh/config
+
+      - name: Verify SSH connectivity
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-1'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install dependencies
+        run: |
+          cd ansible
+          uv sync
+
+      - name: Upgrade golyat-1
+        run: |
+          cd ansible
+          source .venv/bin/activate
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--check"
+          fi
+          ansible-playbook \
+            -i inventories/production/hosts.yml \
+            playbooks/upgrade-k8s.yml \
+            --tags upgrade \
+            --limit golyat-1 \
+            -e "ansible_ssh_common_args=''" \
+            -e "kubernetes_upgrade_version=${K8S_VERSION}" \
+            -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
+            -e "crio_upgrade_version=${CRIO_VERSION}" \
+            -e "node_role=worker" \
+            ${DRY_RUN_FLAG} \
+            -v
+
+  upgrade-worker-2:
+    name: Upgrade golyat-2
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3, upgrade-worker-1]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (needs.upgrade-worker-1.result == 'success' || needs.upgrade-worker-1.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'golyat-2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::839695154978:role/GitHubActions_Ansible_Apply
+          aws-region: ap-northeast-1
+
+      - name: Setup Cloudflare credentials
+        run: |
+          CF_ID=""
+          for i in 1 2 3; do
+            CF_ID=$(aws ssm get-parameter --name "bastion-cf-access-client-id" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_ID"
+            sleep 5
+          done
+          if [ -z "$CF_ID" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_ID after 3 attempts"
+            exit 1
+          fi
+
+          CF_SECRET=""
+          for i in 1 2 3; do
+            CF_SECRET=$(aws ssm get-parameter --name "bastion-cf-access-client-secret" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_SECRET"
+            sleep 5
+          done
+          if [ -z "$CF_SECRET" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_SECRET"
+            exit 1
+          fi
+
+          echo "::add-mask::$CF_ID"
+          echo "::add-mask::$CF_SECRET"
+          echo "CF_ACCESS_CLIENT_ID=$CF_ID" >> "$GITHUB_ENV"
+          echo "CF_ACCESS_CLIENT_SECRET=$CF_SECRET" >> "$GITHUB_ENV"
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Install aqua
+        uses: aquaproj/aqua-installer@f6be09d5313d3af86e3ad665911c67b149a4498c # v4.0.4
+        with:
+          aqua_version: v2.60.1
+          working_directory: aqua
+
+      - name: Setup SSH config
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+
+          cat >> ~/.ssh/config << EOF
+          Host bastion
+            HostName bastion.b0xp.io
+            User ansible
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
+            StrictHostKeyChecking accept-new
+
+          Host ${NODE_IP}
+            HostName ${NODE_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+
+          Host ${CP_IP}
+            HostName ${CP_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+          EOF
+
+          chmod 600 ~/.ssh/config
+
+      - name: Verify SSH connectivity
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-2'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install dependencies
+        run: |
+          cd ansible
+          uv sync
+
+      - name: Upgrade golyat-2
+        run: |
+          cd ansible
+          source .venv/bin/activate
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--check"
+          fi
+          ansible-playbook \
+            -i inventories/production/hosts.yml \
+            playbooks/upgrade-k8s.yml \
+            --tags upgrade \
+            --limit golyat-2 \
+            -e "ansible_ssh_common_args=''" \
+            -e "kubernetes_upgrade_version=${K8S_VERSION}" \
+            -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
+            -e "crio_upgrade_version=${CRIO_VERSION}" \
+            -e "node_role=worker" \
+            ${DRY_RUN_FLAG} \
+            -v
+
+  upgrade-worker-3:
+    name: Upgrade golyat-3
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3, upgrade-worker-1, upgrade-worker-2]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (needs.upgrade-worker-1.result == 'success' || needs.upgrade-worker-1.result == 'skipped') && (needs.upgrade-worker-2.result == 'success' || needs.upgrade-worker-2.result == 'skipped') && (inputs.target_node == 'all' || inputs.target_node == 'golyat-3')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      K8S_VERSION: ${{ inputs.kubernetes_version }}
+      K8S_PACKAGE: ${{ inputs.kubernetes_package }}
+      CRIO_VERSION: ${{ inputs.crio_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::839695154978:role/GitHubActions_Ansible_Apply
+          aws-region: ap-northeast-1
+
+      - name: Setup Cloudflare credentials
+        run: |
+          CF_ID=""
+          for i in 1 2 3; do
+            CF_ID=$(aws ssm get-parameter --name "bastion-cf-access-client-id" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_ID"
+            sleep 5
+          done
+          if [ -z "$CF_ID" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_ID after 3 attempts"
+            exit 1
+          fi
+
+          CF_SECRET=""
+          for i in 1 2 3; do
+            CF_SECRET=$(aws ssm get-parameter --name "bastion-cf-access-client-secret" --with-decryption --query "Parameter.Value" --output text) && break
+            echo "Retry $i: Failed to get CF_ACCESS_CLIENT_SECRET"
+            sleep 5
+          done
+          if [ -z "$CF_SECRET" ]; then
+            echo "::error::Failed to retrieve CF_ACCESS_CLIENT_SECRET"
+            exit 1
+          fi
+
+          echo "::add-mask::$CF_ID"
+          echo "::add-mask::$CF_SECRET"
+          echo "CF_ACCESS_CLIENT_ID=$CF_ID" >> "$GITHUB_ENV"
+          echo "CF_ACCESS_CLIENT_SECRET=$CF_SECRET" >> "$GITHUB_ENV"
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Install aqua
+        uses: aquaproj/aqua-installer@f6be09d5313d3af86e3ad665911c67b149a4498c # v4.0.4
+        with:
+          aqua_version: v2.60.1
+          working_directory: aqua
+
+      - name: Setup SSH config
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+
+          cat >> ~/.ssh/config << EOF
+          Host bastion
+            HostName bastion.b0xp.io
+            User ansible
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
+            StrictHostKeyChecking accept-new
+
+          Host ${NODE_IP}
+            HostName ${NODE_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+
+          Host ${CP_IP}
+            HostName ${CP_IP}
+            User boxp
+            IdentityFile ~/.ssh/id_ed25519
+            ProxyJump bastion
+            StrictHostKeyChecking accept-new
+          EOF
+
+          chmod 600 ~/.ssh/config
+
+      - name: Verify SSH connectivity
+        run: |
+          NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-3'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install dependencies
+        run: |
+          cd ansible
+          uv sync
+
+      - name: Upgrade golyat-3
+        run: |
+          cd ansible
+          source .venv/bin/activate
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--check"
+          fi
+          ansible-playbook \
+            -i inventories/production/hosts.yml \
+            playbooks/upgrade-k8s.yml \
+            --tags upgrade \
+            --limit golyat-3 \
+            -e "ansible_ssh_common_args=''" \
+            -e "kubernetes_upgrade_version=${K8S_VERSION}" \
+            -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
+            -e "crio_upgrade_version=${CRIO_VERSION}" \
+            -e "node_role=worker" \
+            ${DRY_RUN_FLAG} \
+            -v
+
   post-check:
     name: Post-upgrade Validation
-    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3]
-    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-3.result == 'success')
+    needs: [pre-check, upgrade-cp-1, upgrade-cp-2, upgrade-cp-3, upgrade-worker-1, upgrade-worker-2, upgrade-worker-3]
+    if: always() && !cancelled() && needs.pre-check.result == 'success' && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-1.result == 'skipped') && (needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-2.result == 'skipped') && (needs.upgrade-cp-3.result == 'success' || needs.upgrade-cp-3.result == 'skipped') && (needs.upgrade-worker-1.result == 'success' || needs.upgrade-worker-1.result == 'skipped') && (needs.upgrade-worker-2.result == 'success' || needs.upgrade-worker-2.result == 'skipped') && (needs.upgrade-worker-3.result == 'success' || needs.upgrade-worker-3.result == 'skipped') && (needs.upgrade-cp-1.result == 'success' || needs.upgrade-cp-2.result == 'success' || needs.upgrade-cp-3.result == 'success' || needs.upgrade-worker-1.result == 'success' || needs.upgrade-worker-2.result == 'success' || needs.upgrade-worker-3.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -35,3 +35,37 @@ all:
         network_dns_servers:
           - "8.8.8.8"
           - "8.8.4.4"
+    workers:
+      hosts:
+        golyat-1:
+          ansible_host: 192.168.10.101
+          node_ip: 192.168.10.101
+        golyat-2:
+          ansible_host: 192.168.10.105
+          node_ip: 192.168.10.105
+        golyat-3:
+          ansible_host: 192.168.10.106
+          node_ip: 192.168.10.106
+      vars:
+        ansible_user: boxp
+        ansible_ssh_common_args: '-o ProxyCommand="cloudflared access ssh --hostname %h"'
+        ansible_python_interpreter: /usr/bin/python3
+
+        # Kubernetes configuration
+        kubernetes_version: "1.32"
+        kubernetes_package_version: "1.32.0-1.1"
+        crio_version: "1.32"
+
+        # Cluster configuration
+        cluster_vip: "192.168.10.99"
+        cluster_domain: "cluster.local"
+        cluster_dns: "10.96.0.10"
+
+        # Hardware configuration
+        hardware_type: "orange_pi_zero3"
+        architecture: "arm64"
+        # Network configuration
+        network_gateway: "192.168.10.1"
+        network_dns_servers:
+          - "8.8.8.8"
+          - "8.8.4.4"

--- a/ansible/playbooks/upgrade-k8s.yml
+++ b/ansible/playbooks/upgrade-k8s.yml
@@ -45,25 +45,38 @@
         node_role: control_plane
         is_first_control_plane: false
 
-# Upgrade worker nodes (Phase 3 で有効化。inventory に workers グループ追加が前提)
-# - name: Upgrade worker nodes
-#   hosts: workers
-#   serial: 1
-#   gather_facts: true
-#   tags: [upgrade]
-#   roles:
-#     - role: kubernetes_upgrade
-#       vars:
-#         node_role: worker
+# Upgrade worker nodes
+- name: Upgrade worker nodes
+  hosts: workers
+  serial: 1
+  gather_facts: true
+  tags: [upgrade]
+  roles:
+    - role: kubernetes_upgrade
+      vars:
+        node_role: worker
 
 # Post-upgrade cluster-wide health check
-- name: Post-upgrade cluster health check
+- name: Post-upgrade control-plane health check
   hosts: control_plane
   gather_facts: false
   tags: [health_check]
   tasks:
-    - name: Verify all nodes health
+    - name: Verify control-plane node health
       ansible.builtin.include_role:
         name: kubernetes_upgrade
         tasks_from: health_check.yml
+      tags: [health_check]
+
+- name: Post-upgrade worker health check
+  hosts: workers
+  gather_facts: false
+  tags: [health_check]
+  tasks:
+    - name: Verify worker node health
+      ansible.builtin.include_role:
+        name: kubernetes_upgrade
+        tasks_from: health_check.yml
+      vars:
+        node_role: worker
       tags: [health_check]

--- a/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for node to be Ready
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ health_check_kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: node_ready
   check_mode: false
@@ -10,11 +10,18 @@
   delay: "{{ upgrade_health_check_delay }}"
   changed_when: false
   become: true
+  delegate_to: "{{ health_check_delegate_host }}"
+  vars:
+    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_kubectl_api_server: >-
+      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      if node_role == 'worker' else kubectl_api_server }}
+    health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]
 
 - name: Verify kubelet version on node
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ health_check_kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{.status.nodeInfo.kubeletVersion}'
   register: node_kubelet_version
   check_mode: false
@@ -23,11 +30,18 @@
     - not ansible_check_mode
     - kubernetes_upgrade_version not in node_kubelet_version.stdout
   become: true
+  delegate_to: "{{ health_check_delegate_host }}"
+  vars:
+    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_kubectl_api_server: >-
+      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      if node_role == 'worker' else kubectl_api_server }}
+    health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]
 
 - name: Verify node conditions (no pressure)
   ansible.builtin.command: >
-    kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get node {{ inventory_hostname }}
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ health_check_kubectl_api_server_arg }} get node {{ inventory_hostname }}
     -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
   register: node_conditions
   check_mode: false
@@ -37,6 +51,13 @@
     'DiskPressure=True' in node_conditions.stdout or
     'PIDPressure=True' in node_conditions.stdout
   become: true
+  delegate_to: "{{ health_check_delegate_host }}"
+  vars:
+    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_kubectl_api_server: >-
+      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      if node_role == 'worker' else kubectl_api_server }}
+    health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]
 
 - name: Verify etcd cluster health (control plane only)

--- a/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
@@ -32,10 +32,21 @@
   tags: [pre_checks]
 
 - name: Verify all nodes are Ready
-  ansible.builtin.command: kubectl --kubeconfig={{ kubeconfig_path }} {{ kubectl_api_server_arg }} get nodes --no-headers
+  ansible.builtin.command: >
+    kubectl --kubeconfig={{ kubeconfig_path }} {{ pre_check_kubectl_api_server_arg }}
+    get nodes --no-headers
   register: node_status
   check_mode: false
   changed_when: false
-  failed_when: "'NotReady' in node_status.stdout"
+  failed_when: >
+    node_status.rc != 0 or
+    'NotReady' in node_status.stdout
   become: true
+  delegate_to: "{{ pre_check_delegate_host }}"
+  vars:
+    pre_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    pre_check_kubectl_api_server: >-
+      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      if node_role == 'worker' else kubectl_api_server }}
+    pre_check_kubectl_api_server_arg: "{{ '--server=' ~ pre_check_kubectl_api_server }}"
   tags: [pre_checks]

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
@@ -6,6 +6,7 @@
     --timeout={{ upgrade_drain_timeout }}s
   delegate_to: "{{ groups['control_plane'][0] }}"
   become: true
+  when: not ansible_check_mode
   changed_when: true
   tags: [upgrade]
 
@@ -18,6 +19,7 @@
     name: kubeadm
     selection: install
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Install target kubeadm version
@@ -26,6 +28,7 @@
     state: present
     allow_downgrade: false
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Hold kubeadm
@@ -33,11 +36,13 @@
     name: kubeadm
     selection: hold
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Run kubeadm upgrade node
   ansible.builtin.command: kubeadm upgrade node
   become: true
+  when: not ansible_check_mode
   changed_when: true
   tags: [upgrade]
 
@@ -51,18 +56,21 @@
     state: restarted
     daemon_reload: true
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Reboot worker node
   ansible.builtin.reboot:
     reboot_timeout: 300
   become: true
+  when: not ansible_check_mode
   tags: [upgrade]
 
 - name: Uncordon worker node
   ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} uncordon {{ inventory_hostname }}"
   delegate_to: "{{ groups['control_plane'][0] }}"
   become: true
+  when: not ansible_check_mode
   changed_when: true
   tags: [upgrade]
 

--- a/docs/project_docs/lolice-k8s-135-worker-upgrade/plan.md
+++ b/docs/project_docs/lolice-k8s-135-worker-upgrade/plan.md
@@ -1,0 +1,25 @@
+# lolice k8s 1.35 worker upgrade
+
+## Goal
+
+Enable the existing Kubernetes Upgrade workflow to upgrade lolice worker nodes to Kubernetes 1.35 one node at a time.
+
+## Scope
+
+- Add `golyat-1`, `golyat-2`, and `golyat-3` to the production Ansible inventory as worker nodes.
+- Enable the worker upgrade play in `playbooks/upgrade-k8s.yml`.
+- Ensure worker health checks use a control-plane kubeconfig instead of expecting `/etc/kubernetes/admin.conf` on workers.
+- Add worker targets to `.github/workflows/upgrade-k8s.yml`.
+- Keep etcd snapshots on the Longhorn PVC during upgrades; cleanup is a final Phase 5 task after all nodes are stable.
+
+## Execution policy
+
+- Run workflow dispatch with one explicit `target_node` per execution.
+- Verify the upgraded node is Ready and at the requested kubelet version before starting the next node.
+- Do not use the `all` target for this Phase 4 production rollout.
+
+## Validation
+
+- `ansible-playbook --syntax-check` for `playbooks/upgrade-k8s.yml`.
+- `uv run ansible-lint` for the touched playbook and role tasks.
+- `actionlint` / `ghalint run` for workflow changes.


### PR DESCRIPTION
## Summary

- Add `golyat-1`, `golyat-2`, and `golyat-3` as worker nodes in the production Ansible inventory.
- Enable worker-node execution in the Kubernetes upgrade playbook.
- Delegate worker pre-check and health-check kubectl calls to `shanghai-1`, so workers do not need `/etc/kubernetes/admin.conf`.
- Add worker targets to the Kubernetes Upgrade workflow.
- Add the project plan for this Phase 4 worker-upgrade change.

## Operation note

For the Phase 4 production rollout, run workflow dispatch with one explicit worker target at a time:

1. `target_node=golyat-1`
2. verify Ready / kubelet version / workload recovery
3. `target_node=golyat-2`
4. verify recovery
5. `target_node=golyat-3`

Do not use `target_node=all` for the production Phase 4 rollout.

## Validation

- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check`
- `cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/tasks/pre_checks.yml roles/kubernetes_upgrade/tasks/health_check.yml roles/kubernetes_upgrade/tasks/upgrade_worker.yml`
- `actionlint .github/workflows/upgrade-k8s.yml`
- `ghalint run .github/workflows/upgrade-k8s.yml`
- `cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --tags upgrade --limit golyat-1 -e "ansible_ssh_common_args=''" -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4 -e node_role=worker --check -v`
