### PR TITLE
[codex] Fix GPU worker first boot

### DIFF
--- a/.github/workflows/apply-ansible.yml
+++ b/.github/workflows/apply-ansible.yml
@@ -16,11 +16,11 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node: [shanghai-1, shanghai-2, shanghai-3]
+        node: [shanghai-1, shanghai-2, shanghai-3, golyat-4]
       max-parallel: 1
       fail-fast: true
     env:
-      NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104"}'
+      NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104","golyat-4":"192.168.10.107"}'
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -121,18 +121,33 @@ jobs:
           cd ansible
           uv sync
 
-      - name: Run control-plane playbook
+      - name: Run primary node playbook
         run: |
           cd ansible
           source .venv/bin/activate
 
-          echo "Running control-plane playbook on node: ${{ matrix.node }}"
+          NODE="${{ matrix.node }}"
+          if [[ "$NODE" == shanghai-* ]]; then
+            PLAYBOOK="playbooks/control-plane.yml"
+            PLAYBOOK_NAME="control-plane"
+            EXTRA_ARGS=()
+          elif [[ "$NODE" == golyat-* ]]; then
+            PLAYBOOK="playbooks/worker-image.yml"
+            PLAYBOOK_NAME="worker-image"
+            EXTRA_ARGS=(-e "worker_configure_static_network=true" -e "worker_static_network_interface=enp44s0")
+          else
+            echo "::error::Unsupported Ansible target node: $NODE"
+            exit 1
+          fi
+
+          echo "Running ${PLAYBOOK_NAME} playbook on node: ${NODE}"
           ansible-playbook \
             -i inventories/production/hosts.yml \
-            playbooks/control-plane.yml \
-            --limit ${{ matrix.node }} \
+            "$PLAYBOOK" \
+            --limit "$NODE" \
             -e "ansible_ssh_common_args=''" \
-            -e "node_name=${{ matrix.node }}" \
+            -e "node_name=${NODE}" \
+            "${EXTRA_ARGS[@]}" \
             -v
 
       - name: Run node-specific playbook

--- a/.github/workflows/plan-ansible.yml
+++ b/.github/workflows/plan-ansible.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node: [shanghai-1, shanghai-2, shanghai-3]
+        node: [shanghai-1, shanghai-2, shanghai-3, golyat-4]
       fail-fast: false
     env:
-      NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104"}'
+      NODE_IPS: '{"shanghai-1":"192.168.10.102","shanghai-2":"192.168.10.103","shanghai-3":"192.168.10.104","golyat-4":"192.168.10.107"}'
       AQUA_POLICY_CONFIG: ${{ github.workspace }}/aqua/aqua-policy.yaml
     steps:
       - name: Checkout
@@ -164,6 +164,7 @@ jobs:
             local node="$2"
             local playbook_name="$3"
             local output_file="$4"
+            shift 4
             local json_file="plan_outputs/${node}-${playbook_name}.json"
 
             set +e
@@ -174,6 +175,7 @@ jobs:
               --limit "$node" \
               -e "ansible_ssh_common_args=''" \
               -e "node_name=$node" \
+              "$@" \
               --check --diff \
               > "$json_file" \
               2>"plan_outputs/${node}-${playbook_name}.stderr"
@@ -202,8 +204,18 @@ jobs:
             return 0
           }
 
-          run_ansible "playbooks/control-plane.yml" "$NODE" "control-plane" \
-            "plan_outputs/${NODE}-control-plane.fmt.json"
+          if [[ "$NODE" == shanghai-* ]]; then
+            run_ansible "playbooks/control-plane.yml" "$NODE" "control-plane" \
+              "plan_outputs/${NODE}-control-plane.fmt.json"
+          elif [[ "$NODE" == golyat-* ]]; then
+            run_ansible "playbooks/worker-image.yml" "$NODE" "worker-image" \
+              "plan_outputs/${NODE}-worker-image.fmt.json" \
+              -e "worker_configure_static_network=true" \
+              -e "worker_static_network_interface=enp44s0"
+          else
+            echo "::error::Unsupported Ansible target node: $NODE"
+            exit 1
+          fi
 
           PLAYBOOK="playbooks/node-${NODE}.yml"
           if [ -f "$PLAYBOOK" ]; then

