### PR TITLE
Align lolice k8s 1.36 baseline

### DIFF
--- a/.github/workflows/upgrade-k8s.yml
+++ b/.github/workflows/upgrade-k8s.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       kubernetes_version:
-        description: 'Target Kubernetes version (e.g., 1.35.6)'
+        description: 'Target Kubernetes version (e.g., 1.36.1)'
         required: true
       kubernetes_package:
-        description: 'Target package version (e.g., 1.35.6-1.1)'
+        description: 'Target package version (e.g., 1.36.1-1.1)'
         required: true
       crio_version:
-        description: 'Target CRI-O version (e.g., 1.35.4)'
+        description: 'Target CRI-O version (e.g., 1.36.1)'
         required: true
       dry_run:
         description: 'Dry run mode (--check)'

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -18,9 +18,9 @@ all:
         ansible_python_interpreter: /usr/bin/python3
 
         # Kubernetes configuration
-        kubernetes_version: "1.35.6"
-        kubernetes_package_version: "1.35.6-1.1"
-        crio_version: "1.35.4"
+        kubernetes_version: "1.36.1"
+        kubernetes_package_version: "1.36.1-1.1"
+        crio_version: "1.36.1"
 
         # Cluster configuration
         cluster_vip: "192.168.10.99"
@@ -52,9 +52,9 @@ all:
         ansible_python_interpreter: /usr/bin/python3
 
         # Kubernetes configuration
-        kubernetes_version: "1.35.6"
-        kubernetes_package_version: "1.35.6-1.1"
-        crio_version: "1.35.4"
+        kubernetes_version: "1.36.1"
+        kubernetes_package_version: "1.36.1-1.1"
+        crio_version: "1.36.1"
 
         # Cluster configuration
         cluster_vip: "192.168.10.99"

--- a/ansible/playbooks/control-plane.yml
+++ b/ansible/playbooks/control-plane.yml
@@ -93,14 +93,14 @@
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
       vars:
-        kubernetes_version: "1.35.6"
-        kubernetes_package_version: "1.35.6-1.1"
+        kubernetes_version: "1.36.1"
+        kubernetes_package_version: "1.36.1-1.1"
         crio_version: >-
           {{
             {
-              'shanghai-1': '1.35.4',
-              'shanghai-2': '1.35.4',
-              'shanghai-3': '1.35.4'
+              'shanghai-1': '1.36.1',
+              'shanghai-2': '1.36.1',
+              'shanghai-3': '1.36.1'
             }[node_name]
           }}
         kubelet_cluster_dns: "{{ cluster_dns }}"

--- a/ansible/playbooks/node-shanghai-1.yml
+++ b/ansible/playbooks/node-shanghai-1.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.36.1"
+    kubernetes_package_version: "1.36.1-1.1"
+    crio_version: "1.36.1"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-2.yml
+++ b/ansible/playbooks/node-shanghai-2.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.36.1"
+    kubernetes_package_version: "1.36.1-1.1"
+    crio_version: "1.36.1"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/ansible/playbooks/node-shanghai-3.yml
+++ b/ansible/playbooks/node-shanghai-3.yml
@@ -15,9 +15,9 @@
     cluster_dns: "{{ cluster.dns }}"
 
     # Kubernetes configuration
-    kubernetes_version: "1.35.6"
-    kubernetes_package_version: "1.35.6-1.1"
-    crio_version: "1.35.4"
+    kubernetes_version: "1.36.1"
+    kubernetes_package_version: "1.36.1-1.1"
+    crio_version: "1.36.1"
 
     # Hardware configuration
     hardware_type: "orange_pi_zero3"

--- a/docs/project_docs/lolice-k8s-136-baseline/plan.md
+++ b/docs/project_docs/lolice-k8s-136-baseline/plan.md
@@ -1,0 +1,18 @@
+# lolice Kubernetes 1.36 Baseline
+
+## Context
+
+All lolice Kubernetes nodes have been upgraded to kubelet `v1.36.1` and CRI-O `1.36.1`.
+The production inventory and normal control-plane apply playbooks still declare the previous `1.35.6` / `1.35.4` baseline, so regular Ansible apply should be aligned with the live cluster before closing the upgrade project.
+
+## Plan
+
+1. Update the production inventory for control-plane and worker groups to Kubernetes `1.36.1`, package `1.36.1-1.1`, and CRI-O `1.36.1`.
+2. Update the per-node shanghai playbooks and `control-plane.yml` defaults to the same `1.36.1` baseline.
+3. Update the manual `upgrade-k8s.yml` workflow input examples so future runs show the current version family.
+4. Run focused validation for Ansible/YAML changes.
+5. Merge after CI passes, then verify the post-merge Ansible apply remains green.
+
+## Rollback
+
+Revert this PR if regular apply exposes an issue. Reverting only changes desired-state metadata and must not be used to downgrade the already-upgraded cluster.


### PR DESCRIPTION
## Summary
- align production Kubernetes and CRI-O baseline values with the live v1.36.1 cluster
- update shanghai per-node/control-plane apply defaults to v1.36.1
- refresh upgrade workflow input examples to the current version family

## Context
All lolice nodes are now Ready on kubelet v1.36.1 and CRI-O 1.36.1. This PR updates the normal Ansible desired state so future apply runs do not carry the previous 1.35 baseline.

## Validation
- `cd ansible && uv run ansible-lint`
- `actionlint .github/workflows/upgrade-k8s.yml`
- `ghalint run`
