### PR TITLE
Avoid Kubernetes baseline downgrades

### DIFF
--- a/ansible/roles/kubernetes_components/defaults/main.yml
+++ b/ansible/roles/kubernetes_components/defaults/main.yml
@@ -36,10 +36,15 @@ crio_version_apt_key_url: "https://download.opensuse.org/repositories/isv:/cri-o
 crio_version_apt_repository: "https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v{{ crio_repo_version }}/deb/"
 
 # Packages to install
+kubernetes_package_names:
+  - kubelet
+  - kubeadm
+  - kubectl
+
 kubernetes_packages:
-  - kubelet={{ kubernetes_package_version }}
-  - kubeadm={{ kubernetes_package_version }}
-  - kubectl={{ kubernetes_package_version }}
+  - "kubelet={{ kubernetes_package_version }}"
+  - "kubeadm={{ kubernetes_package_version }}"
+  - "kubectl={{ kubernetes_package_version }}"
 
 # Services to enable
 kubernetes_services:

--- a/ansible/roles/kubernetes_components/tasks/kubernetes.yml
+++ b/ansible/roles/kubernetes_components/tasks/kubernetes.yml
@@ -14,21 +14,60 @@
     mode: '0644'
   become: true
 
+- name: Check Kubernetes package versions against baseline
+  ansible.builtin.shell: |
+    set -eu
+    package={{ item | quote }}
+    desired={{ kubernetes_package_version | quote }}
+    installed="$(dpkg-query -W -f='${Version}' "$package" 2>/dev/null || true)"
+
+    if [ -z "$installed" ] || dpkg --compare-versions "$installed" lt "$desired"; then
+      printf '%s=%s\n' "$package" "$desired"
+    elif dpkg --compare-versions "$installed" gt "$desired"; then
+      printf 'skip-newer:%s=%s\n' "$package" "$installed"
+    fi
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: false
+  loop: "{{ kubernetes_package_names }}"
+  register: kubernetes_package_version_checks
+
+- name: Set Kubernetes packages that need install or upgrade
+  ansible.builtin.set_fact:
+    kubernetes_packages_to_install: >-
+      {{ kubernetes_package_version_checks.results
+      | map(attribute='stdout')
+      | select('match', '^[^:]+=')
+      | list }}
+    kubernetes_packages_newer_than_baseline: >-
+      {{ kubernetes_package_version_checks.results
+      | map(attribute='stdout')
+      | select('match', '^skip-newer:')
+      | list }}
+
+- name: Report Kubernetes packages newer than baseline
+  ansible.builtin.debug:
+    msg: "Skipping Kubernetes package downgrade during normal apply: {{ kubernetes_packages_newer_than_baseline }}"
+  when: kubernetes_packages_newer_than_baseline | length > 0
+
 - name: Install Kubernetes packages
   ansible.builtin.apt:
-    name: "{{ kubernetes_packages }}"
+    name: "{{ kubernetes_packages_to_install }}"
     state: present
     update_cache: true
-    allow_downgrade: true
+    allow_change_held_packages: true
+    allow_downgrade: false
   become: true
   notify: Restart kubelet
+  when: kubernetes_packages_to_install | length > 0
 
 - name: Hold Kubernetes packages to prevent automatic updates
   ansible.builtin.dpkg_selections:
-    name: "{{ item.split('=')[0] }}"
+    name: "{{ item }}"
     selection: hold
   become: true
-  loop: "{{ kubernetes_packages }}"
+  loop: "{{ kubernetes_package_names }}"
 
 - name: Create kubelet configuration directory
   ansible.builtin.file:

--- a/docs/project_docs/lolice-k8s-136-avoid-baseline-downgrade/plan.md
+++ b/docs/project_docs/lolice-k8s-136-avoid-baseline-downgrade/plan.md
@@ -1,0 +1,21 @@
+# lolice k8s 1.36 avoid baseline downgrade plan
+
+## Context
+
+After merging the 1.36 snapshot gate fix, the normal `Apply Ansible` workflow failed on `shanghai-1`.
+
+`shanghai-1` had already been upgraded to Kubernetes `1.36.1`, while the normal apply baseline still declares `1.35.6-1.1`. The `kubernetes_components` role tried to install the older package versions during normal apply, which would be a downgrade. APT refused because the Kubernetes packages are held, so the node was not downgraded.
+
+## Plan
+
+1. Keep the upgrade workflow as the path for explicit Kubernetes version changes.
+2. Make normal apply skip Kubernetes packages that are already newer than the declared baseline.
+3. Continue installing missing packages or upgrading packages older than the baseline.
+4. Allow held packages to change for baseline upgrades after the rolling cluster upgrade is complete.
+5. Keep package holds in place after normal apply.
+
+## Validation
+
+- Run Ansible lint for `kubernetes_components`.
+- Run the `kubernetes_components` Molecule scenario locally.
+- Confirm the next main `Apply Ansible` no longer attempts to downgrade `shanghai-1`.


### PR DESCRIPTION
## Summary
- skip Kubernetes package installation during normal apply when the installed package is newer than the declared baseline
- keep installing missing packages or upgrading packages older than the baseline
- allow held package changes for future baseline upgrades, while disallowing downgrades
- keep package holds applied by package name

## Context
After `shanghai-1` was upgraded to Kubernetes 1.36.1, the normal `Apply Ansible` workflow still had a 1.35.6 baseline and attempted to install `kubelet/kubeadm/kubectl=1.35.6-1.1`. APT refused the downgrade because the packages are held. This change keeps normal apply from downgrading nodes during a rolling upgrade.

## Validation
- `cd ansible && uv run ansible-lint roles/kubernetes_components/tasks/kubernetes.yml roles/kubernetes_components/defaults/main.yml`
- `git diff --check`
- `cd ansible/roles/kubernetes_components && uv run molecule test`
