### PR TITLE
[codex] Fix GPU worker image workflow runner

### DIFF
--- a/.github/workflows/build-gpu-worker-image.yml
+++ b/.github/workflows/build-gpu-worker-image.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -51,6 +51,9 @@ jobs:
             qemu-utils \
             xz-utils
           sudo chmod 0644 /boot/vmlinuz-*
+          if [ -e /dev/kvm ]; then
+            sudo chmod 0666 /dev/kvm
+          fi
 
       - name: Build GPU worker image
         id: build
@@ -62,6 +65,7 @@ jobs:
           OUTPUT_DIR: build/gpu-worker-image
           LIBGUESTFS_BACKEND: direct
         run: |
+          set -o pipefail
           scripts/images/build-gpu-worker-image.sh | tee build-output.log
           final_image_line="$(grep '^FINAL_IMAGE=' build-output.log | tail -n1)"
           checksum_file_line="$(grep '^CHECKSUM_FILE=' build-output.log | tail -n1)"
@@ -69,6 +73,12 @@ jobs:
           final_image="${final_image_line#FINAL_IMAGE=}"
           checksum_file="${checksum_file_line#CHECKSUM_FILE=}"
           image_info="${image_info_line#IMAGE_INFO=}"
+          for output_path in "$final_image" "$checksum_file" "$image_info"; do
+            if [ -z "$output_path" ] || [ ! -f "$output_path" ]; then
+              echo "Missing expected build output: $output_path" >&2
+              exit 1
+            fi
+          done
           {
             echo "final_image=$final_image"
             echo "checksum_file=$checksum_file"

--- a/docs/project_docs/BOXP-23-gpu-worker-image-workflow-fix/plan.md
+++ b/docs/project_docs/BOXP-23-gpu-worker-image-workflow-fix/plan.md
@@ -1,0 +1,41 @@
+# BOXP-23: GPU worker image workflow fix
+
+## Goal
+
+Unblock the durable Phase 2 GPU worker image artifact build from `boxp/arch` main branch.
+
+## Context
+
+The first main-branch `Build GPU Worker Image` dispatch after BOXP-23 merge failed before S3 and GitHub artifact upload.
+
+- Run: `28310875665`
+- Ref: `main`
+- SHA: `d10efc324e5f2d54cd050bf4967e0b1a4bc68b00`
+- Failure: `virt-customize: error: libguestfs error: passt exited with status 1`
+- Workflow issue: the build step piped the script through `tee` without `pipefail`, so the step reported success and the following verify step received empty output paths.
+
+## Scope
+
+1. Pin the image build workflow to `ubuntu-22.04` instead of `ubuntu-latest` so libguestfs behavior does not change under the workflow.
+2. Make `/dev/kvm` usable on GitHub-hosted runners when present.
+3. Add `set -o pipefail` to the build step so script failures stop the job at the failing step.
+4. Validate that the image, checksum, and metadata files exist before writing step outputs.
+
+## Non-Goals
+
+- Do not change the generated image contents.
+- Do not alter S3 prefixes, retention, IAM policy, or artifact naming.
+- Do not write the image to the physical GPU worker in this fix.
+
+## Verification
+
+Local checks:
+
+- Parse `.github/workflows/build-gpu-worker-image.yml` as YAML.
+- `git diff --check`
+
+Remote checks after merge:
+
+- Dispatch `Build GPU Worker Image` from `main`.
+- Confirm `Verify image artifact`, `Upload image to S3`, and `Upload GitHub artifact` pass.
+- Record final image name, checksum, S3 stable path, S3 artifact prefix, and GitHub run URL in the Obsidian project log.


### PR DESCRIPTION
## Summary

Fix the BOXP-23 GPU worker image workflow after the first main-branch dispatch failed before durable artifact upload.

## Root Cause

The workflow used `ubuntu-latest`, which currently hit a libguestfs `passt exited with status 1` failure during `virt-customize` on GitHub-hosted runners. The build step also piped the script through `tee` without `pipefail`, so the failed build script was reported as a successful step and the verify step received empty artifact paths.

## Changes

- Pin `Build GPU Worker Image` to `ubuntu-22.04` for a stable libguestfs runner environment.
- Make `/dev/kvm` readable/writable on hosted runners when present.
- Add `set -o pipefail` to the build step.
- Validate generated image, checksum, and metadata paths before exporting workflow outputs.
- Add the required project plan at `docs/project_docs/BOXP-23-gpu-worker-image-workflow-fix/plan.md`.

## Validation

- `python3` YAML parse for `.github/workflows/build-gpu-worker-image.yml`
- `git diff --check`
- `actionlint .github/workflows/build-gpu-worker-image.yml`

Note: `ghalint run -c .github/workflows/build-gpu-worker-image.yml` currently fails on existing `.github/workflows/claude.yml` policy `checkout_persist_credentials_should_be_false`, unrelated to this change.
