### PR TITLE
Fix worker upgrade precheck delegate

### DIFF
--- a/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/pre_checks.yml
@@ -44,9 +44,9 @@
   become: true
   delegate_to: "{{ pre_check_delegate_host }}"
   vars:
-    pre_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    pre_check_delegate_host: "{{ kubernetes_worker_drain_delegate if node_role == 'worker' else inventory_hostname }}"
     pre_check_kubectl_api_server: >-
-      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      {{ 'https://' ~ hostvars[pre_check_delegate_host].node_ip ~ ':6443'
       if node_role == 'worker' else kubectl_api_server }}
     pre_check_kubectl_api_server_arg: "{{ '--server=' ~ pre_check_kubectl_api_server }}"
   tags: [pre_checks]

--- a/docs/project_docs/lolice-k8s-135-worker-precheck-delegate/plan.md
+++ b/docs/project_docs/lolice-k8s-135-worker-precheck-delegate/plan.md
@@ -1,0 +1,22 @@
+# lolice k8s 1.35 worker precheck delegate fix
+
+## 背景
+
+`Kubernetes Upgrade` workflow の `target_node=golyat-2` run `27923067729` で、pre-upgrade validation と snapshot は成功したが、worker upgrade job 内の `pre_checks` が失敗した。
+
+失敗箇所は `Verify all nodes are Ready` で、worker drain delegate は `shanghai-2` に変更済みだった一方、この precheck はまだ `shanghai-1` へ delegate していた。worker job の SSH config は `golyat-2` と `shanghai-2` を前提にしているため、`shanghai-1` への direct SSH が timeout した。
+
+## 方針
+
+- worker upgrade job 内の `pre_checks` も `kubernetes_worker_drain_delegate` を使う。
+- worker precheck の API server も delegate 先 control plane の `node_ip:6443` に合わせる。
+- control plane upgrade の precheck は従来どおり対象 node 自身を使う。
+
+## 検証
+
+- `ansible-lint` で対象 playbook / role task を検証する。
+- `actionlint` / `ghalint` は workflow の変更がないため、必要に応じて既存 CI に任せる。
+
+## 運用
+
+main merge 後、`target_node=golyat-2` / `dry_run=false` / version input 明示で再実行する。`golyat-2` が Ready かつ `v1.35.6` / CRI-O `1.35.4` で復帰するまで、`golyat-3` は開始しない。


### PR DESCRIPTION
## Summary
- make worker upgrade pre_checks use kubernetes_worker_drain_delegate instead of hardcoding the first control plane
- point worker precheck kubectl API server at the same delegate control plane
- add project plan doc for the golyat-2 retry blocker

## Context
Kubernetes Upgrade run 27923067729 passed pre-upgrade validation and PVC snapshot handling, then failed inside the golyat-2 upgrade job because Verify all nodes are Ready still delegated to shanghai-1. The worker job SSH config now prepares golyat-2 and shanghai-2, so this must use the same delegate as worker drain/uncordon.

## Tests
- cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/tasks/pre_checks.yml roles/kubernetes_upgrade/tasks/upgrade_worker.yml
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check --limit golyat-2 -e "node_role=worker" -e "kubernetes_upgrade_version=1.35.6" -e "kubernetes_upgrade_package=1.35.6-1.1" -e "crio_upgrade_version=1.35.4"

## Notes
A local live pre_checks run was attempted but could not reach golyat-2 over the local cloudflared SSH path before executing checks. The GitHub Actions run already verified worker SSH connectivity, so the retry should be performed from GHA after merge.