### PR TITLE
Reuse existing etcd snapshot during k8s upgrades

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -189,7 +189,6 @@ jobs:
             -e "kubernetes_upgrade_version=${K8S_VERSION}" \
             -e "kubernetes_upgrade_package=${K8S_PACKAGE}" \
             -e "crio_upgrade_version=${CRIO_VERSION}" \
-            -e "etcd_snapshot_force=true" \
             -vv 2>&1 | tee /tmp/etcd-snapshot-ansible.log
 
       - name: Upload pre-check logs

--- a/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
@@ -165,6 +165,10 @@
               snapshot_path="${@: -1}"
               test -s "$snapshot_path"
               ;;
+            *"exec "*" sh -c "*"ls -1t "*"pre-upgrade-"*)
+              shell_command="${@: -1}"
+              bash -c "$shell_command"
+              ;;
             *"exec "*" sh -c "*"pre-upgrade-"*)
               echo "mock prune"
               ;;

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -26,6 +26,7 @@
     _etcd_snapshot_pod_path: "{{ etcd_snapshot_pod_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_remote_path: "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_needs_create: "{{ (etcd_snapshot_force | bool) or (_valid_existing_snapshots | length == 0) }}"
+    _etcd_snapshot_reused_from_pvc: false
   tags: [etcd_snapshot]
 
 - name: Reuse existing etcd snapshot for today
@@ -77,6 +78,39 @@
 - name: Set etcd snapshot store pod name
   ansible.builtin.set_fact:
     _etcd_snapshot_store_pod: "{{ etcd_snapshot_store_pod_result.stdout }}"
+  tags: [etcd_snapshot]
+
+- name: Find existing etcd snapshot in Longhorn PVC for today
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - exec
+      - "{{ _etcd_snapshot_store_pod }}"
+      - --
+      - sh
+      - -c
+      - >-
+        ls -1t {{ etcd_snapshot_store_mount_path | quote
+        }}/pre-upgrade-{{ ansible_facts['date_time']['date'] | replace('-', '')
+        }}*.db 2>/dev/null | head -n 1 || true
+  become: true
+  changed_when: false
+  register: existing_pvc_snapshot
+  when: not (etcd_snapshot_force | bool)
+  tags: [etcd_snapshot]
+
+- name: Reuse existing etcd snapshot in Longhorn PVC for today
+  ansible.builtin.set_fact:
+    _etcd_snapshot_filename: "{{ existing_pvc_snapshot.stdout | basename }}"
+    _etcd_snapshot_needs_create: false
+    _etcd_snapshot_reused_from_pvc: true
+  when:
+    - not (etcd_snapshot_force | bool)
+    - existing_pvc_snapshot.stdout | default('') | length > 0
   tags: [etcd_snapshot]
 
 - name: Take etcd snapshot inside etcd pod
@@ -166,6 +200,25 @@
   become: true
   changed_when: false
   when: _etcd_snapshot_needs_create | bool
+  tags: [etcd_snapshot]
+
+- name: Verify reused etcd snapshot exists in Longhorn PVC
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - "--kubeconfig={{ kubeconfig_path }}"
+      - "{{ kubectl_api_server_arg }}"
+      - -n
+      - "{{ etcd_snapshot_store_namespace }}"
+      - exec
+      - "{{ _etcd_snapshot_store_pod }}"
+      - --
+      - test
+      - -s
+      - "{{ etcd_snapshot_store_mount_path }}/{{ _etcd_snapshot_filename }}"
+  become: true
+  changed_when: false
+  when: _etcd_snapshot_reused_from_pvc | bool
   tags: [etcd_snapshot]
 
 - name: Prune old etcd snapshots from Longhorn PVC

--- a/docs/project_docs/lolice-k8s-135-reuse-etcd-snapshot/plan.md
+++ b/docs/project_docs/lolice-k8s-135-reuse-etcd-snapshot/plan.md
@@ -1,0 +1,22 @@
+# lolice k8s 1.35 reuse etcd snapshot plan
+
+## Goal
+
+- Reuse an existing same-day etcd snapshot in the `etcd-snapshots` Longhorn PVC during Kubernetes upgrade runs.
+- Avoid taking a new etcd snapshot for every worker node when a valid upgrade snapshot already exists.
+- Keep the existing behavior of creating a new snapshot when no same-day PVC snapshot exists.
+
+## Scope
+
+- Remove forced `etcd_snapshot_force=true` from the Kubernetes Upgrade workflow production snapshot step.
+- Teach `kubernetes_upgrade` to look for a same-day `pre-upgrade-*.db` in the Longhorn PVC and skip new snapshot creation when one exists.
+- Verify reused PVC snapshots are non-empty before allowing the upgrade workflow to continue.
+
+## Validation
+
+- `cd ansible && uv run ansible-lint`
+- `actionlint .github/workflows/upgrade-k8s.yml`
+- `ghalint run .github/workflows/upgrade-k8s.yml`
+- syntax-check `playbooks/upgrade-k8s.yml` with v1.35 inputs
+- `cd ansible/roles/kubernetes_upgrade && PATH=../../.venv/bin:$PATH ../../.venv/bin/molecule test`
+- production `--tags etcd_snapshot` dry validation: reused existing PVC snapshot and skipped new etcd snapshot creation


