### PR TITLE
Use secondary control plane for worker drains

### DIFF
--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -16,6 +16,7 @@ upgrade_health_check_delay: 10       # seconds
 upgrade_uncordon_retries: 18
 upgrade_uncordon_delay: 10           # seconds
 kubeadm_upgrade_etcd: false          # skip kubeadm's etcd static pod phase unless explicitly enabled
+kubernetes_worker_drain_delegate: "{{ groups['control_plane'][1] | default(groups['control_plane'][0]) }}"
 
 # etcd snapshot
 etcd_snapshot_dir: /var/lib/etcd-snapshots

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
@@ -4,7 +4,7 @@
     kubectl --kubeconfig={{ kubeconfig_path }} drain {{ inventory_hostname }}
     --ignore-daemonsets --delete-emptydir-data
     --timeout={{ upgrade_drain_timeout }}s
-  delegate_to: "{{ groups['control_plane'][0] }}"
+  delegate_to: "{{ kubernetes_worker_drain_delegate }}"
   become: true
   when: not ansible_check_mode
   changed_when: true
@@ -68,7 +68,7 @@
 
 - name: Uncordon worker node
   ansible.builtin.command: "kubectl --kubeconfig={{ kubeconfig_path }} uncordon {{ inventory_hostname }}"
-  delegate_to: "{{ groups['control_plane'][0] }}"
+  delegate_to: "{{ kubernetes_worker_drain_delegate }}"
   become: true
   when: not ansible_check_mode
   changed_when: true

--- a/docs/project_docs/lolice-k8s-135-worker-drain-delegate/plan.md
+++ b/docs/project_docs/lolice-k8s-135-worker-drain-delegate/plan.md
@@ -1,0 +1,18 @@
+# lolice k8s 1.35 worker drain delegate plan
+
+## Goal
+
+- Avoid repeating the `golyat-2` upgrade failure where worker drain delegated to `shanghai-1` became unreachable.
+- Keep worker upgrades one node at a time.
+- Leave control-plane upgrade behavior unchanged.
+
+## Scope
+
+- Add `kubernetes_worker_drain_delegate` with a default of the second control-plane node when available.
+- Use that delegate for worker drain and uncordon tasks.
+- Keep the value overrideable for future maintenance runs.
+
+## Validation
+
+- `cd ansible && uv run ansible-lint`
+- syntax-check `playbooks/upgrade-k8s.yml` with v1.35 inputs


### PR DESCRIPTION
## Summary
- add a worker drain delegate variable that defaults to the second control-plane node when present
- use that delegate for worker drain and uncordon during k8s upgrades
- document the fix for the golyat-2 drain delegate failure

## Validation
- cd ansible && uv run ansible-lint
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check -e kubernetes_upgrade_version=1.35.6 -e kubernetes_upgrade_package=1.35.6-1.1 -e crio_upgrade_version=1.35.4