### PR TITLE
Fix etcd snapshot PVC gate

### DIFF
--- a/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
+++ b/ansible/roles/kubernetes_upgrade/molecule/default/prepare.yml
@@ -80,6 +80,20 @@
         - /etc/kubernetes/pki/etcd/healthcheck-client.key
       become: true
 
+    - name: Create mock host etcd snapshot directory
+      ansible.builtin.file:
+        path: /var/lib/etcd-snapshots
+        state: directory
+        mode: '0700'
+      become: true
+
+    - name: Create pre-existing host-only etcd snapshot
+      ansible.builtin.copy:
+        dest: "/var/lib/etcd-snapshots/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
+        content: "host-only mock snapshot"
+        mode: '0600'
+      become: true
+
     - name: Create mock kubeconfig file
       ansible.builtin.copy:
         dest: /etc/kubernetes/admin.conf

--- a/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/etcd_snapshot.yml
@@ -7,35 +7,13 @@
   become: true
   tags: [etcd_snapshot]
 
-- name: Check if etcd snapshot already exists for today
-  ansible.builtin.find:
-    paths: "{{ etcd_snapshot_dir }}"
-    patterns: "pre-upgrade-{{ ansible_facts['date_time']['date'] | replace('-', '') }}*.db"
-  become: true
-  register: existing_snapshots
-  tags: [etcd_snapshot]
-
-- name: Set valid existing etcd snapshots
-  ansible.builtin.set_fact:
-    _valid_existing_snapshots: "{{ existing_snapshots.files | selectattr('size', 'gt', 0) | list }}"
-  tags: [etcd_snapshot]
-
 - name: Set etcd snapshot paths
   ansible.builtin.set_fact:
     _etcd_snapshot_filename: "pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_pod_path: "{{ etcd_snapshot_pod_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
     _etcd_snapshot_remote_path: "{{ etcd_snapshot_dir }}/pre-upgrade-{{ ansible_facts['date_time']['iso8601_basic_short'] }}.db"
-    _etcd_snapshot_needs_create: "{{ (etcd_snapshot_force | bool) or (_valid_existing_snapshots | length == 0) }}"
+    _etcd_snapshot_needs_create: true
     _etcd_snapshot_reused_from_pvc: false
-  tags: [etcd_snapshot]
-
-- name: Reuse existing etcd snapshot for today
-  ansible.builtin.set_fact:
-    _etcd_snapshot_remote_path: "{{ (_valid_existing_snapshots | sort(attribute='mtime') | last).path }}"
-    _etcd_snapshot_filename: "{{ (_valid_existing_snapshots | sort(attribute='mtime') | last).path | basename }}"
-  when:
-    - not (etcd_snapshot_force | bool)
-    - _valid_existing_snapshots | length > 0
   tags: [etcd_snapshot]
 
 - name: Wait for etcd snapshot store pod
@@ -183,7 +161,7 @@
   when: _etcd_snapshot_needs_create | bool
   tags: [etcd_snapshot]
 
-- name: Verify etcd snapshot exists in Longhorn PVC
+- name: Verify selected etcd snapshot exists in Longhorn PVC
   ansible.builtin.command:
     argv:
       - kubectl
@@ -199,26 +177,6 @@
       - "{{ etcd_snapshot_store_mount_path }}/{{ _etcd_snapshot_filename }}"
   become: true
   changed_when: false
-  when: _etcd_snapshot_needs_create | bool
-  tags: [etcd_snapshot]
-
-- name: Verify reused etcd snapshot exists in Longhorn PVC
-  ansible.builtin.command:
-    argv:
-      - kubectl
-      - "--kubeconfig={{ kubeconfig_path }}"
-      - "{{ kubectl_api_server_arg }}"
-      - -n
-      - "{{ etcd_snapshot_store_namespace }}"
-      - exec
-      - "{{ _etcd_snapshot_store_pod }}"
-      - --
-      - test
-      - -s
-      - "{{ etcd_snapshot_store_mount_path }}/{{ _etcd_snapshot_filename }}"
-  become: true
-  changed_when: false
-  when: _etcd_snapshot_reused_from_pvc | bool
   tags: [etcd_snapshot]
 
 - name: Prune old etcd snapshots from Longhorn PVC

--- a/docs/project_docs/lolice-k8s-136-snapshot-gate-fix/plan.md
+++ b/docs/project_docs/lolice-k8s-136-snapshot-gate-fix/plan.md
@@ -1,0 +1,21 @@
+# lolice k8s 1.36 snapshot gate fix plan
+
+## Context
+
+The `shanghai-1` production run for the 1.36 upgrade succeeded, but the follow-up PVC check showed zero `pre-upgrade-*.db` files in the `etcd-snapshots` Longhorn PVC.
+
+The snapshot role could skip new snapshot creation when a same-day host-side file existed under `/var/lib/etcd-snapshots`, even if the Longhorn PVC had no snapshot. That lets the upgrade gate pass without the expected PVC backup.
+
+## Plan
+
+1. Treat the Longhorn PVC as the authoritative reusable snapshot location.
+2. Stop using host-only existing snapshots as a reason to skip new snapshot creation.
+3. Reuse a same-day PVC snapshot only when it exists in the snapshot store pod.
+4. Always verify the selected PVC snapshot is non-empty before allowing the upgrade workflow to continue.
+5. Add a Molecule fixture with a host-only snapshot so the regression is covered.
+
+## Validation
+
+- Run Ansible lint on the changed role and Molecule files.
+- Run the `kubernetes_upgrade` Molecule scenario if the local environment supports it.
+- After merge, rerun the production snapshot gate for the next node and verify the PVC has a non-empty `pre-upgrade-*.db` before continuing the 1.36 upgrade.


### PR DESCRIPTION
## Summary
- stop treating host-only same-day etcd snapshots as satisfying the upgrade snapshot gate
- reuse only snapshots found in the Longhorn PVC snapshot store
- always verify the selected PVC snapshot is non-empty before continuing
- add a Molecule fixture for the host-only snapshot regression

## Context
During the lolice Kubernetes 1.36 production run for `shanghai-1`, the workflow succeeded but the `etcd-snapshots` PVC had `count=0` for `pre-upgrade-*.db`. The role could skip creation because a host-side `/var/lib/etcd-snapshots` file existed, even though the project backup policy requires the PVC snapshot.

## Validation
- `cd ansible && uv run ansible-lint roles/kubernetes_upgrade/tasks/etcd_snapshot.yml roles/kubernetes_upgrade/molecule/default/prepare.yml roles/kubernetes_upgrade/molecule/default/verify.yml`
- `git diff --check`
- `cd ansible/roles/kubernetes_upgrade && uv run molecule test`

## Follow-up
After merge and main apply, rerun the production snapshot gate before starting `shanghai-2` and verify the PVC contains a non-empty `pre-upgrade-*.db`.
