### PR TITLE
[codex] Grow GPU worker root filesystem on first boot

### DIFF
--- a/ansible/playbooks/worker-image.yml
+++ b/ansible/playbooks/worker-image.yml
@@ -17,6 +17,8 @@
       - lsb-release
       - openssh-server
       - sudo
+      - cloud-guest-utils
+      - e2fsprogs
       - vim
     worker_gpu_host_packages:
       - clinfo
@@ -121,6 +123,101 @@
         kubelet_node_ip: "{{ node_ip }}"
 
   tasks:
+    - name: Install root filesystem grow script
+      ansible.builtin.copy:
+        dest: /usr/local/sbin/lolice-grow-rootfs
+        mode: "0755"
+        content: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          marker="/var/lib/lolice-grow-rootfs.done"
+          log_file="/var/log/lolice-grow-rootfs.log"
+
+          mkdir -p "$(dirname "$marker")"
+          exec > >(tee -a "$log_file") 2>&1
+
+          if [ -e "$marker" ]; then
+            echo "Root filesystem grow already completed: $marker"
+            exit 0
+          fi
+
+          root_source="$(findmnt -n -o SOURCE /)"
+          root_device="$(readlink -f "$root_source" 2>/dev/null || true)"
+          root_fstype="$(findmnt -n -o FSTYPE /)"
+
+          if [ -z "$root_device" ] || [ ! -b "$root_device" ]; then
+            root_majmin="$(findmnt -n -o MAJ:MIN /)"
+            root_device="$(lsblk -rpno NAME,MAJ:MIN | awk -v majmin="$root_majmin" '$2 == majmin { print $1; exit }')"
+          fi
+
+          if [[ "$root_device" != /dev/* ]] || [ ! -b "$root_device" ]; then
+            echo "Unsupported root source: $root_source resolved to $root_device" >&2
+            exit 1
+          fi
+
+          disk_name="$(lsblk -no PKNAME "$root_device" | tr -d '[:space:]')"
+          part_num="$(lsblk -no PARTN "$root_device" | tr -d '[:space:]')"
+
+          if [ -z "$disk_name" ] || [ -z "$part_num" ]; then
+            echo "Could not determine parent disk or partition number for $root_device" >&2
+            lsblk -o NAME,PKNAME,PARTN,FSTYPE,SIZE,MOUNTPOINTS
+            exit 1
+          fi
+
+          disk="/dev/${disk_name}"
+          echo "Growing root partition: disk=$disk partition=$part_num root=$root_device fstype=$root_fstype"
+
+          growpart "$disk" "$part_num"
+          partprobe "$disk" || true
+          udevadm settle || true
+
+          case "$root_fstype" in
+            ext2|ext3|ext4)
+              resize2fs "$root_device"
+              ;;
+            xfs)
+              xfs_growfs /
+              ;;
+            btrfs)
+              btrfs filesystem resize max /
+              ;;
+            *)
+              echo "Unsupported root filesystem type: $root_fstype" >&2
+              exit 1
+              ;;
+          esac
+
+          date -u +%Y-%m-%dT%H:%M:%SZ > "$marker"
+          echo "Root filesystem grow completed"
+      tags: [bootstrap, grow-rootfs]
+
+    - name: Install root filesystem grow systemd service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/lolice-grow-rootfs.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Grow lolice worker root filesystem to fill disk
+          After=local-fs.target
+          ConditionPathExists=!/var/lib/lolice-grow-rootfs.done
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/lolice-grow-rootfs
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+      tags: [bootstrap, grow-rootfs]
+
+    - name: Enable root filesystem grow service via symlink
+      ansible.builtin.file:
+        src: /etc/systemd/system/lolice-grow-rootfs.service
+        dest: /etc/systemd/system/multi-user.target.wants/lolice-grow-rootfs.service
+        state: link
+      tags: [bootstrap, grow-rootfs]
+
     - name: Record worker image build metadata
       ansible.builtin.copy:
         dest: /etc/lolice-worker-image

--- a/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
+++ b/docs/GPU_WORKER_IMAGE_DEPLOYMENT.md
@@ -41,6 +41,8 @@ Timestamped S3 objects under the `artifacts/` prefix expire after 30 days. `late
 
 The workflow intentionally does not upload the image to GitHub Actions artifacts. The customized image can include node access material and must stay in the private S3 image bucket, matching the Orange Pi image workflow storage model.
 
+The image is built at the requested `image_size`, currently `64G`, and includes `lolice-grow-rootfs.service`. On first boot, that service runs `growpart` against the mounted root partition and resizes the root filesystem so the flashed image can use the full target disk.
+
 The Phase 2 local artifact verified on 2026-06-27 was:
 
 ```text
@@ -101,6 +103,15 @@ sudo partprobe /dev/nvmeXn1
 ```
 
 First boot should reach SSH with the baked `boxp` account. Cluster join is performed later with `kubeadm join`.
+
+After first boot, confirm root filesystem expansion:
+
+```bash
+systemctl status lolice-grow-rootfs.service --no-pager
+cat /var/log/lolice-grow-rootfs.log
+lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINTS
+df -h /
+```
 
 ## Rollback And Recovery
 

--- a/docs/project_docs/BOXP-23-gpu-worker-grow-root/plan.md
+++ b/docs/project_docs/BOXP-23-gpu-worker-grow-root/plan.md
@@ -1,0 +1,36 @@
+# BOXP-23: GPU worker root filesystem growth
+
+## Goal
+
+Ensure the GPU worker image expands its root partition and filesystem to fill the target disk after it is flashed to physical storage.
+
+## Context
+
+The current image builder expands the Ubuntu cloud image only to the workflow input `image_size`, currently `64G`:
+
+- `qemu-img create -f qcow2 "$qcow_image" "$IMAGE_SIZE"`
+- `virt-resize --expand /dev/sda1 "$cache_dir/$base_image" "$qcow_image"`
+
+No GPU worker image task currently installs or enables an explicit first-boot `growpart` / filesystem resize path. That means a `64G` image flashed to a larger NVMe should be expected to keep a roughly 64G root filesystem unless some implicit cloud-init behavior happens to run. The image should not depend on that implicit behavior.
+
+## Scope
+
+1. Install `cloud-guest-utils` and `e2fsprogs` in the worker image.
+2. Add `/usr/local/sbin/lolice-grow-rootfs`.
+3. Add and enable `lolice-grow-rootfs.service` as a first-boot systemd oneshot.
+4. Detect the mounted root device with `findmnt`, resolve parent disk and partition number with `lsblk`, run `growpart`, then resize the mounted root filesystem.
+5. Write `/var/lib/lolice-grow-rootfs.done` only after success so the service runs once.
+6. Document the first-boot expansion behavior and verification commands.
+
+## Non-Goals
+
+- Do not change the default image build size.
+- Do not change S3 artifact storage paths or retention.
+- Do not write the image to the physical GPU worker.
+
+## Verification
+
+- `ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml --syntax-check -e node_name=golyat-4 -e chroot_build=true`
+- YAML parse for `.github/workflows/build-gpu-worker-image.yml` and `ansible/playbooks/worker-image.yml`
+- `git diff --check`
+- Post-merge `Build GPU Worker Image` run from `main` succeeds and uploads only to S3.


### PR DESCRIPTION
## Summary

Add an explicit first-boot root filesystem growth path to the BOXP-23 GPU worker image.

## Current Behavior Checked

The GPU worker image builder currently expands the Ubuntu cloud image only to the workflow input `image_size`, currently `64G`:

- `qemu-img create -f qcow2 "$qcow_image" "$IMAGE_SIZE"`
- `virt-resize --expand /dev/sda1 "$cache_dir/$base_image" "$qcow_image"`

There was no explicit GPU worker first-boot `growpart` / filesystem resize task. Relying on implicit cloud-init behavior is too weak for the physical worker flash path.

## Changes

- Install `cloud-guest-utils` and `e2fsprogs` in the worker image.
- Add `/usr/local/sbin/lolice-grow-rootfs`.
- Add and enable `lolice-grow-rootfs.service` as a first-boot systemd oneshot.
- Detect the mounted root device with `findmnt`, resolve parent disk and partition number with `lsblk`, run `growpart`, then resize the mounted root filesystem.
- Write `/var/lib/lolice-grow-rootfs.done` after success so the service runs once.
- Document first-boot expansion and verification commands in `docs/GPU_WORKER_IMAGE_DEPLOYMENT.md`.
- Add the required project plan at `docs/project_docs/BOXP-23-gpu-worker-grow-root/plan.md`.

## Validation

- YAML parse for `.github/workflows/build-gpu-worker-image.yml`
- YAML parse for `ansible/playbooks/worker-image.yml`
- `ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml --syntax-check -e node_name=golyat-4 -e chroot_build=true`
- `uv run ansible-lint playbooks/worker-image.yml`
- `bash -n` on the embedded `lolice-grow-rootfs` script extracted from YAML
- `git diff --check`

Post-merge, dispatch `Build GPU Worker Image` from `main` and confirm it uploads only to S3.