### PR DESCRIPTION
## Summary
- reuse an existing same-day etcd snapshot in the Longhorn PVC during k8s upgrade runs
- stop forcing a fresh etcd snapshot from the GitHub Actions production precheck
- verify reused PVC snapshots are non-empty and update Molecule mocks

## Validation
- cd ansible && uv run ansible-lint
- actionlint .github/workflows/upgrade-k8s.yml
- ghalint run .github/workflows/upgrade-k8s.yml
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4
- cd ansible/roles/kubernetes_upgrade && PATH=../../.venv/bin:/home/boxp/.rbenv/bin:/home/boxp/go/bin:/home/boxp/.nodebrew/node/v24.13.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/boxp/.codex/tmp/arg0/codex-arg0jelRUq:/Users/keitaro.takeuchi/.rd/bin:/home/boxp/.nodebrew/current/bin:/home/boxp/.local/share/gem/ruby/3.0.0/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/boxp/bin:/home/boxp/.local/bin:/home/boxp/go/bin:/opt/android-sdk/tools:/opt/android-sdk/platform-tools:/usr/share/git/diff-highlight:./node_modules/.bin:/opt/marp:/opt/webstorm/bin:/home/boxp/.yarn/bin:/home/boxp/.config/yarn/global/node_modules/.bin:/opt/Jasper:/opt/Postman/Postman:/home/boxp/.cache/dein/repos/github.com/liquidz/vim-iced/bin:/home/boxp/Downloads/google-cloud-sdk/bin:/home/boxp/.rbenv/bin:/home/boxp/go/bin:/Users/keitaro.takeuchi/.rd/bin:/home/boxp/.nodebrew/current/bin:/home/boxp/.local/share/gem/ruby/3.0.0/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/boxp/bin:/home/boxp/.local/bin:/home/boxp/go/bin:/opt/android-sdk/tools:/opt/android-sdk/platform-tools:/usr/share/git/diff-highlight:./node_modules/.bin:/opt/marp:/opt/webstorm/bin:/home/boxp/.yarn/bin:/home/boxp/.config/yarn/global/node_modules/.bin:/opt/Jasper:/opt/Postman/Postman:/home/boxp/.cache/dein/repos/github.com/liquidz/vim-iced/bin:/home/boxp/Downloads/google-cloud-sdk/bin:/home/boxp/.rbenv/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/d/Program_Files/PlasticSCM/server:/mnt/d/Program_Files/PlasticSCM/client:/mnt/c/Program Files/Alacritty/:/mnt/c/Python313/Scripts/:/mnt/c/Python313/:/mnt/g/Programs/cursor/resources/app/bin:/mnt/g/Programs/CUDA/DEV/bin:/mnt/g/Programs/CUDA/DEV/libnvvp:/mnt/g/CUDA_Development/bin:/mnt/g/CUDA_Development/libnvvp:/mnt/c/Program Files (x86)/Razer/ChromaBroadcast/bin:/mnt/c/Program Files/Razer/ChromaBroadcast/bin:/mnt/c/Program Files (x86)/Common Files/Oracle/Java/javapath:/mnt/c/Program Files/Oculus/Support/oculus-runtime:/mnt/c/Program Files (x86)/Razer Chroma SDK/bin:/mnt/c/Program Files/Razer Chroma SDK/bin:/mnt/c/ProgramData/Oracle/Java/javapath:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files (x86)/GtkSharp/2.12/bin:/mnt/c/WINDOWS/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps:/mnt/c/Program Files (x86)/Nodist/bin:/mnt/c/Program Files (x86)/Intel/Intel(R) Management Engine Components/DAL:/mnt/c/Program Files/Intel/Intel(R) Management Engine Components:/mnt/c/Program Files/NVIDIA Corporation/NVIDIA App/NvDLISR:/mnt/e/Git/cmd:/mnt/d/Program_Files/nodejs/:/mnt/c/ProgramData/chocolatey/bin:/mnt/d/Program_Files/WezTerm:/mnt/c/Program Files/Cloudflare/Cloudflare WARP/:/mnt/g/Programs/Python/Scripts/:/mnt/g/Programs/Python/:/mnt/c/Users/BOXP/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/BOXP/Documents/OpenSSH-Win32:/mnt/c/Users/BOXP/bin:/mnt/c/Users/BOXP/AppData/Local/Google/Cloud SDK/google-cloud-sdk/bin:/mnt/d/ドキュメント/platform-tools:/mnt/c/P:/mnt/c/Program Files (x86)/FAHClient:/mnt/c/Users/BOXP/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/BOXP/AppData/Local/gitkraken/bin:/mnt/c/Users/BOXP/AppData/Local/GitHubDesktop/bin:/mnt/c/Users/BOXP/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/BOXP/.dotnet/tools:/mnt/g/cmdline-tools/bin:/mnt/g/Programs/cursor/resources/app/bin:/mnt/c/Users/BOXP/AppData/Roaming/npm:/mnt/c/Users/BOXP/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Obsidian.app/Contents/MacOS:/Applications/Obsidian.app/Contents/MacOS ../../.venv/bin/molecule test
- production --tags etcd_snapshot validation reused existing PVC snapshot and skipped new etcd snapshot creation