### PR TITLE
Disable all-node k8s upgrade dispatch

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -17,11 +17,10 @@ on:
         type: boolean
         default: true
       target_node:
-        description: 'Upgrade only the specified node. Select "all" to upgrade all nodes sequentially'
+        description: 'Upgrade only the specified node. Run this workflow one node at a time'
         type: choice
-        default: all
+        default: shanghai-1
         options:
-          - all
           - shanghai-1
           - shanghai-2
           - shanghai-3
@@ -46,6 +45,13 @@ jobs:
       K8S_PACKAGE: ${{ inputs.kubernetes_package }}
       CRIO_VERSION: ${{ inputs.crio_version }}
     steps:
+      - name: Validate per-node execution
+        run: |
+          if [ "${{ inputs.target_node }}" = "all" ]; then
+            echo "::error::target_node=all is disabled. Run this workflow once per node and verify cluster health before continuing."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/docs/project_docs/lolice-k8s-136-upgrade-guard/plan.md
+++ b/docs/project_docs/lolice-k8s-136-upgrade-guard/plan.md
@@ -1,0 +1,24 @@
+# lolice k8s 1.36 upgrade guard
+
+## 背景
+
+lolice cluster を Kubernetes 1.36 系へ上げる前に、`Kubernetes Upgrade` workflow の本番実行が control plane / worker をまとめて進めないようにする。
+
+1.35 upgrade では workflow の job dependency は存在していたが、運用としては各 node の Ready、static pods、etcd health、Longhorn / workload 回復を確認してから次の node に進む必要がある。`target_node=all` が選べる状態だと、この gate を operator が明示的に挟まない事故が起きやすい。
+
+## 方針
+
+- `workflow_dispatch` の `target_node` choices から `all` を外す。
+- default は `shanghai-1` にする。
+- API や古い UI state から `target_node=all` が渡されても、pre-check の先頭で fail させる。
+- 既存の per-node job 構成は残し、1 node ずつの workflow_dispatch だけを許可する。
+
+## 検証
+
+- `actionlint`
+- `ghalint run`
+- PR CI
+
+## Rollback
+
+この変更自体は workflow の選択肢と guard のみなので、問題があれば PR revert で戻す。


### PR DESCRIPTION
## Summary
- remove target_node=all from the Kubernetes Upgrade workflow dispatch choices
- add an explicit guard so target_node=all fails before any upgrade work
- add project plan documentation

## Tests
- actionlint .github/workflows/upgrade-k8s.yml
- ghalint run
- git diff --check