### PR TITLE
Tolerate default qdisc sysctl reload warning

### DIFF
--- a/ansible/roles/kubernetes_components/handlers/main.yml
+++ b/ansible/roles/kubernetes_components/handlers/main.yml
@@ -3,8 +3,17 @@
 
 - name: Reload sysctl
   ansible.builtin.command: sysctl --system --ignore
+  register: sysctl_reload_result
   become: true
   changed_when: true
+  failed_when: >
+    sysctl_reload_result.rc != 0 and
+    (
+      sysctl_reload_result.stderr_lines
+      | reject('search', 'net.core.default_qdisc')
+      | list
+      | length
+    ) > 0
   listen: "Reload sysctl"
   when: chroot_build is not defined or not chroot_build
 

--- a/docs/project_docs/lolice-k8s-136-sysctl-default-qdisc/plan.md
+++ b/docs/project_docs/lolice-k8s-136-sysctl-default-qdisc/plan.md
@@ -1,0 +1,27 @@
+# lolice k8s 1.36 sysctl default qdisc reload tolerance
+
+## Context
+
+The post-merge `Apply Ansible` run after `#10358` passed on `shanghai-1` but failed on `shanghai-2`.
+`sysctl --system --ignore` still returned `rc=1` when the only stderr line was the existing host setting `net.core.default_qdisc`, which is unavailable on that node.
+
+The inotify settings were applied, but the strict handler result blocked the main apply gate.
+
+## Plan
+
+1. Keep using `sysctl --system --ignore`.
+2. Register the handler result and fail only when stderr contains lines other than the known `net.core.default_qdisc` unavailable-key message.
+3. Validate the Ansible role locally.
+4. Merge and confirm post-merge `Apply Ansible` succeeds on all control-plane nodes.
+
+## Validation
+
+- `cd ansible && uv run ansible-lint`
+- `git diff --check`
+- GitHub Actions CI on the pull request
+- Post-merge `Apply Ansible`
+
+## Rollback
+
+Revert this PR if sysctl reload should again fail on the existing `net.core.default_qdisc` host setting.
+The underlying host setting should eventually be cleaned up or made conditional, but it should not block Kubernetes node sysctl management during the upgrade.


### PR DESCRIPTION
## Summary
- keep sysctl --system --ignore for reloads
- tolerate the known net.core.default_qdisc unavailable-key stderr while still failing on other sysctl reload errors
- document the Apply Ansible failure and recovery plan

## Validation
- cd ansible && uv run ansible-lint
- git diff --check