### PR TITLE
Fix k8s upgrade handler ordering and inotify sysctl

### DIFF
--- a/ansible/roles/kubernetes_components/defaults/main.yml
+++ b/ansible/roles/kubernetes_components/defaults/main.yml
@@ -61,6 +61,8 @@ sysctl_config:
   net.bridge.bridge-nf-call-iptables: 1
   net.bridge.bridge-nf-call-ip6tables: 1
   net.ipv4.ip_forward: 1
+  fs.inotify.max_user_watches: 524288
+  fs.inotify.max_user_instances: 512
 
 # etcd resource configuration for ARM boards
 # Increased from default 100m CPU / 100Mi memory to accommodate ARM processor characteristics

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_first.yml
@@ -12,6 +12,10 @@
   ansible.builtin.include_tasks: upgrade_apt_source.yml
   tags: [upgrade]
 
+- name: Apply CRI-O restart before continuing control plane upgrade
+  ansible.builtin.meta: flush_handlers
+  tags: [upgrade]
+
 - name: Unhold kubeadm
   ansible.builtin.dpkg_selections:
     name: kubeadm

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_control_plane_secondary.yml
@@ -12,6 +12,10 @@
   ansible.builtin.include_tasks: upgrade_apt_source.yml
   tags: [upgrade]
 
+- name: Apply CRI-O restart before continuing control plane upgrade
+  ansible.builtin.meta: flush_handlers
+  tags: [upgrade]
+
 - name: Unhold kubeadm
   ansible.builtin.dpkg_selections:
     name: kubeadm

--- a/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
+++ b/ansible/roles/kubernetes_upgrade/tasks/upgrade_worker.yml
@@ -14,6 +14,10 @@
   ansible.builtin.include_tasks: upgrade_apt_source.yml
   tags: [upgrade]
 
+- name: Apply CRI-O restart before continuing worker upgrade
+  ansible.builtin.meta: flush_handlers
+  tags: [upgrade]
+
 - name: Unhold kubeadm
   ansible.builtin.dpkg_selections:
     name: kubeadm

--- a/docs/project_docs/lolice-k8s-136-worker-handler-sysctl/plan.md
+++ b/docs/project_docs/lolice-k8s-136-worker-handler-sysctl/plan.md
@@ -1,0 +1,27 @@
+# lolice k8s 1.36 worker handler and sysctl fix
+
+## Context
+
+The `golyat-1` Kubernetes 1.36 upgrade completed the package upgrade, reboot, uncordon, and readiness checks, but the GitHub Actions job failed when the delayed `Restart crio` handler ran after the health checks.
+
+During the same worker phase, kube-proxy 1.36 also required higher inotify limits than the current node defaults. Runtime values were temporarily raised on the cluster to restore kube-proxy, but the setting must be made persistent by Ansible.
+
+## Plan
+
+1. Flush the CRI-O restart handler immediately after CRI-O package upgrade tasks.
+2. Apply the same handler ordering for worker and control-plane upgrade task flows so health checks are not followed by an unexpected CRI-O restart.
+3. Persist kube-proxy-compatible inotify sysctl values in the Kubernetes component role.
+4. Raise the Ansible CI timeout so changed-role Molecule tests can run both `kubernetes_components` and `kubernetes_upgrade` in one PR.
+5. Run Ansible and YAML validation locally.
+6. Merge the fix, confirm post-merge CI, then continue worker upgrades one node at a time.
+
+## Validation
+
+- `cd ansible && uv run ansible-lint`
+- `git diff --check`
+- GitHub Actions CI on the pull request
+- Post-merge CI on `main`
+
+## Rollback
+
+Revert this PR. The handler ordering change only affects the manual Kubernetes upgrade workflow behavior. The sysctl additions are safe Kubernetes node tunables and can be removed by reverting the Ansible change if needed.


### PR DESCRIPTION
## Summary
- flush the CRI-O restart handler immediately after CRI-O package upgrade tasks
- persist kube-proxy-compatible inotify sysctl values in the Kubernetes component role
- add the project plan under docs/project_docs/lolice-k8s-136-worker-handler-sysctl/plan.md

## Validation
- cd ansible && uv run ansible-lint
- git diff --check

## Context
The golyat-1 upgrade reached v1.36.1 and passed readiness checks, but failed when the delayed Restart crio handler ran after health checks and temporarily broke SSH. kube-proxy 1.36 also required higher inotify sysctl values, which were applied runtime to recover the cluster and should now be made persistent.