### PR TITLE
Align lolice k8s baseline to 1.35

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -18,9 +18,9 @@ all:
         ansible_python_interpreter: /usr/bin/python3
 
         # Kubernetes configuration
-        kubernetes_version: "1.32"
-        kubernetes_package_version: "1.32.0-1.1"
-        crio_version: "1.32"
+        kubernetes_version: "1.35.6"
+        kubernetes_package_version: "1.35.6-1.1"
+        crio_version: "1.35.4"
 
         # Cluster configuration
         cluster_vip: "192.168.10.99"
@@ -52,9 +52,9 @@ all:
         ansible_python_interpreter: /usr/bin/python3
 
         # Kubernetes configuration
-        kubernetes_version: "1.32"
-        kubernetes_package_version: "1.32.0-1.1"
-        crio_version: "1.32"
+        kubernetes_version: "1.35.6"
+        kubernetes_package_version: "1.35.6-1.1"
+        crio_version: "1.35.4"
 
         # Cluster configuration
         cluster_vip: "192.168.10.99"

--- a/docs/project_docs/lolice-k8s-135-baseline/plan.md
+++ b/docs/project_docs/lolice-k8s-135-baseline/plan.md
@@ -1,0 +1,16 @@
+# lolice k8s 1.35 baseline
+
+## Context
+
+All lolice Kubernetes nodes have been upgraded to kubelet v1.35.6 and CRI-O 1.35.4. The production inventory still carries an older Kubernetes/CRI-O baseline, so regular Ansible apply should be aligned with the live cluster before closing the upgrade project.
+
+## Plan
+
+1. Update production inventory Kubernetes and CRI-O version variables to the live v1.35 baseline.
+2. Validate the inventory/playbooks with ansible-lint and syntax checks.
+3. Merge after CI passes and verify main Apply Ansible succeeds.
+4. After baseline apply succeeds, complete post-upgrade cleanup: restore maintenance settings, remove upgrade etcd snapshots from the Longhorn PVC, and update project notes.
+
+## Rollback
+
+Revert the PR if regular apply exposes an issue. The cluster is already running v1.35.6, so reverting only changes desired-state metadata and should not be used to downgrade nodes.


### PR DESCRIPTION
## Summary
- align production inventory Kubernetes baseline to 1.35.6 / 1.35.6-1.1
- align production inventory CRI-O baseline to 1.35.4
- add the required project plan document

## Validation
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/control-plane.yml --syntax-check
- cd ansible && uv run ansible-playbook -i inventories/production/hosts.yml playbooks/upgrade-k8s.yml --syntax-check --limit golyat-3 -e "node_role=worker" -e "kubernetes_upgrade_version=1.35.6" -e "kubernetes_upgrade_package=1.35.6-1.1" -e "crio_upgrade_version=1.35.4"
- cd ansible && uv run ansible-lint inventories/production/hosts.yml playbooks/control-plane.yml playbooks/upgrade-k8s.yml