### PR TITLE
[codex] Keep GPU worker images in S3 only

### DIFF
--- a/.github/workflows/build-gpu-worker-image.yml
+++ b/.github/workflows/build-gpu-worker-image.yml
@@ -135,16 +135,6 @@ jobs:
             --key "${S3_ARTIFACT_PREFIX}/${final_name}" \
             --tagging "TagSet=[{Key=NodeName,Value=${NODE_NAME}},{Key=BuildDate,Value=$(date +%Y-%m-%d)},{Key=GitSHA,Value=${GITHUB_SHA}}]"
 
-      - name: Upload GitHub artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: gpu-worker-image-${{ inputs.node_name }}
-          path: |
-            ${{ steps.build.outputs.final_image }}
-            ${{ steps.build.outputs.checksum_file }}
-            ${{ steps.build.outputs.image_info }}
-          retention-days: 7
-
       - name: Build summary
         run: |
           {
@@ -154,6 +144,7 @@ jobs:
             echo "- Image: $(basename "${{ steps.build.outputs.final_image }}")"
             echo "- Size: $(du -h "${{ steps.build.outputs.final_image }}" | cut -f1)"
             echo "- Checksum: $(cut -d' ' -f1 "${{ steps.build.outputs.checksum_file }}")"
+            echo "- Artifact storage: S3 only"
             echo "- S3 latest path: s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/${{ inputs.node_name }}/latest.img.xz"
             echo "- S3 artifact path: s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/artifacts/${{ inputs.node_name }}/"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
+++ b/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
@@ -39,11 +39,7 @@ s3://arch-orange-pi-images/images/ubuntu-amd64-gpu-worker/artifacts/golyat-4/
 
 Timestamped S3 objects under the `artifacts/` prefix expire after 30 days. `latest.img.xz`, `latest.img.xz.sha256`, and `image-info.json` under the stable node prefix are overwritten on each successful build and are not current-object expiration targets. Noncurrent versions are retained for 30 days by the bucket lifecycle policy.
 
-The workflow also uploads a 7-day GitHub Actions artifact containing:
-
-- `ubuntu-jammy-amd64-gpu-worker-<node>-<timestamp>-<sha>.img.xz`
-- matching `.sha256`
-- `image-info.json`
+The workflow intentionally does not upload the image to GitHub Actions artifacts. The customized image can include node access material and must stay in the private S3 image bucket, matching the Orange Pi image workflow storage model.
 
 The Phase 2 local artifact verified on 2026-06-27 was:
 

--- a/docs/project_docs/BOXP-23-gpu-worker-image-s3-only/plan.md
+++ b/docs/project_docs/BOXP-23-gpu-worker-image-s3-only/plan.md
@@ -1,0 +1,35 @@
+# BOXP-23: GPU worker image S3-only artifacts
+
+## Goal
+
+Prevent the GPU worker image from being exposed as a GitHub Actions artifact. The image should be stored only in the private AWS S3 image bucket, matching the Orange Pi image workflow.
+
+## Context
+
+The GPU worker image is customized for node bootstrapping. Even if SSH host keys are regenerated later, image distribution should assume node access material can be sensitive. GitHub Actions artifacts are not the desired storage boundary for this image.
+
+The previous `Build GPU Worker Image` run uploaded `gpu-worker-image-golyat-4` as a GitHub Actions artifact. That artifact must be deleted, and future runs must not create a replacement GitHub artifact.
+
+## Scope
+
+1. Remove the `Upload GitHub artifact` step from `.github/workflows/build-gpu-worker-image.yml`.
+2. Keep S3 upload, stable latest objects, timestamped artifacts, checksums, and metadata unchanged.
+3. Update the build summary to state that artifact storage is S3-only.
+4. Update `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md` to document that GitHub Actions artifacts are intentionally not used for GPU worker images.
+5. Delete existing GitHub Actions artifact `gpu-worker-image-golyat-4` from run `28311016611`.
+6. Re-run the workflow from `main` after merge and verify that S3 upload succeeds and no GitHub artifact is created.
+
+## Non-Goals
+
+- Do not change the image contents.
+- Do not change S3 bucket names, prefixes, retention, or IAM policy.
+- Do not write the image to the physical GPU worker.
+
+## Verification
+
+- Parse `.github/workflows/build-gpu-worker-image.yml` as YAML.
+- Run `actionlint .github/workflows/build-gpu-worker-image.yml`.
+- Run `git diff --check`.
+- Confirm no `actions/upload-artifact` reference remains in the GPU worker image workflow.
+- Confirm artifact ID `7931086983` is deleted.
+- Confirm a post-merge `Build GPU Worker Image` run succeeds with no GitHub Actions artifacts.


### PR DESCRIPTION
## Summary

Keep BOXP-23 GPU worker image artifacts in S3 only, matching the Orange Pi image workflow.

## Why

The GPU worker image is a bootable node image and should be treated as sensitive because it can contain node access material. GitHub Actions artifacts are not the intended storage boundary for this image.

## Changes

- Remove the `Upload GitHub artifact` step from `build-gpu-worker-image.yml`.
- Leave S3 stable and timestamped uploads unchanged.
- Mark the build summary as `Artifact storage: S3 only`.
- Update `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md` to state that GitHub Actions artifacts are intentionally not used.
- Add the required project plan at `docs/project_docs/BOXP-23-gpu-worker-image-s3-only/plan.md`.

## Immediate Cleanup

Deleted the existing GitHub Actions artifact from run `28311016611`:

- artifact: `gpu-worker-image-golyat-4`
- artifact ID: `7931086983`
- verification: run artifact count is now `0`

## Validation

- `python3` YAML parse for `.github/workflows/build-gpu-worker-image.yml`
- `actionlint .github/workflows/build-gpu-worker-image.yml`
- `git diff --check`
- Confirmed no `actions/upload-artifact` reference remains in the GPU worker image workflow

Post-merge, run `Build GPU Worker Image` from `main` and confirm S3 upload succeeds with no GitHub Actions artifacts.