--- a/ansible/playbooks/worker-image.yml
+++ b/ansible/playbooks/worker-image.yml
@@ -14,12 +14,18 @@
       - curl
       - gnupg
       - jq
+      - linux-firmware
       - lsb-release
       - openssh-server
+      - python3-apt
       - sudo
       - cloud-guest-utils
       - e2fsprogs
       - vim
+      - wireless-regdb
+    worker_extra_kernel_modules_package: true
+    worker_static_network_interface: enp44s0
+    worker_static_networkd_config: /etc/systemd/network/20-wired.network
     worker_gpu_host_packages:
       - clinfo
       - intel-gpu-tools
@@ -36,7 +42,7 @@
 
     - name: Detect chroot environment
       ansible.builtin.set_fact:
-        is_chroot: "{{ worker_chroot_check.stat.ino is not defined or worker_chroot_check.stat.ino != 2 }}"
+        is_chroot: "{{ chroot_build | default(false) | bool }}"
       tags: [always]
 
     - name: Install worker base packages
@@ -44,6 +50,24 @@
         name: "{{ worker_base_packages }}"
         state: present
         update_cache: true
+      tags: [bootstrap, packages]
+
+    - name: Find installed generic kernel module trees
+      ansible.builtin.find:
+        paths: /lib/modules
+        file_type: directory
+        patterns: "*-generic"
+      register: worker_generic_kernel_modules
+      tags: [bootstrap, packages]
+
+    - name: Install extra modules for installed generic kernels
+      ansible.builtin.apt:
+        name: "{{ worker_generic_kernel_modules.files | map(attribute='path') | map('basename') | map('regex_replace', '^(.*)$', 'linux-modules-extra-\\1') | list }}"
+        state: present
+        update_cache: true
+      when:
+        - worker_extra_kernel_modules_package | bool
+        - worker_generic_kernel_modules.files | length > 0
       tags: [bootstrap, packages]
 
     - name: Install optional Intel GPU host smoke-test tools
@@ -82,6 +106,47 @@
       when: is_chroot | bool
       tags: [ssh, bootstrap]
 
+    - name: Install SSH runtime directory tmpfiles rule
+      ansible.builtin.copy:
+        dest: /etc/tmpfiles.d/lolice-sshd.conf
+        mode: "0644"
+        content: |
+          d /run/sshd 0755 root root -
+      tags: [ssh, bootstrap]
+
+    - name: Install first boot SSH host key service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/lolice-ssh-hostkeys.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Generate SSH host keys before sshd starts
+          Before=ssh.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/mkdir -p /run/sshd
+          ExecStart=/usr/bin/ssh-keygen -A
+
+          [Install]
+          WantedBy=ssh.service
+      tags: [ssh, bootstrap]
+
+    - name: Create ssh.service.wants directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/ssh.service.wants
+        state: directory
+        mode: "0755"
+      tags: [ssh, bootstrap]
+
+    - name: Enable first boot SSH host key service via symlink
+      ansible.builtin.file:
+        src: /etc/systemd/system/lolice-ssh-hostkeys.service
+        dest: /etc/systemd/system/ssh.service.wants/lolice-ssh-hostkeys.service
+        state: link
+        force: true
+      tags: [ssh, bootstrap]
+
     - name: Configure SSH server
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
@@ -96,20 +161,53 @@
       notify: Restart SSH service
       tags: [ssh, bootstrap]
 
