### PR TITLE
Fix worker upgrade health check delegate

### DIFF
--- a/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/health_check.yml
@@ -12,9 +12,9 @@
   become: true
   delegate_to: "{{ health_check_delegate_host }}"
   vars:
-    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_delegate_host: "{{ kubernetes_worker_drain_delegate if node_role == 'worker' else inventory_hostname }}"
     health_check_kubectl_api_server: >-
-      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      {{ 'https://' ~ hostvars[health_check_delegate_host].node_ip ~ ':6443'
       if node_role == 'worker' else kubectl_api_server }}
     health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]
@@ -32,9 +32,9 @@
   become: true
   delegate_to: "{{ health_check_delegate_host }}"
   vars:
-    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_delegate_host: "{{ kubernetes_worker_drain_delegate if node_role == 'worker' else inventory_hostname }}"
     health_check_kubectl_api_server: >-
-      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      {{ 'https://' ~ hostvars[health_check_delegate_host].node_ip ~ ':6443'
       if node_role == 'worker' else kubectl_api_server }}
     health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]
@@ -53,9 +53,9 @@
   become: true
   delegate_to: "{{ health_check_delegate_host }}"
   vars:
-    health_check_delegate_host: "{{ groups['control_plane'][0] if node_role == 'worker' else inventory_hostname }}"
+    health_check_delegate_host: "{{ kubernetes_worker_drain_delegate if node_role == 'worker' else inventory_hostname }}"
     health_check_kubectl_api_server: >-
-      {{ 'https://' ~ hostvars[groups['control_plane'][0]].node_ip ~ ':6443'
+      {{ 'https://' ~ hostvars[health_check_delegate_host].node_ip ~ ':6443'
       if node_role == 'worker' else kubectl_api_server }}
     health_check_kubectl_api_server_arg: "{{ '--server=' ~ health_check_kubectl_api_server }}"
   tags: [health_check]

--- a/docs/project_docs/lolice-k8s-135-health-check-delegate/plan.md
+++ b/docs/project_docs/lolice-k8s-135-health-check-delegate/plan.md
@@ -1,0 +1,16 @@
+# lolice k8s 1.35 health check delegate fix
+
+## Context
+
+`golyat-2` upgraded to Kubernetes v1.35.6 and CRI-O 1.35.4, but the GitHub Actions run failed during the worker health check because `health_check.yml` still delegated worker checks to `groups['control_plane'][0]` (`shanghai-1`). Worker drain and pre-checks already use `kubernetes_worker_drain_delegate`, which currently resolves to `shanghai-2` and is reachable from GitHub Actions.
+
+## Plan
+
+1. Change worker health checks to delegate through `kubernetes_worker_drain_delegate`.
+2. Use the selected delegate host's API server when checking worker node readiness, kubelet version, and pressure conditions.
+3. Validate the playbook syntax and ansible-lint for the touched role files.
+4. Merge after CI passes, wait for main apply, then continue with one-node-at-a-time worker upgrades.
+
+## Rollback
+
+Revert the PR. The change only affects where worker health-check `kubectl` commands are executed from.


### PR DESCRIPTION
## Summary
- delegate worker health checks through kubernetes_worker_drain_delegate instead of the first control-plane node
- use the selected delegate host API server for worker readiness/version/condition checks
- add the required project plan document

## Validation
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check --limit golyat-2 -e "node_role=worker" -e "kubernetes_upgrade_version=1.35.6" -e "kubernetes_upgrade_package=1.35.6-1.1" -e "crio_upgrade_version=1.35.4"
- cd ansible && uv run ansible-lint playbooks/upgrade-k8s.yml roles/kubernetes_upgrade/tasks/health_check.yml roles/kubernetes_upgrade/defaults/main.yml