### PR TITLE
Add llama SYCL image build

### DIFF
--- a/.github/workflows/build-llama-sycl-image.yml
+++ b/.github/workflows/build-llama-sycl-image.yml
@@ -1,0 +1,71 @@
+name: Build llama-server SYCL Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['docker/llama-sycl/**']
+  pull_request:
+    paths: ['docker/llama-sycl/**', '.github/workflows/build-llama-sycl-image.yml']
+  workflow_dispatch:
+    inputs:
+      llama_repo:
+        description: 'llama.cpp source repository'
+        required: true
+        default: 'https://github.com/TheTom/llama-cpp-turboquant.git'
+      llama_ref:
+        description: 'llama.cpp source ref'
+        required: true
+        default: 'feature/turboquant-kv-cache'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve source
+        id: source
+        env:
+          INPUT_LLAMA_REPO: ${{ inputs.llama_repo }}
+          INPUT_LLAMA_REF: ${{ inputs.llama_ref }}
+        run: |
+          repo="${INPUT_LLAMA_REPO:-https://github.com/TheTom/llama-cpp-turboquant.git}"
+          ref="${INPUT_LLAMA_REF:-feature/turboquant-kv-cache}"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/boxp/arch/llama-sycl
+          tags: |
+            type=raw,value={{date 'YYYYMMDDHHmm'}},enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: docker/llama-sycl
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          build-args: |
+            LLAMA_REPO=${{ steps.source.outputs.repo }}
+            LLAMA_REF=${{ steps.source.outputs.ref }}

--- a/docker/llama-sycl/Dockerfile
+++ b/docker/llama-sycl/Dockerfile
@@ -1,0 +1,109 @@
+FROM ubuntu:24.04 AS builder
+
+ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
+ARG LLAMA_REF=feature/turboquant-kv-cache
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      cmake \
+      curl \
+      git \
+      gnupg \
+      ninja-build \
+      pkg-config \
+      software-properties-common \
+    && add-apt-repository -y ppa:kobuk-team/intel-graphics \
+    && install -d -m 0755 /usr/share/keyrings \
+    && curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+      | gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+      > /etc/apt/sources.list.d/oneAPI.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      clinfo \
+      intel-ocloc \
+      intel-oneapi-compiler-dpcpp-cpp \
+      intel-oneapi-mkl-devel \
+      intel-opencl-icd \
+      libze-dev \
+      libze-intel-gpu1 \
+      libze1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    git clone --filter=blob:none --no-checkout "${LLAMA_REPO}" /src/llama.cpp; \
+    cd /src/llama.cpp; \
+    git checkout "${LLAMA_REF}"; \
+    git rev-parse HEAD > /opt/llama-source-revision
+
+RUN source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 \
+    && cmake -S /src/llama.cpp -B /src/llama.cpp/build-sycl -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DGGML_SYCL=ON \
+      -DGGML_SYCL_F16=ON \
+      -DCMAKE_C_COMPILER=icx \
+      -DCMAKE_CXX_COMPILER=icpx \
+    && cmake --build /src/llama.cpp/build-sycl --target llama-ls-sycl-device llama-server -j"$(nproc)" \
+    && install -d -m 0755 /opt/llama.cpp/bin \
+    && cp -a /src/llama.cpp/build-sycl/bin/. /opt/llama.cpp/bin/
+
+FROM ubuntu:24.04
+
+ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
+ARG LLAMA_REF=feature/turboquant-kv-cache
+
+LABEL org.opencontainers.image.title="llama-server SYCL" \
+      org.opencontainers.image.description="Intel GPU SYCL build of llama-server for lolice local LLM workers" \
+      org.opencontainers.image.source="${LLAMA_REPO}" \
+      org.opencontainers.image.revision="${LLAMA_REF}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    ONEAPI_DEVICE_SELECTOR=level_zero:0 \
+    PATH=/opt/llama.cpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      libgomp1 \
+      software-properties-common \
+      tini \
+    && add-apt-repository -y ppa:kobuk-team/intel-graphics \
+    && install -d -m 0755 /usr/share/keyrings \
+    && curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+      | gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+      > /etc/apt/sources.list.d/oneAPI.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      clinfo \
+      intel-ocloc \
+      intel-oneapi-compiler-dpcpp-cpp-runtime \
+      intel-oneapi-mkl-core \
+      intel-oneapi-mkl-sycl \
+      intel-oneapi-openmp \
+      intel-oneapi-tbb \
+      intel-opencl-icd \
+      libze-intel-gpu1 \
+      libze1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/llama.cpp /opt/llama.cpp
+COPY --from=builder /opt/llama-source-revision /opt/llama-source-revision
+COPY entrypoint.sh /usr/local/bin/llama-sycl-entrypoint
+
+RUN chmod 0755 /usr/local/bin/llama-sycl-entrypoint \
+    && useradd --create-home --shell /usr/sbin/nologin llama
+
+USER llama
+WORKDIR /models
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/llama-sycl-entrypoint"]
+CMD ["llama-server", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/llama-sycl/entrypoint.sh
+++ b/docker/llama-sycl/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -r /opt/intel/oneapi/setvars.sh ]]; then
+  # shellcheck disable=SC1091
+  set +u
+  source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1
+  set -u
+fi
+
+exec "$@"

