### PR TITLE
Fix llama SYCL runtime library path

### DIFF
--- a/docker/llama-sycl/Dockerfile
+++ b/docker/llama-sycl/Dockerfile
@@ -99,7 +99,9 @@ COPY --from=builder /opt/llama.cpp /opt/llama.cpp
 COPY --from=builder /opt/llama-source-revision /opt/llama-source-revision
 COPY entrypoint.sh /usr/local/bin/llama-sycl-entrypoint
 
-RUN chmod 0755 /usr/local/bin/llama-sycl-entrypoint \
+RUN echo /opt/llama.cpp/bin > /etc/ld.so.conf.d/llama-sycl.conf \
+    && ldconfig \
+    && chmod 0755 /usr/local/bin/llama-sycl-entrypoint \
     && useradd --create-home --shell /usr/sbin/nologin llama
 
 USER llama

--- a/docs/project_docs/BOXP-23-llama-sycl-runtime-lib/plan.md
+++ b/docs/project_docs/BOXP-23-llama-sycl-runtime-lib/plan.md
@@ -1,0 +1,24 @@
+# BOXP-23 llama-sycl runtime library path fix
+
+## Context
+
+`ghcr.io/boxp/arch/llama-sycl:latest` published from `boxp/arch#10613`, but the Kubernetes smoke pod failed at startup:
+
+```text
+llama-server: error while loading shared libraries: libllama-server-impl.so: cannot open shared object file: No such file or directory
+```
+
+The binary and shared library are both copied under `/opt/llama.cpp/bin`, but the runtime linker does not search that directory.
+
+## Plan
+
+1. Add `/opt/llama.cpp/bin` to the runtime image dynamic linker configuration.
+2. Run `ldconfig` during image build.
+3. Rebuild and publish `ghcr.io/boxp/arch/llama-sycl`.
+4. Restart the `local-llm` pod and rerun `/health`, `/v1/models`, and chat completion smoke.
+
+## Validation
+
+- `docker buildx build --check docker/llama-sycl`
+- GitHub Actions `Build llama-server SYCL Image`
+- Kubernetes `local-llm` rollout on `golyat-4`


### PR DESCRIPTION
## Summary
- add /opt/llama.cpp/bin to the runtime linker path for llama-sycl
- run ldconfig during image build
- document the runtime startup failure and validation plan

## Validation
- docker buildx build --check docker/llama-sycl
- git diff --check

## Context
The published llama-sycl image started in Kubernetes but exited with:

```text
llama-server: error while loading shared libraries: libllama-server-impl.so: cannot open shared object file: No such file or directory
```
