### PR TITLE
Extend worker drain timeout for Longhorn

### DIFF
--- a/ansible/roles/kubernetes_upgrade/defaults/main.yml
+++ b/ansible/roles/kubernetes_upgrade/defaults/main.yml
@@ -11,6 +11,7 @@ crio_previous_version: ""
 
 # Upgrade behavior
 upgrade_drain_timeout: 300           # seconds
+kubernetes_worker_drain_timeout: 1800
 upgrade_health_check_retries: 30
 upgrade_health_check_delay: 10       # seconds
 upgrade_uncordon_retries: 18

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
@@ -3,7 +3,7 @@
   ansible.builtin.command: >
     kubectl --kubeconfig={{ kubeconfig_path }} drain {{ inventory_hostname }}
     --ignore-daemonsets --delete-emptydir-data
-    --timeout={{ upgrade_drain_timeout }}s
+    --timeout={{ kubernetes_worker_drain_timeout }}s
   delegate_to: "{{ kubernetes_worker_drain_delegate }}"
   become: true
   when: not ansible_check_mode

--- a/docs/project_docs/lolice-k8s-135-worker-longhorn-drain/plan.md
+++ b/docs/project_docs/lolice-k8s-135-worker-longhorn-drain/plan.md
@@ -1,0 +1,24 @@
+# lolice k8s 1.35 worker Longhorn drain fix
+
+## 背景
+
+`Kubernetes Upgrade` workflow の `target_node=golyat-2` run `27924328237` は、pre-upgrade validation と etcd snapshot reuse には成功したが、worker drain で失敗した。
+
+`longhorn-system/instance-manager-fbc98d39ab24982baed6584271104234` の PDB が `disruptionsAllowed=0` で、`kubectl drain` が 5分 timeout に到達した。`golyat-2` には `prod-hitohub/tikv-tidb-cluster-tikv-0` の Longhorn single replica があり、現行の Longhorn `node-drain-policy=block-if-contains-last-replica` では drain を止めるのが正しい。
+
+## 方針
+
+- worker drain timeout を control plane と分離する。
+- worker drain は Longhorn replica eviction / rebuild を待てるように `1800s` を使う。
+- Longhorn `node-drain-policy` の一時切り替えは cluster operation として扱う。
+  - upgrade 中: `block-for-eviction-if-contains-last-replica`
+  - worker upgrade 完了後: `block-if-contains-last-replica`
+
+## 検証
+
+- `ansible-lint` で worker drain task と role defaults を検証する。
+- `ansible-playbook --syntax-check` で upgrade playbook を検証する。
+
+## 運用
+
+main merge 後、Longhorn setting を計画メンテナンス用に一時変更してから `golyat-2` を再実行する。`golyat-2` が Ready かつ `v1.35.6` / CRI-O `1.35.4` で復帰するまで、`golyat-3` は開始しない。


### PR DESCRIPTION
## Summary
- add a worker-specific drain timeout for Kubernetes upgrades
- use 1800s for worker drains so Longhorn planned-maintenance replica eviction/rebuild can complete
- document the Longhorn drain failure and operational policy in the project plan

## Context
Kubernetes Upgrade run 27924328237 failed before package changes while draining golyat-2. Longhorn blocked eviction of instance-manager-fbc98d39ab24982baed6584271104234 because golyat-2 contains the last replica for prod-hitohub/tikv-tidb-cluster-tikv-0 under node-drain-policy=block-if-contains-last-replica.

For the retry, Longhorn node-drain-policy should be changed temporarily to block-for-eviction-if-contains-last-replica during planned worker maintenance, then restored to block-if-contains-last-replica after worker upgrades finish.

## Tests
- cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/defaults/main.yml roles/kubernetes_upgrade/tasks/upgrade_worker.yml
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check --limit golyat-2 -e "node_role=worker" -e "kubernetes_upgrade_version=1.35.6" -e "kubernetes_upgrade_package=1.35.6-1.1" -e "crio_upgrade_version=1.35.4"