--- a/docs/project_docs/BOXP-23-llama-sycl-image/plan.md
+++ b/docs/project_docs/BOXP-23-llama-sycl-image/plan.md
@@ -1,0 +1,20 @@
+# BOXP-23 llama-server SYCL image plan
+
+## Context
+
+`golyat-4` の Intel Arc GPU では CUDA build は使えない。Host smoke では upstream `llama.cpp` の SYCL backend が動くことを確認済みだが、lolice の local LLM workload では Ooedo と同じ `TheTom/llama-cpp-turboquant` `feature/turboquant-kv-cache` を優先する。
+
+## Plan
+
+1. `boxp/arch` で `ghcr.io/boxp/arch/llama-sycl` を build / publish する。
+2. Dockerfile の default source は `https://github.com/TheTom/llama-cpp-turboquant.git` / `feature/turboquant-kv-cache` にする。
+3. `workflow_dispatch` では `llama_repo` / `llama_ref` を override できるようにして、upstream `ggml-org/llama.cpp` での切り分けも可能にする。
+4. Image には Ubuntu 24.04、Intel graphics PPA runtime、Intel oneAPI runtime、`llama-server` / `llama-ls-sycl-device` を含める。
+5. `boxp/lolice` 側の Kubernetes manifest は、この GHCR image を使い、`gpu.intel.com/i915: 1` request、`lolice.io/gpu-worker=true` selector、GPU worker taint toleration を設定する。
+
+## Verification
+
+- PR build: Docker image build completes without push.
+- Main build: GHCR に timestamp / `sha-*` / `latest` tag を publish。
+- Runtime smoke: `golyat-4` 上の Kubernetes Pod で `llama-server --list-devices` が `SYCL0: Intel(R) Arc(TM) Graphics` を返す。
+- Model smoke: small GGUF で `/health` と `/v1/chat/completions` が通る。


### PR DESCRIPTION
## Summary

Add a GHCR image build for lolice local LLM workers:

- image: `ghcr.io/boxp/arch/llama-sycl`
- default source repo: `https://github.com/TheTom/llama-cpp-turboquant.git`
- default source ref: `feature/turboquant-kv-cache`
- runtime base: Ubuntu 24.04 + Intel graphics PPA + Intel oneAPI runtime
- build: `-DGGML_SYCL=ON` / `-DGGML_SYCL_F16=ON` with `icx` / `icpx`

The workflow supports `workflow_dispatch` overrides for `llama_repo` / `llama_ref` so upstream `ggml-org/llama.cpp` can still be used for isolation.

## Verification

- `actionlint .github/workflows/build-llama-sycl-image.yml`
- `bash -n docker/llama-sycl/entrypoint.sh`
- `docker buildx build --check ... docker/llama-sycl`
- On `golyat-4`, verified `TheTom/llama-cpp-turboquant` `feature/turboquant-kv-cache` commit `a33ef00b13476e9c609caecc3c1c015b8615011d` builds with SYCL and sees Intel Arc via `llama-ls-sycl-device`.
- Confirmed `llama-server --help` still exposes `turbo3`, `--models-preset`, `--models-max`, and `--no-models-autoload`.
- Confirmed TinyLlama Q4_K_M smoke on `golyat-4`: `/health`, `/v1/chat/completions`, and `offloaded 23/23 layers to GPU`.
- Confirmed a temporary Kubernetes Job requesting `gpu.intel.com/i915: 1` on `golyat-4` can build/run SYCL `llama-server` in a container and offload to `SYCL0`.
