### PR TITLE
Use SYCL turbo3 SET_ROWS llama source

### DIFF
--- a/docker/llama-sycl/Dockerfile
+++ b/docker/llama-sycl/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
 
-ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
-ARG LLAMA_REF=feature/turboquant-kv-cache
+ARG LLAMA_REPO=https://github.com/cclecle/llama-cpp-turboquant.git
+ARG LLAMA_REF=76d7e0727abd24247bcc8b62b9820e8685efbb7c
 
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -54,8 +54,8 @@ RUN source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 \
 
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
-ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
-ARG LLAMA_REF=feature/turboquant-kv-cache
+ARG LLAMA_REPO=https://github.com/cclecle/llama-cpp-turboquant.git
+ARG LLAMA_REF=76d7e0727abd24247bcc8b62b9820e8685efbb7c
 
 LABEL org.opencontainers.image.title="llama-server SYCL" \
       org.opencontainers.image.description="Intel GPU SYCL build of llama-server for lolice local LLM workers" \

--- a/docs/project_docs/BOXP-23-llama-sycl-turbo3-set-rows/plan.md
+++ b/docs/project_docs/BOXP-23-llama-sycl-turbo3-set-rows/plan.md
@@ -1,0 +1,23 @@
+# Plan: llama SYCL turbo3 SET_ROWS
+
+## Context
+
+`local-llm` on `golyat-4` aborts with Gemma4 and `--cache-type-v turbo3`:
+
+```text
+pre-allocated tensor (cache_v_l0 (view)) in a buffer (SYCL0) that cannot run the operation (SET_ROWS)
+```
+
+TurboQuant issue TheTom/llama-cpp-turboquant#120 tracks missing SYCL backend coverage for turbo2/turbo3/turbo4 V-cache `SET_ROWS`. The cclecle fork branch linked from that issue contains an unmerged SYCL implementation attempt tested on Intel A380.
+
+## Change
+
+- Pin `docker/llama-sycl` to `cclecle/llama-cpp-turboquant` commit `76d7e0727abd24247bcc8b62b9820e8685efbb7c`.
+- Keep `turbo3` support enabled; do not change lolice runtime args to q8/default V-cache.
+
+## Verification
+
+- Run `docker buildx build --check docker/llama-sycl`.
+- Build/publish `ghcr.io/boxp/arch/llama-sycl:latest` via GitHub Actions after merge.
+- Roll out the refreshed image on `golyat-4`.
+- Verify `llama-server` with Gemma4, `--cache-type-v turbo3`, and `/v1/chat/completions`.


### PR DESCRIPTION
## Summary
- pin llama-sycl to cclecle/llama-cpp-turboquant commit 76d7e0727abd24247bcc8b62b9820e8685efbb7c
- keep turbo3 enabled for lolice Gemma4
- add project plan for the SET_ROWS issue

## Context
TurboQuant issue TheTom/llama-cpp-turboquant#120 tracks missing SYCL SET_ROWS support for turbo2/turbo3/turbo4 V cache. lolice Gemma4 currently aborts with cache_v_l0 / SET_ROWS on SYCL0 when using --cache-type-v turbo3.

## Test
- docker buildx build --check docker/llama-sycl