+    - name: Create systemd-networkd configuration directory
+      ansible.builtin.file:
+        path: /etc/systemd/network
+        state: directory
+        mode: "0755"
+      when: worker_configure_static_network | bool
+      tags: [network, bootstrap]
+
+    - name: Remove worker netplan static configuration
+      ansible.builtin.file:
+        path: "/etc/netplan/01-static-{{ worker_static_network_interface }}.yaml"
+        state: absent
+      when: worker_configure_static_network | bool
+      tags: [network, bootstrap]
+
+    - name: Configure worker static network with systemd-networkd
+      ansible.builtin.copy:
+        dest: "{{ worker_static_networkd_config }}"
+        mode: "0644"
+        content: |
+          [Match]
+          Name={{ worker_static_network_interface }}
+
+          [Network]
+          Address={{ node_ip }}/24
+          Gateway={{ cluster.gateway }}
+          {% for dns in cluster.dns_servers %}
+          DNS={{ dns }}
+          {% endfor %}
+      notify: Restart systemd-networkd
+      when: worker_configure_static_network | bool
+      tags: [network, bootstrap]
+
+    - name: Enable systemd-networkd service via symlink
+      ansible.builtin.file:
+        src: /lib/systemd/system/systemd-networkd.service
+        dest: /etc/systemd/system/multi-user.target.wants/systemd-networkd.service
+        state: link
+      when: worker_configure_static_network | bool
+      tags: [network, bootstrap]
+
   roles:
     - role: user_management
       tags: [users, bootstrap]
       vars:
         user_management_use_github_keys: true
         user_management_github_username: "boxp"
-
-    - role: network_configuration
-      tags: [network, bootstrap]
-      vars:
-        network_ip_address: "{{ node_ip }}"
-        network_gateway: "{{ cluster.gateway }}"
-        network_dns_servers: "{{ cluster.dns_servers }}"
-      when: worker_configure_static_network | bool
 
     - role: kubernetes_components
       tags: [kubernetes, k8s-components]
@@ -157,18 +255,25 @@
           fi
 
           disk_name="$(lsblk -no PKNAME "$root_device" | tr -d '[:space:]')"
-          part_num="$(lsblk -no PARTN "$root_device" | tr -d '[:space:]')"
+          root_block="$(basename "$root_device")"
+          part_num="$(cat "/sys/class/block/${root_block}/partition" 2>/dev/null || true)"
 
           if [ -z "$disk_name" ] || [ -z "$part_num" ]; then
             echo "Could not determine parent disk or partition number for $root_device" >&2
-            lsblk -o NAME,PKNAME,PARTN,FSTYPE,SIZE,MOUNTPOINTS
+            lsblk -o NAME,PKNAME,FSTYPE,SIZE,MOUNTPOINTS
             exit 1
           fi
 
           disk="/dev/${disk_name}"
           echo "Growing root partition: disk=$disk partition=$part_num root=$root_device fstype=$root_fstype"
 
-          growpart "$disk" "$part_num"
+          growpart_rc=0
+          growpart_output="$(growpart "$disk" "$part_num" 2>&1)" || growpart_rc=$?
+          echo "$growpart_output"
+          if [ "$growpart_rc" -ne 0 ] && ! grep -q '^NOCHANGE:' <<< "$growpart_output"; then
+            exit "$growpart_rc"
+          fi
+
           partprobe "$disk" || true
           udevadm settle || true
 
@@ -235,5 +340,11 @@
     - name: Restart SSH service
       ansible.builtin.systemd:
         name: ssh
+        state: restarted
+      when: not (is_chroot | default(false) | bool)
+
+    - name: Restart systemd-networkd
+      ansible.builtin.systemd:
+        name: systemd-networkd
         state: restarted
       when: not (is_chroot | default(false) | bool)

--- a/ansible/roles/kubernetes_components/tasks/kubelet.yml
+++ b/ansible/roles/kubernetes_components/tasks/kubelet.yml
@@ -54,7 +54,7 @@
   ansible.builtin.copy:
     content: |
       [Service]
-      Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
+      Environment="KUBELET_RESOLV_CONF_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
     dest: /etc/systemd/system/kubelet.service.d/10-resolv-conf.conf
     mode: '0644'
   become: true

--- a/ansible/roles/kubernetes_components/tasks/system_preparation.yml
+++ b/ansible/roles/kubernetes_components/tasks/system_preparation.yml
@@ -10,7 +10,7 @@
 
 - name: Set chroot fact
   ansible.builtin.set_fact:
