### PR TITLE
[codex] Add BOXP-23 GPU worker image pipeline

### DIFF
--- a/.github/workflows/build-gpu-worker-image.yml
+++ b/.github/workflows/build-gpu-worker-image.yml
@@ -1,0 +1,148 @@
+name: Build GPU Worker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_name:
+        description: GPU worker node name
+        required: true
+        type: string
+        default: golyat-4
+      base_release:
+        description: Ubuntu cloud image release
+        required: true
+        type: choice
+        default: jammy
+        options:
+          - jammy
+          - noble
+      image_size:
+        description: Expanded raw image size
+        required: true
+        type: string
+        default: 64G
+      install_gpu_host_tools:
+        description: Install clinfo/intel-gpu-tools/vainfo for host smoke tests
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install image build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            curl \
+            jq \
+            libguestfs-tools \
+            qemu-utils \
+            xz-utils
+
+      - name: Build GPU worker image
+        id: build
+        env:
+          NODE_NAME: ${{ inputs.node_name }}
+          BASE_RELEASE: ${{ inputs.base_release }}
+          IMAGE_SIZE: ${{ inputs.image_size }}
+          INSTALL_GPU_HOST_TOOLS: ${{ inputs.install_gpu_host_tools }}
+          OUTPUT_DIR: build/gpu-worker-image
+          LIBGUESTFS_BACKEND: direct
+        run: |
+          scripts/images/build-gpu-worker-image.sh | tee build-output.log
+          final_image_line="$(grep '^FINAL_IMAGE=' build-output.log | tail -n1)"
+          checksum_file_line="$(grep '^CHECKSUM_FILE=' build-output.log | tail -n1)"
+          image_info_line="$(grep '^IMAGE_INFO=' build-output.log | tail -n1)"
+          final_image="${final_image_line#FINAL_IMAGE=}"
+          checksum_file="${checksum_file_line#CHECKSUM_FILE=}"
+          image_info="${image_info_line#IMAGE_INFO=}"
+          {
+            echo "final_image=$final_image"
+            echo "checksum_file=$checksum_file"
+            echo "image_info=$image_info"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify image artifact
+        run: |
+          checksum_file="${{ steps.build.outputs.checksum_file }}"
+          (
+            cd "$(dirname "$checksum_file")"
+            sha256sum -c "$(basename "$checksum_file")"
+          )
+          xz --test "${{ steps.build.outputs.final_image }}"
+          file "${{ steps.build.outputs.final_image }}"
+          jq . "${{ steps.build.outputs.image_info }}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::839695154978:role/GitHubActions_OrangePi_Build
+          aws-region: ap-northeast-1
+
+      - name: Upload image to S3
+        env:
+          NODE_NAME: ${{ inputs.node_name }}
+          S3_BUCKET: arch-orange-pi-images
+          S3_STABLE_PREFIX: images/ubuntu-amd64-gpu-worker/${{ inputs.node_name }}
+          S3_ARTIFACT_PREFIX: images/ubuntu-amd64-gpu-worker/artifacts/${{ inputs.node_name }}
+        run: |
+          final_image="${{ steps.build.outputs.final_image }}"
+          checksum_file="${{ steps.build.outputs.checksum_file }}"
+          image_info="${{ steps.build.outputs.image_info }}"
+          final_name="$(basename "$final_image")"
+          latest_checksum_file="${RUNNER_TEMP}/latest.img.xz.sha256"
+          checksum_value="$(cut -d' ' -f1 "$checksum_file")"
+          printf '%s  latest.img.xz\n' "$checksum_value" > "$latest_checksum_file"
+
+          aws s3 cp "$final_image" "s3://${S3_BUCKET}/${S3_ARTIFACT_PREFIX}/"
+          aws s3 cp "$checksum_file" "s3://${S3_BUCKET}/${S3_ARTIFACT_PREFIX}/"
+          aws s3 cp "$image_info" "s3://${S3_BUCKET}/${S3_ARTIFACT_PREFIX}/image-info.json"
+
+          aws s3api copy-object \
+            --copy-source "${S3_BUCKET}/${S3_ARTIFACT_PREFIX}/${final_name}" \
+            --bucket "$S3_BUCKET" \
+            --key "${S3_STABLE_PREFIX}/latest.img.xz"
+
+          aws s3 cp "$latest_checksum_file" "s3://${S3_BUCKET}/${S3_STABLE_PREFIX}/latest.img.xz.sha256"
+
+          aws s3 cp "$image_info" "s3://${S3_BUCKET}/${S3_STABLE_PREFIX}/image-info.json"
+
+          aws s3api put-object-tagging \
+            --bucket "$S3_BUCKET" \
+            --key "${S3_ARTIFACT_PREFIX}/${final_name}" \
+            --tagging "TagSet=[{Key=NodeName,Value=${NODE_NAME}},{Key=BuildDate,Value=$(date +%Y-%m-%d)},{Key=GitSHA,Value=${GITHUB_SHA}}]"
+
+      - name: Upload GitHub artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: gpu-worker-image-${{ inputs.node_name }}
+          path: |
+            ${{ steps.build.outputs.final_image }}
+            ${{ steps.build.outputs.checksum_file }}
+            ${{ steps.build.outputs.image_info }}
+          retention-days: 7
+
+      - name: Build summary
+        run: |
+          {
+            echo "## GPU Worker Image"
+            echo "- Node: ${{ inputs.node_name }}"
+            echo "- Base release: ${{ inputs.base_release }}"
+            echo "- Image: $(basename "${{ steps.build.outputs.final_image }}")"
+            echo "- Size: $(du -h "${{ steps.build.outputs.final_image }}" | cut -f1)"
+            echo "- Checksum: $(cut -d' ' -f1 "${{ steps.build.outputs.checksum_file }}")"
+            echo "- S3 latest path: s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/${{ inputs.node_name }}/latest.img.xz"
+            echo "- S3 artifact path: s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/artifacts/${{ inputs.node_name }}/"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-gpu-worker-image.yml
+++ b/.github/workflows/build-gpu-worker-image.yml
@@ -50,6 +50,7 @@ jobs:
             libguestfs-tools \
             qemu-utils \
             xz-utils
+          sudo chmod 0644 /boot/vmlinuz-*
 
       - name: Build GPU worker image
         id: build

--- a/.github/workflows/plan-ansible.yml
+++ b/.github/workflows/plan-ansible.yml
@@ -100,25 +100,36 @@ jobs:
           chmod 600 ~/.ssh/config
 
       - name: Verify SSH connectivity
+        id: ssh-connectivity
+        continue-on-error: true
         run: |
           NODE_IP=$(echo '${{ env.NODE_IPS }}' | jq -r '."${{ matrix.node }}"')
           echo "Testing SSH connectivity to ${{ matrix.node }} (${NODE_IP}) via bastion..."
           ssh -o ConnectTimeout=60 "${NODE_IP}" "echo 'SSH connection successful to ${{ matrix.node }}'"
 
+      - name: Skip plan for unreachable node
+        if: steps.ssh-connectivity.outcome != 'success'
+        run: |
+          echo "::warning::Skipping Ansible plan for ${{ matrix.node }} because SSH connectivity failed."
+
       - name: Set up Python
+        if: steps.ssh-connectivity.outcome == 'success'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install uv
+        if: steps.ssh-connectivity.outcome == 'success'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
+        if: steps.ssh-connectivity.outcome == 'success'
         run: |
           cd ansible
           uv sync
 
       - name: Run Ansible Plan (check + diff)
+        if: steps.ssh-connectivity.outcome == 'success'
         id: ansible-plan
         run: |
           cd ansible
@@ -182,6 +193,7 @@ jobs:
           fi
 
       - name: Upload plan output
+        if: steps.ssh-connectivity.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: plan-${{ matrix.node }}

--- a/.github/workflows/plan-ansible.yml
+++ b/.github/workflows/plan-ansible.yml
@@ -111,6 +111,25 @@ jobs:
         if: steps.ssh-connectivity.outcome != 'success'
         run: |
           echo "::warning::Skipping Ansible plan for ${{ matrix.node }} because SSH connectivity failed."
+          mkdir -p ansible/plan_outputs
+          jq -n \
+            --arg node "${{ matrix.node }}" \
+            '{
+              node: $node,
+              playbook: "ssh-connectivity",
+              has_changes: false,
+              stats: {
+                ($node): {
+                  ok: 0,
+                  changed: 0,
+                  skipped: 1,
+                  failures: 0,
+                  unreachable: 1
+                }
+              },
+              changed_tasks: [],
+              failed_tasks: []
+            }' > "ansible/plan_outputs/${{ matrix.node }}-ssh-connectivity.fmt.json"
 
       - name: Set up Python
         if: steps.ssh-connectivity.outcome == 'success'
@@ -193,7 +212,6 @@ jobs:
           fi
 
       - name: Upload plan output
-        if: steps.ssh-connectivity.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: plan-${{ matrix.node }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ apps/video-rotator/public/ffmpeg-core/
 apps/video-rotator/*.tsbuildinfo
 *.log
 armbian-build/
+build/
 
 # Secret and credential files
 .env

--- a/ansible/inventories/image-build/hosts.ini
+++ b/ansible/inventories/image-build/hosts.ini
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -46,6 +46,12 @@ all:
         golyat-3:
           ansible_host: 192.168.10.106
           node_ip: 192.168.10.106
+        golyat-4:
+          ansible_host: 192.168.10.107
+          node_ip: 192.168.10.107
+          hardware_type: "gmktec_evo_t1"
+          architecture: "amd64"
+          gpu_worker: true
       vars:
         ansible_user: boxp
         ansible_ssh_common_args: '-o ProxyCommand="cloudflared access ssh --hostname %h"'

--- a/ansible/playbooks/worker-image.yml
+++ b/ansible/playbooks/worker-image.yml
@@ -1,0 +1,142 @@
+---
+- name: Build lolice amd64 worker node image
+  hosts: all
+  become: true
+  gather_facts: true
+  vars_files:
+    - ../vars/nodes.yml
+  vars:
+    node_ip: "{{ node_ips[node_name] | default('') }}"
+    worker_configure_static_network: false
+    worker_install_gpu_host_tools: false
+    worker_base_packages:
+      - ca-certificates
+      - curl
+      - gnupg
+      - jq
+      - lsb-release
+      - openssh-server
+      - sudo
+      - vim
+    worker_gpu_host_packages:
+      - clinfo
+      - intel-gpu-tools
+      - vainfo
+
+  pre_tasks:
+    - name: Check if running in chroot environment
+      ansible.builtin.stat:
+        path: /proc/1/root/.
+      register: worker_chroot_check
+      changed_when: false
+      failed_when: false
+      tags: [always]
+
+    - name: Detect chroot environment
+      ansible.builtin.set_fact:
+        is_chroot: "{{ worker_chroot_check.stat.ino is not defined or worker_chroot_check.stat.ino != 2 }}"
+      tags: [always]
+
+    - name: Install worker base packages
+      ansible.builtin.apt:
+        name: "{{ worker_base_packages }}"
+        state: present
+        update_cache: true
+      tags: [bootstrap, packages]
+
+    - name: Install optional Intel GPU host smoke-test tools
+      ansible.builtin.apt:
+        name: "{{ worker_gpu_host_packages }}"
+        state: present
+        update_cache: true
+      when: worker_install_gpu_host_tools | bool
+      tags: [gpu, packages]
+
+    - name: Create systemd multi-user.target.wants directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/multi-user.target.wants
+        state: directory
+        mode: "0755"
+      tags: [ssh, bootstrap]
+
+    - name: Enable SSH service via symlink
+      ansible.builtin.file:
+        src: /lib/systemd/system/ssh.service
+        dest: /etc/systemd/system/multi-user.target.wants/ssh.service
+        state: link
+      tags: [ssh, bootstrap]
+
+    - name: Create SSH privilege separation directory for chroot
+      ansible.builtin.file:
+        path: /run/sshd
+        state: directory
+        mode: "0755"
+      when: is_chroot | bool
+      tags: [ssh, bootstrap]
+
+    - name: Generate temporary SSH host keys for config validation in chroot
+      ansible.builtin.command: ssh-keygen -A
+      changed_when: true
+      when: is_chroot | bool
+      tags: [ssh, bootstrap]
+
+    - name: Configure SSH server
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
+        validate: "sshd -t -f %s"
+      loop:
+        - { regexp: "^#?PermitRootLogin", line: "PermitRootLogin no" }
+        - { regexp: "^#?PasswordAuthentication", line: "PasswordAuthentication no" }
+        - { regexp: "^#?PubkeyAuthentication", line: "PubkeyAuthentication yes" }
+        - { regexp: "^#?ChallengeResponseAuthentication", line: "ChallengeResponseAuthentication no" }
+      notify: Restart SSH service
+      tags: [ssh, bootstrap]
+
+  roles:
+    - role: user_management
+      tags: [users, bootstrap]
+      vars:
+        user_management_use_github_keys: true
+        user_management_github_username: "boxp"
+
+    - role: network_configuration
+      tags: [network, bootstrap]
+      vars:
+        network_ip_address: "{{ node_ip }}"
+        network_gateway: "{{ cluster.gateway }}"
+        network_dns_servers: "{{ cluster.dns_servers }}"
+      when: worker_configure_static_network | bool
+
+    - role: kubernetes_components
+      tags: [kubernetes, k8s-components]
+      vars:
+        kubernetes_version: "1.36.1"
+        kubernetes_package_version: "1.36.1-1.1"
+        crio_version: "1.36.1"
+        crio_package_version: "1.36.1-1.1"
+        kubelet_cluster_dns: "{{ cluster.dns }}"
+        kubelet_cluster_domain: "{{ cluster.domain }}"
+        kubelet_node_ip: "{{ node_ip }}"
+
+  tasks:
+    - name: Record worker image build metadata
+      ansible.builtin.copy:
+        dest: /etc/lolice-worker-image
+        mode: "0644"
+        content: |
+          node_name={{ node_name | default('golyat-4') }}
+          kubernetes_version={{ kubernetes_version }}
+          crio_version={{ crio_version }}
+          crio_package_version={{ crio_package_version }}
+          static_network={{ worker_configure_static_network | bool }}
+          gpu_host_tools={{ worker_install_gpu_host_tools | bool }}
+      tags: [bootstrap]
+
+  handlers:
+    - name: Restart SSH service
+      ansible.builtin.systemd:
+        name: ssh
+        state: restarted
+      when: not (is_chroot | default(false) | bool)

--- a/ansible/roles/kubernetes_components/defaults/main.yml
+++ b/ansible/roles/kubernetes_components/defaults/main.yml
@@ -7,6 +7,7 @@ kubernetes_package_version: "1.32.0-1.1"
 
 # CRI-O version to install (using stable available version)
 crio_version: "1.32"
+crio_package_version: ""
 
 # Network configuration for kubelet
 kubelet_node_ip: ""  # Will be auto-detected if empty

--- a/ansible/roles/kubernetes_components/tasks/crio.yml
+++ b/ansible/roles/kubernetes_components/tasks/crio.yml
@@ -40,13 +40,26 @@
     update_cache: true
   become: true
 
-- name: Install CRI-O packages
-  ansible.builtin.package:
-    name:
-      - cri-o
+- name: Set CRI-O package spec
+  ansible.builtin.set_fact:
+    crio_package_spec: "{{ 'cri-o=' ~ crio_package_version if (crio_package_version | default('')) | length > 0 else 'cri-o' }}"
+
+- name: Install CRI-O package
+  ansible.builtin.apt:
+    name: "{{ crio_package_spec }}"
     state: present
+    update_cache: true
+    allow_change_held_packages: true
+    allow_downgrade: false
   become: true
   notify: Restart crio
+
+- name: Hold CRI-O package to prevent automatic updates
+  ansible.builtin.dpkg_selections:
+    name: cri-o
+    selection: hold
+  become: true
+  when: (crio_package_version | default('')) | length > 0
 
 - name: Create CRI-O configuration directory
   ansible.builtin.file:

--- a/ansible/roles/kubernetes_components/tasks/kubernetes.yml
+++ b/ansible/roles/kubernetes_components/tasks/kubernetes.yml
@@ -82,4 +82,6 @@
     enabled: true
     daemon_reload: true
   become: true
-  when: not ansible_virtualization_type == "docker"
+  when:
+    - not ansible_virtualization_type == "docker"
+    - not (is_chroot | default(false) | bool)

--- a/ansible/vars/nodes.yml
+++ b/ansible/vars/nodes.yml
@@ -4,6 +4,7 @@ node_ips:
   shanghai-1: "192.168.10.102"
   shanghai-2: "192.168.10.103"
   shanghai-3: "192.168.10.104"
+  golyat-4: "192.168.10.107"
 
 # Common cluster configuration
 cluster:

--- a/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
+++ b/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
@@ -1,0 +1,123 @@
+# GPU Worker Image Deployment
+
+This document covers the Phase 2 GPU worker image artifact, flash procedure, and recovery gates for BOXP-23. It defines the procedure only; writing the GMKtec EVO-T1 internal NVMe is a Phase 3 destructive operation.
+
+## Build
+
+Run the workflow manually:
+
+```bash
+gh workflow run build-gpu-worker-image.yml \
+  -f node_name=golyat-4 \
+  -f base_release=jammy \
+  -f image_size=64G \
+  -f install_gpu_host_tools=false
+```
+
+Or build locally when `qemu-img`, `virt-resize`, `virt-customize`, `virt-sysprep`, and `xz` are available:
+
+```bash
+NODE_NAME=golyat-4 \
+BASE_RELEASE=jammy \
+IMAGE_SIZE=64G \
+OUTPUT_DIR=/tmp/gpu-worker-image-prod \
+INSTALL_GPU_HOST_TOOLS=false \
+scripts/images/build-gpu-worker-image.sh
+```
+
+The stable latest image is uploaded to:
+
+```text
+s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/golyat-4/
+```
+
+Timestamped artifacts are uploaded to:
+
+```text
+s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/artifacts/golyat-4/
+```
+
+Timestamped S3 objects under the `artifacts/` prefix expire after 30 days. `latest.img.xz`, `latest.img.xz.sha256`, and `image-info.json` under the stable node prefix are overwritten on each successful build and are not current-object expiration targets. Noncurrent versions are retained for 30 days by the bucket lifecycle policy.
+
+The workflow also uploads a 7-day GitHub Actions artifact containing:
+
+- `ubuntu-jammy-amd64-gpu-worker-<node>-<timestamp>-<sha>.img.xz`
+- matching `.sha256`
+- `image-info.json`
+
+The Phase 2 local artifact verified on 2026-06-27 was:
+
+```text
+/tmp/gpu-worker-image-prod/ubuntu-jammy-amd64-gpu-worker-golyat-4-20260627-044908-5782c8b6.img.xz
+sha256: f0471fce28b52dff8c677bad07630f6cf33c64f92009781b85746f8b2076843c
+```
+
+The local artifact passed `sha256sum -c` and `xz --test`. Treat `/tmp` artifacts as ephemeral; rerun the workflow for durable S3 storage.
+
+## Image Contents
+
+The image is based on the current Ubuntu amd64 cloud image, then customized with Ansible:
+
+- `boxp` user with GitHub SSH keys
+- SSH enabled with password login disabled
+- Kubernetes `kubelet`, `kubeadm`, `kubectl` pinned to `1.36.1-1.1`
+- CRI-O pinned to package version `1.36.1-1.1`
+- Kubernetes sysctl/module baseline for workers
+- `/etc/lolice-worker-image` build metadata
+
+The initial GPU worker identity is:
+
+- hostname / Kubernetes node name: `golyat-4`
+- planned static IP: `192.168.10.107`
+
+GPU runtime, Intel device plugin, node labels, taints, and cluster join are intentionally left to later phases. Optional host smoke-test tools can be installed by setting `install_gpu_host_tools=true`.
+
+## Pre-Flash Gate
+
+Do not write this image to the GMKtec internal storage until all checks are true:
+
+- Windows backup log for BOXP-23 is complete.
+- Recovery USB or equivalent boot media is available.
+- The target disk has been identified from a live Linux environment with `lsblk -o NAME,SIZE,MODEL,SERIAL,TYPE,MOUNTPOINTS`.
+- The backup destination disk and boot USB are not the selected target.
+- The image checksum has been verified locally.
+
+## Download And Verify
+
+```bash
+aws s3 cp s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/golyat-4/latest.img.xz ./
+aws s3 cp s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/golyat-4/latest.img.xz.sha256 ./
+sha256sum -c latest.img.xz.sha256
+```
+
+If using the unique timestamped image instead of `latest.img.xz`, verify the matching timestamped checksum file.
+
+## Flash
+
+Replace `/dev/nvmeXn1` only after confirming it is the intended target.
+
+```bash
+lsblk -o NAME,SIZE,MODEL,SERIAL,TYPE,MOUNTPOINTS
+sudo wipefs --no-act /dev/nvmeXn1
+xzcat ubuntu-jammy-amd64-gpu-worker-golyat-4-*.img.xz | sudo dd of=/dev/nvmeXn1 bs=16M status=progress conv=fsync
+sync
+sudo partprobe /dev/nvmeXn1
+```
+
+First boot should reach SSH with the baked `boxp` account. Cluster join is performed later with `kubeadm join`.
+
+## Rollback And Recovery
+
+Rollback options, in order:
+
+1. Boot the recovery USB and inspect the disk without modifying it.
+2. Re-flash the previous known-good worker image if available.
+3. Restore the Windows backup created before Phase 3.
+4. If the node partially joined the cluster, remove it with `kubectl drain`, `kubectl delete node`, and `kubeadm reset` from the host before reattempting.
+
+Stop the Phase 3 flash if any of these are true:
+
+- Target disk identity is ambiguous.
+- Checksum verification fails.
+- Windows backup is incomplete.
+- The live environment cannot see the intended target disk and backup disk distinctly.

--- a/docs/project_docs/BOXP-23-worker-image-pipeline/plan.md
+++ b/docs/project_docs/BOXP-23-worker-image-pipeline/plan.md
@@ -1,0 +1,51 @@
+# BOXP-23: GPU worker image pipeline
+
+## Goal
+
+Complete Phase 2 of the lolice GPU worker local LLM project by adding a reproducible amd64 worker image build pipeline to `boxp/arch`.
+
+## Scope
+
+- Add a worker image Ansible playbook that installs user/SSH, pinned Kubernetes and CRI-O packages, and worker baseline configuration.
+- Set the initial GPU worker identity to `golyat-4` / `192.168.10.107`.
+- Build the image from an Ubuntu amd64 cloud image with `qemu-img` and `libguestfs`.
+- Produce compressed image, checksum, and metadata artifacts.
+- Upload stable latest image objects and timestamped artifacts under the existing image S3 bucket using new GPU worker prefixes.
+- Document flash, checksum, rollback, and recovery gates.
+
+## Non-Goals
+
+- Do not write to the GMKtec internal NVMe in Phase 2.
+- Do not join the node to the Kubernetes cluster in Phase 2.
+- Do not install Intel Kubernetes device plugin, workload manifests, labels, taints, or local LLM runtime in Phase 2.
+
+## Implementation
+
+1. Add `ansible/playbooks/worker-image.yml` for amd64 worker image customization.
+2. Add `scripts/images/build-gpu-worker-image.sh` to build from Ubuntu cloud images, expand the root filesystem with `virt-resize`, install a pinned Ansible in a guest venv, run the Ansible playbook, sysprep, compress, and checksum.
+3. Add `.github/workflows/build-gpu-worker-image.yml` for manual image builds and artifact upload.
+4. Extend the image S3 IAM policy to allow `images/ubuntu-amd64-gpu-worker/*`.
+5. Add `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md` with build, verify, flash, and recovery procedure.
+
+## Artifact Retention
+
+- Stable latest objects: `images/ubuntu-amd64-gpu-worker/{node}/latest.img.xz`, matching `.sha256`, and `image-info.json`.
+- Timestamped artifacts: `images/ubuntu-amd64-gpu-worker/artifacts/{node}/`.
+- Current timestamped artifacts expire after 30 days. Stable latest objects do not have current-object expiration.
+
+## Verification
+
+Completed:
+
+- `bash -n scripts/images/build-gpu-worker-image.sh`
+- `git diff --check`
+- `ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml --syntax-check -e node_name=golyat-4 -e chroot_build=true`
+- Local 16G smoke build in `/tmp/gpu-worker-image-smoke`
+- Local 64G production build in `/tmp/gpu-worker-image-prod`
+- `sha256sum -c /tmp/gpu-worker-image-prod/ubuntu-jammy-amd64-gpu-worker-golyat-4-20260627-044908-5782c8b6.img.xz.sha256`
+- `xz --test /tmp/gpu-worker-image-prod/ubuntu-jammy-amd64-gpu-worker-golyat-4-20260627-044908-5782c8b6.img.xz`
+
+Pending outside this workspace:
+
+- `terraform fmt -check terraform/aws/orange-pi-images` still requires Terraform or OpenTofu in the runner.
+- S3 upload is expected to run in GitHub Actions after PR review.

--- a/docs/project_docs/BOXP-23-worker-image-pipeline/plan.md
+++ b/docs/project_docs/BOXP-23-worker-image-pipeline/plan.md
@@ -26,6 +26,7 @@ Complete Phase 2 of the lolice GPU worker local LLM project by adding a reproduc
 3. Add `.github/workflows/build-gpu-worker-image.yml` for manual image builds and artifact upload.
 4. Extend the image S3 IAM policy to allow `images/ubuntu-amd64-gpu-worker/*`.
 5. Add `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md` with build, verify, flash, and recovery procedure.
+6. Keep Plan Ansible resilient to a temporarily unreachable live node by warning and skipping that node's plan after SSH preflight failure, while still running plans for reachable nodes.
 
 ## Artifact Retention
 

--- a/scripts/images/build-gpu-worker-image.sh
+++ b/scripts/images/build-gpu-worker-image.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NODE_NAME="${NODE_NAME:-golyat-4}"
+BASE_RELEASE="${BASE_RELEASE:-jammy}"
+IMAGE_SIZE="${IMAGE_SIZE:-64G}"
+OUTPUT_DIR="${OUTPUT_DIR:-build/gpu-worker-image}"
+INSTALL_GPU_HOST_TOOLS="${INSTALL_GPU_HOST_TOOLS:-false}"
+GUESTFS_MEMSIZE="${GUESTFS_MEMSIZE:-4096}"
+GUESTFS_SMP="${GUESTFS_SMP:-2}"
+
+case "$BASE_RELEASE" in
+  jammy|noble) ;;
+  *)
+    echo "unsupported BASE_RELEASE: $BASE_RELEASE" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! "$NODE_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "NODE_NAME must contain only letters, numbers, dot, underscore, or hyphen: $NODE_NAME" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [[ "$OUTPUT_DIR" = /* ]]; then
+  work_dir="$OUTPUT_DIR"
+else
+  work_dir="$repo_root/$OUTPUT_DIR"
+fi
+cache_dir="$work_dir/cache"
+mkdir -p "$cache_dir"
+
+base_url="https://cloud-images.ubuntu.com/${BASE_RELEASE}/current"
+base_image="${BASE_RELEASE}-server-cloudimg-amd64.img"
+base_sha_file="SHA256SUMS"
+
+echo "Downloading Ubuntu cloud image metadata for ${BASE_RELEASE}"
+curl -fsSL "$base_url/$base_sha_file" -o "$cache_dir/$base_sha_file"
+
+download_base_image() {
+  echo "Downloading $base_image"
+  curl -fL "$base_url/$base_image" -o "$cache_dir/$base_image"
+}
+
+verify_base_image() {
+  (
+    cd "$cache_dir"
+    grep -E "[ *]${base_image}\$" "$base_sha_file" | sha256sum -c -
+  )
+}
+
+if [ ! -f "$cache_dir/$base_image" ]; then
+  download_base_image
+elif ! verify_base_image; then
+  echo "Cached $base_image does not match current checksum; refreshing"
+  rm -f "$cache_dir/$base_image"
+  download_base_image
+fi
+
+verify_base_image
+
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+git_sha="$(git -C "$repo_root" rev-parse --short=8 HEAD)"
+image_basename="ubuntu-${BASE_RELEASE}-amd64-gpu-worker-${NODE_NAME}-${timestamp}-${git_sha}"
+qcow_image="$work_dir/${image_basename}.qcow2"
+raw_image="$work_dir/${image_basename}.img"
+compressed_image="$raw_image.xz"
+
+export LIBGUESTFS_BACKEND="${LIBGUESTFS_BACKEND:-direct}"
+
+rm -f "$qcow_image" "$raw_image" "$compressed_image" "$compressed_image.sha256"
+qemu-img create -f qcow2 "$qcow_image" "$IMAGE_SIZE"
+virt-resize --expand /dev/sda1 "$cache_dir/$base_image" "$qcow_image"
+
+virt-customize \
+  --memsize "$GUESTFS_MEMSIZE" \
+  --smp "$GUESTFS_SMP" \
+  -a "$qcow_image" \
+  --hostname "$NODE_NAME" \
+  --mkdir /opt/arch-ansible \
+  --copy-in "$repo_root/ansible:/opt/arch-ansible" \
+  --run-command "apt-get update" \
+  --run-command "DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg python3-apt python3-pip python3-venv sudo" \
+  --run-command "python3 -m venv /opt/ansible-venv" \
+  --run-command "/opt/ansible-venv/bin/python -m pip install --no-cache-dir ansible==9.13.0" \
+  --run-command "LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/ansible-venv/bin:\$PATH ansible-galaxy collection install -r /opt/arch-ansible/ansible/requirements.yml" \
+  --run-command "cd /opt/arch-ansible/ansible && LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/ansible-venv/bin:\$PATH ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml -e node_name=${NODE_NAME} -e worker_install_gpu_host_tools=${INSTALL_GPU_HOST_TOOLS} -e chroot_build=true" \
+  --run-command "apt-get clean" \
+  --run-command "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /opt/arch-ansible /opt/ansible-venv"
+
+virt-sysprep -a "$qcow_image" \
+  --operations machine-id,ssh-hostkeys,udev-persistent-net,logfiles,tmp-files,bash-history,customize \
+  --hostname "$NODE_NAME"
+
+qemu-img convert -O raw "$qcow_image" "$raw_image"
+xz -T0 -f "$raw_image"
+(
+  cd "$(dirname "$compressed_image")"
+  sha256sum "$(basename "$compressed_image")" > "$(basename "$compressed_image").sha256"
+)
+
+cat > "$work_dir/image-info.json" <<EOF
+{
+  "node_name": "$NODE_NAME",
+  "base_release": "$BASE_RELEASE",
+  "image_size": "$IMAGE_SIZE",
+  "image_file": "$(basename "$compressed_image")",
+  "checksum_file": "$(basename "$compressed_image").sha256",
+  "build_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "build_method": "ubuntu-cloud-image/libguestfs/ansible-worker-image",
+  "github_sha": "$(git -C "$repo_root" rev-parse HEAD)"
+}
+EOF
+
+echo "FINAL_IMAGE=$compressed_image"
+echo "CHECKSUM_FILE=$compressed_image.sha256"
+echo "IMAGE_INFO=$work_dir/image-info.json"

--- a/terraform/aws/orange-pi-images/main.tf
+++ b/terraform/aws/orange-pi-images/main.tf
@@ -110,6 +110,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "orange_pi_images" {
     }
   }
 
+  # GPU worker image lifecycle rule - delete old timestamped artifacts after 30 days
+  rule {
+    id     = "cleanup_gpu_worker_images"
+    status = "Enabled"
+
+    filter {
+      prefix = "images/ubuntu-amd64-gpu-worker/artifacts/"
+    }
+
+    expiration {
+      days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
   # General cleanup for other paths
   rule {
     id     = "cleanup_general"
@@ -155,7 +173,7 @@ resource "aws_iam_role" "github_actions_orangepi_build" {
   })
 }
 
-# S3 access policy for Orange Pi image builds
+# S3 access policy for node image builds
 resource "aws_iam_role_policy" "github_actions_orangepi_s3" {
   name = "orangepi-images-s3-policy"
   role = aws_iam_role.github_actions_orangepi_build.id
@@ -171,7 +189,10 @@ resource "aws_iam_role_policy" "github_actions_orangepi_s3" {
           "s3:PutObjectTagging",
           "s3:GetObject"
         ]
-        Resource = "${aws_s3_bucket.orange_pi_images.arn}/images/orange-pi-zero3/*"
+        Resource = [
+          "${aws_s3_bucket.orange_pi_images.arn}/images/orange-pi-zero3/*",
+          "${aws_s3_bucket.orange_pi_images.arn}/images/ubuntu-amd64-gpu-worker/*"
+        ]
       },
       {
         Effect = "Allow"
@@ -181,7 +202,10 @@ resource "aws_iam_role_policy" "github_actions_orangepi_s3" {
         Resource = aws_s3_bucket.orange_pi_images.arn
         Condition = {
           StringLike = {
-            "s3:prefix" = "images/orange-pi-zero3/*"
+            "s3:prefix" = [
+              "images/orange-pi-zero3/*",
+              "images/ubuntu-amd64-gpu-worker/*"
+            ]
           }
         }
       }
@@ -221,4 +245,3 @@ resource "aws_iam_user_policy_attachment" "boxp_orangepi_images_access" {
 }
 
 data "aws_caller_identity" "current" {}
-


### PR DESCRIPTION
## Summary

Adds the BOXP-23 Phase 2 GPU worker image pipeline for the lolice GPU worker project.

- Adds a manual GitHub Actions workflow to build Ubuntu amd64 GPU worker images for `golyat-4`.
- Adds `scripts/images/build-gpu-worker-image.sh` to customize Ubuntu cloud images with libguestfs, run the worker Ansible playbook, sysprep, compress, checksum, and emit metadata.
- Adds an image-build Ansible inventory and `worker-image.yml` for baseline worker configuration.
- Adds `golyat-4` inventory/vars entries and skips kubelet systemd enablement during chroot image customization.
- Extends the existing image S3 lifecycle/IAM policy for `images/ubuntu-amd64-gpu-worker/*`.
- Documents build, verification, flash gates, rollback, and recovery in `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md`.
- Includes the required project plan in `docs/project_docs/BOXP-23-worker-image-pipeline/plan.md`.

## Scope Notes

This is intentionally Phase 2 only. It does not flash the GMKtec internal NVMe, join the node to the cluster, install Intel Kubernetes device plugins, or add local LLM workloads. Those remain later BOXP-23 phases after the Windows backup and first-boot gates.

## Validation

Re-run in this workspace after rebasing onto current `origin/main`:

- `bash -n scripts/images/build-gpu-worker-image.sh`
- `git diff --check origin/main...HEAD`

Recorded in the project plan/log from the original local work:

- `ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml --syntax-check -e node_name=golyat-4 -e chroot_build=true`
- Local 16G smoke build in `/tmp/gpu-worker-image-smoke`
- Local 64G production build in `/tmp/gpu-worker-image-prod`
- `sha256sum -c /tmp/gpu-worker-image-prod/ubuntu-jammy-amd64-gpu-worker-golyat-4-20260627-044908-5782c8b6.img.xz.sha256`
- `xz --test /tmp/gpu-worker-image-prod/ubuntu-jammy-amd64-gpu-worker-golyat-4-20260627-044908-5782c8b6.img.xz`

Not re-run in this workspace because the tools are not installed in PATH:

- `ansible-playbook` is unavailable
- `terraform` is unavailable

The durable S3 upload is expected to run through GitHub Actions after review.