### PR TITLE
Fix worker upgrade delegate SSH aliases

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -668,6 +668,8 @@ jobs:
 
       - name: Setup SSH config
         run: |
+          NODE_NAME=golyat-1
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
           CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
@@ -679,14 +681,14 @@ jobs:
             ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
             StrictHostKeyChecking accept-new
 
-          Host ${NODE_IP}
+          Host ${NODE_NAME} ${NODE_IP}
             HostName ${NODE_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
             ProxyJump bastion
             StrictHostKeyChecking accept-new
 
-          Host ${CP_IP}
+          Host ${CP_NODE} ${CP_IP}
             HostName ${CP_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
@@ -698,10 +700,12 @@ jobs:
 
       - name: Verify SSH connectivity
         run: |
+          NODE_NAME=golyat-1
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-1"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-1'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
+          ssh -o ConnectTimeout=60 "${NODE_NAME}" "echo 'SSH connection successful to golyat-1 inventory name'"
+          ssh -o ConnectTimeout=60 "${CP_NODE}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -805,6 +809,8 @@ jobs:
 
       - name: Setup SSH config
         run: |
+          NODE_NAME=golyat-2
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
           CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
@@ -816,14 +822,14 @@ jobs:
             ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
             StrictHostKeyChecking accept-new
 
-          Host ${NODE_IP}
+          Host ${NODE_NAME} ${NODE_IP}
             HostName ${NODE_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
             ProxyJump bastion
             StrictHostKeyChecking accept-new
 
-          Host ${CP_IP}
+          Host ${CP_NODE} ${CP_IP}
             HostName ${CP_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
@@ -835,10 +841,12 @@ jobs:
 
       - name: Verify SSH connectivity
         run: |
+          NODE_NAME=golyat-2
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-2"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-2'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
+          ssh -o ConnectTimeout=60 "${NODE_NAME}" "echo 'SSH connection successful to golyat-2 inventory name'"
+          ssh -o ConnectTimeout=60 "${CP_NODE}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -942,6 +950,8 @@ jobs:
 
       - name: Setup SSH config
         run: |
+          NODE_NAME=golyat-3
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
           CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
 
@@ -953,14 +963,14 @@ jobs:
             ProxyCommand cloudflared access ssh --hostname %h --header "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" --header "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET"
             StrictHostKeyChecking accept-new
 
-          Host ${NODE_IP}
+          Host ${NODE_NAME} ${NODE_IP}
             HostName ${NODE_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
             ProxyJump bastion
             StrictHostKeyChecking accept-new
 
-          Host ${CP_IP}
+          Host ${CP_NODE} ${CP_IP}
             HostName ${CP_IP}
             User boxp
             IdentityFile ~/.ssh/id_ed25519
@@ -972,10 +982,12 @@ jobs:
 
       - name: Verify SSH connectivity
         run: |
+          NODE_NAME=golyat-3
+          CP_NODE=shanghai-2
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."golyat-3"')
-          CP_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."shanghai-2"')
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to golyat-3'"
-          ssh -o ConnectTimeout=60 "${CP_IP}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
+          ssh -o ConnectTimeout=60 "${NODE_NAME}" "echo 'SSH connection successful to golyat-3 inventory name'"
+          ssh -o ConnectTimeout=60 "${CP_NODE}" "echo 'SSH connection successful to worker drain delegate shanghai-2'"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docs/project_docs/lolice-k8s-136-worker-delegate-ssh/plan.md
+++ b/docs/project_docs/lolice-k8s-136-worker-delegate-ssh/plan.md
@@ -1,0 +1,28 @@
+# lolice k8s 1.36 worker delegate SSH fix
+
+## Context
+
+The Kubernetes 1.36 worker upgrade for `golyat-1` failed before package changes started.
+The failing Ansible task delegated worker drain to `shanghai-2`, but the GitHub Actions SSH config only registered IP address aliases for the worker and control-plane delegate.
+
+The workflow also overrides `ansible_ssh_common_args` to an empty string, so Ansible must be able to connect with the inventory host name used by `delegate_to`.
+
+## Plan
+
+1. Add inventory host name aliases to the worker upgrade SSH config for each `golyat-*` job.
+2. Keep IP aliases as well, because the workflow still performs direct IP connectivity checks.
+3. Verify SSH connectivity with both the worker inventory name and `shanghai-2`, matching the names Ansible uses during delegated drain and uncordon tasks.
+4. Run GitHub Actions workflow lint checks locally.
+5. Merge the fix, confirm post-merge CI, then retry worker upgrades one node at a time.
+
+## Validation
+
+- `actionlint .github/workflows/upgrade-k8s.yml`
+- `ghalint run`
+- `git diff --check`
+- GitHub Actions CI on the pull request
+- Post-merge CI on `main`
+
+## Rollback
+
+Revert this PR. The change only affects SSH host aliases in the manual Kubernetes upgrade workflow and does not change cluster state directly.


### PR DESCRIPTION
## Summary
- add worker inventory names and the shanghai-2 delegate name to the Kubernetes upgrade workflow SSH config
- verify SSH connectivity through the same host names Ansible uses for worker drain delegation
- add the project plan under docs/project_docs/lolice-k8s-136-worker-delegate-ssh/plan.md

## Validation
- actionlint .github/workflows/upgrade-k8s.yml
- ghalint run
- git diff --check

## Context
The golyat-1 Kubernetes 1.36 upgrade failed before package changes because Ansible delegated drain to shanghai-2 while the workflow only configured SSH aliases for IP addresses.