-    is_chroot: "{{ chroot_check.stat.ino is not defined or chroot_check.stat.ino != 2 }}"
+    is_chroot: "{{ chroot_build | default(false) | bool }}"
 
 - name: Disable swap
   ansible.builtin.command: swapoff -a

--- a/ansible/roles/kubernetes_components/templates/10-kubeadm.conf.j2
+++ b/ansible/roles/kubernetes_components/templates/10-kubeadm.conf.j2
@@ -2,10 +2,11 @@
 [Service]
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_CONFIG_ARGS=--config=/etc/kubernetes/kubelet-config.yaml"
+Environment="KUBELET_RESOLV_CONF_ARGS="
 {% if detected_node_ip is defined and detected_node_ip != "" %}
 Environment="KUBELET_EXTRA_ARGS=--node-ip={{ detected_node_ip }}"
 {% else %}
 Environment="KUBELET_EXTRA_ARGS="
 {% endif %}
 ExecStart=
-ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_RESOLV_CONF_ARGS $KUBELET_EXTRA_ARGS

--- a/ansible/roles/network_configuration/molecule/default/verify.yml
+++ b/ansible/roles/network_configuration/molecule/default/verify.yml
@@ -46,7 +46,7 @@
     - name: Assert WiFi and Bluetooth are blocked
       ansible.builtin.assert:
         that:
-          - wifi_status.rc != 0 or 'blocked: yes' in wifi_status.stdout
-          - bt_status.rc != 0 or 'blocked: yes' in bt_status.stdout
+          - "wifi_status.rc != 0 or 'blocked: yes' in wifi_status.stdout"
+          - "bt_status.rc != 0 or 'blocked: yes' in bt_status.stdout"
         fail_msg: "WiFi or Bluetooth is not disabled"
-      when: wifi_status.rc == 0 or bt_status.rc == 0
+      when: "wifi_status.rc == 0 or bt_status.rc == 0"

--- a/ansible/roles/network_configuration/molecule/default/verify.yml
+++ b/ansible/roles/network_configuration/molecule/default/verify.yml
@@ -31,22 +31,21 @@
           - "'renderer: networkd' in netplan_config_content"
         fail_msg: "Static IP configuration not found"
 
-    - name: Check if WiFi is disabled
-      ansible.builtin.command: rfkill list wifi
-      register: wifi_status
-      changed_when: false
-      failed_when: false
+    - name: Check disable-wireless service
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/disable-wireless.service
+      register: disable_wireless_service
 
-    - name: Check if Bluetooth is disabled
-      ansible.builtin.command: rfkill list bluetooth
-      register: bt_status
-      changed_when: false
-      failed_when: false
+    - name: Check disable-wireless service symlink
+      ansible.builtin.stat:
+        path: /etc/systemd/system/multi-user.target.wants/disable-wireless.service
+      register: disable_wireless_symlink
 
-    - name: Assert WiFi and Bluetooth are blocked
+    - name: Assert WiFi and Bluetooth are disabled on boot
       ansible.builtin.assert:
         that:
-          - "wifi_status.rc != 0 or 'blocked: yes' in wifi_status.stdout"
-          - "bt_status.rc != 0 or 'blocked: yes' in bt_status.stdout"
-        fail_msg: "WiFi or Bluetooth is not disabled"
-      when: "wifi_status.rc == 0 or bt_status.rc == 0"
+          - "'ExecStart=/usr/sbin/rfkill block wifi' in (disable_wireless_service.content | b64decode)"
+          - "'ExecStart=/usr/sbin/rfkill block bluetooth' in (disable_wireless_service.content | b64decode)"
+          - disable_wireless_symlink.stat.islnk
+          - disable_wireless_symlink.stat.lnk_source == '/etc/systemd/system/disable-wireless.service'
+        fail_msg: "WiFi and Bluetooth disable service is not configured"

