### PR TITLE
Align worker upgrade SSH delegate

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -663,7 +663,7 @@ jobs:
       - name: Setup SSH config
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
           cat >> ~/.ssh/config << EOF
           Host bastion
@@ -693,9 +693,9 @@ jobs:
       - name: Verify SSH connectivity
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-1'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -800,7 +800,7 @@ jobs:
       - name: Setup SSH config
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
           cat >> ~/.ssh/config << EOF
           Host bastion
@@ -830,9 +830,9 @@ jobs:
       - name: Verify SSH connectivity
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-2'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -937,7 +937,7 @@ jobs:
       - name: Setup SSH config
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
           cat >> ~/.ssh/config << EOF
           Host bastion
@@ -967,9 +967,9 @@ jobs:
       - name: Verify SSH connectivity
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-1"')
+          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-3'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to shanghai-1'"
+          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docs/project_docs/lolice-k8s-135-worker-ssh-delegate/plan.md
+++ b/docs/project_docs/lolice-k8s-135-worker-ssh-delegate/plan.md
@@ -1,0 +1,18 @@
+# lolice k8s 1.35 worker SSH delegate plan
+
+## Goal
+
+- Ensure worker upgrade jobs can SSH to the control-plane host used for worker drain and uncordon.
+- Keep worker upgrades one node at a time.
+- Avoid changing package upgrade behavior.
+
+## Scope
+
+- Align worker job SSH config with `kubernetes_worker_drain_delegate`.
+- Use `shanghai-2` as the worker drain delegate host in worker job SSH setup and verification.
+- Apply the same SSH setup to all worker jobs.
+
+## Validation
+
+- `actionlint .github/workflows/upgrade-k8s.yml`
+- `ghalint run .github/workflows/upgrade-k8s.yml`


### PR DESCRIPTION
## Summary
- align worker upgrade job SSH config with the worker drain delegate
- verify SSH to shanghai-2 in worker jobs before running Ansible
- document the fix for the golyat-2 delegate SSH timeout

## Validation
- actionlint .github/workflows/upgrade-k8s.yml
- ghalint run .github/workflows/upgrade-k8s.yml