--- a/ansible/roles/network_configuration/tasks/main.yml
+++ b/ansible/roles/network_configuration/tasks/main.yml
@@ -15,10 +15,16 @@
   ansible.builtin.package:
     name:
       - iproute2
-      - rfkill
       - netplan.io
     state: present
   become: true
+
+- name: Install rfkill when wireless devices should be disabled
+  ansible.builtin.package:
+    name: rfkill
+    state: present
+  become: true
+  when: network_disable_wifi or network_disable_bluetooth
 
 - name: Ensure netplan directory exists
   ansible.builtin.file:

--- a/docs/project_docs/BOXP-23-worker-image-first-boot/plan.md
+++ b/docs/project_docs/BOXP-23-worker-image-first-boot/plan.md
@@ -1,0 +1,41 @@
+# B0XP-23 worker image first boot fixes
+
+## Context
+
+Phase 3 first boot on `golyat-4` proved that the 16GiB GPU worker image can boot from the EVO-T1 internal NVMe and expand rootfs to 1.9T. The smoke test also found first boot gaps that must be fixed in the image before treating the pipeline as production ready.
+
+## Required fixes
+
+- Include RTL8125 support in the image:
+  - `linux-modules-extra-*` for the installed generic kernel, providing `r8169`.
+  - `linux-firmware`, providing `rtl_nic/rtl8125b-2.fw`.
+  - `wireless-regdb`, required by `linux-modules-extra-*`.
+- Generate SSH host keys on first boot after `virt-sysprep` removes build-time keys.
+- Ensure `/run/sshd` exists before `ssh.service` starts.
+- Configure `golyat-4` static networking on `enp44s0` with `192.168.10.107/24` directly via `systemd-networkd`; this node does not require netplan.
+- Fix `lolice-grow-rootfs` partition-number detection on Ubuntu 22.04, where `lsblk -o PARTN` is unavailable.
+- Prevent kubelet drop-ins from overriding `--node-ip` when adding `--resolv-conf`.
+- Include `golyat-4` in normal Ansible plan/apply targets now that SSH access is working.
+- Use explicit `chroot_build=true` as the chroot signal so live `golyat-4` plan/apply does not skip runtime module, swap, sysctl, and service tasks.
+
+## Implementation
+
+- Extend `ansible/playbooks/worker-image.yml` with firmware packages, dynamic install of `linux-modules-extra-$kernel`, SSH first-boot service, `tmpfiles.d` rule for `/run/sshd`, direct `systemd-networkd` static network configuration, and grow-rootfs sysfs-based partition number lookup.
+- Update `scripts/images/build-gpu-worker-image.sh` so static networking is enabled by default for the GPU worker image and the interface defaults to `enp44s0`.
+- Remove worker netplan static config during plan/apply and keep `/etc/systemd/network/20-wired.network` as the managed source.
+- Update kubelet systemd drop-ins so `--resolv-conf` uses a separate `KUBELET_RESOLV_CONF_ARGS` variable instead of overwriting `KUBELET_EXTRA_ARGS`.
+- Extend `plan-ansible.yml` and `apply-ansible.yml` to include `golyat-4` and select `worker-image.yml` for `golyat-*` targets instead of applying `control-plane.yml`.
+- Change worker and Kubernetes component chroot detection to rely on the explicit `chroot_build` variable.
+
+## Verification
+
+- `bash -n scripts/images/build-gpu-worker-image.sh`
+- YAML parse for modified Ansible files.
+- YAML parse for modified GitHub Actions workflows.
+- Ansible syntax-check for `playbooks/worker-image.yml` if `ansible-playbook` is available.
+- Future image rebuild smoke:
+  - boot `golyat-4` from rebuilt image without manual driver ISO.
+  - confirm `ip link` shows RTL8125 ports before manual package installation.
+  - confirm `enp44s0` has `192.168.10.107/24`.
+  - confirm `ssh boxp@192.168.10.107` works after first boot.
+  - confirm `/` expands to roughly 1.9T and `lolice-grow-rootfs.service` does not remain failed.

--- a/scripts/images/build-gpu-worker-image.sh
+++ b/scripts/images/build-gpu-worker-image.sh
@@ -6,6 +6,8 @@ BASE_RELEASE="${BASE_RELEASE:-jammy}"
 IMAGE_SIZE="${IMAGE_SIZE:-16G}"
 OUTPUT_DIR="${OUTPUT_DIR:-build/gpu-worker-image}"
 INSTALL_GPU_HOST_TOOLS="${INSTALL_GPU_HOST_TOOLS:-false}"
+CONFIGURE_STATIC_NETWORK="${CONFIGURE_STATIC_NETWORK:-true}"
+WORKER_NETWORK_INTERFACE="${WORKER_NETWORK_INTERFACE:-enp44s0}"
 GUESTFS_MEMSIZE="${GUESTFS_MEMSIZE:-4096}"
 GUESTFS_SMP="${GUESTFS_SMP:-2}"
 
@@ -85,7 +87,7 @@ virt-customize \
   --run-command "python3 -m venv /opt/ansible-venv" \
   --run-command "/opt/ansible-venv/bin/python -m pip install --no-cache-dir ansible==9.13.0" \
   --run-command "LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/ansible-venv/bin:\$PATH ansible-galaxy collection install -r /opt/arch-ansible/ansible/requirements.yml" \
-  --run-command "cd /opt/arch-ansible/ansible && LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/ansible-venv/bin:\$PATH ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml -e node_name=${NODE_NAME} -e worker_install_gpu_host_tools=${INSTALL_GPU_HOST_TOOLS} -e chroot_build=true" \
+  --run-command "cd /opt/arch-ansible/ansible && LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/ansible-venv/bin:\$PATH ansible-playbook -i inventories/image-build/hosts.ini playbooks/worker-image.yml -e node_name=${NODE_NAME} -e worker_install_gpu_host_tools=${INSTALL_GPU_HOST_TOOLS} -e worker_configure_static_network=${CONFIGURE_STATIC_NETWORK} -e worker_static_network_interface=${WORKER_NETWORK_INTERFACE} -e chroot_build=true" \
   --run-command "apt-get clean" \
   --run-command "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /opt/arch-ansible /opt/ansible-venv"
 


### PR DESCRIPTION
## Summary
- add first-boot requirements for the golyat-4 GPU worker image: RTL8125 modules/firmware, SSH host key generation, /run/sshd tmpfiles, and rootfs grow NOCHANGE handling
- manage golyat-4 static networking directly with systemd-networkd instead of netplan
- include golyat-4 in Ansible plan/apply workflows using worker-image.yml
- keep kubelet --node-ip and --resolv-conf drop-ins from overriding each other

## Why
The Phase 3 first boot smoke on golyat-4 showed the 16GiB image boots and expands on the EVO-T1 NVMe, but the image needed manual recovery for RTL8125 networking, SSH host keys, static IP, and grow-rootfs service state. These fixes make that recovery reproducible through the worker image playbook and normal Ansible plan/apply.

## Validation
- bash -n scripts/images/build-gpu-worker-image.sh
- YAML parse for worker-image.yml and modified GitHub Actions workflows
- git diff --check
- ansible-playbook -i inventories/production/hosts.yml playbooks/worker-image.yml --syntax-check -e node_name=golyat-4 -e worker_configure_static_network=true -e worker_static_network_interface=enp44s0
- ansible-playbook -i inventories/production/hosts.yml playbooks/worker-image.yml --limit golyat-4 -e "ansible_ssh_common_args=''" -e node_name=golyat-4 -e worker_configure_static_network=true -e worker_static_network_interface=enp44s0 --check --diff
- applied worker-image.yml to live golyat-4 successfully
- verified live golyat-4: SSH active, CRI-O active, systemd-networkd active, enp44s0 192.168.10.107/24, /etc/netplan empty, rootfs 1.9T, lolice-grow-rootfs active (exited)

## Notes
kubelet remains in the expected pre-join state because /etc/kubernetes/bootstrap-kubelet.conf is not present until kubeadm join.