### PR TITLE
Use cclecle ref in llama SYCL workflow

### DIFF
--- a/.github/workflows/build-llama-sycl-image.yml
+++ b/.github/workflows/build-llama-sycl-image.yml
@@ -3,7 +3,7 @@ name: Build llama-server SYCL Image
 on:
   push:
     branches: [main]
-    paths: ['docker/llama-sycl/**']
+    paths: ['docker/llama-sycl/**', '.github/workflows/build-llama-sycl-image.yml']
   pull_request:
     paths: ['docker/llama-sycl/**', '.github/workflows/build-llama-sycl-image.yml']
   workflow_dispatch:
@@ -11,11 +11,11 @@ on:
       llama_repo:
         description: 'llama.cpp source repository'
         required: true
-        default: 'https://github.com/TheTom/llama-cpp-turboquant.git'
+        default: 'https://github.com/cclecle/llama-cpp-turboquant.git'
       llama_ref:
         description: 'llama.cpp source ref'
         required: true
-        default: 'feature/turboquant-kv-cache'
+        default: '76d7e0727abd24247bcc8b62b9820e8685efbb7c'
 
 jobs:
   build-and-push:
@@ -35,8 +35,8 @@ jobs:
           INPUT_LLAMA_REPO: ${{ inputs.llama_repo }}
           INPUT_LLAMA_REF: ${{ inputs.llama_ref }}
         run: |
-          repo="${INPUT_LLAMA_REPO:-https://github.com/TheTom/llama-cpp-turboquant.git}"
-          ref="${INPUT_LLAMA_REF:-feature/turboquant-kv-cache}"
+          repo="${INPUT_LLAMA_REPO:-https://github.com/cclecle/llama-cpp-turboquant.git}"
+          ref="${INPUT_LLAMA_REF:-76d7e0727abd24247bcc8b62b9820e8685efbb7c}"
           echo "repo=$repo" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 

--- a/docs/project_docs/BOXP-23-llama-sycl-workflow-ref/plan.md
+++ b/docs/project_docs/BOXP-23-llama-sycl-workflow-ref/plan.md
@@ -1,0 +1,18 @@
+# Plan: llama-sycl workflow source ref
+
+## Context
+
+The `docker/llama-sycl/Dockerfile` defaults to `cclecle/llama-cpp-turboquant` commit `76d7e0727abd24247bcc8b62b9820e8685efbb7c`, which contains the attempted SYCL `SET_ROWS` support for turboquant V cache.
+
+The GitHub Actions workflow still passed the older `TheTom/llama-cpp-turboquant` branch through build args, so the pushed `latest` image kept `/opt/llama-source-revision` at `a33ef00b13476e9c609caecc3c1c015b8615011d`.
+
+## Change
+
+- Update workflow dispatch defaults and fallback values to the same `cclecle` repo/ref as the Dockerfile.
+- Include the workflow file in the push path filter so merging this workflow correction rebuilds `ghcr.io/boxp/arch/llama-sycl`.
+
+## Verification
+
+- Inspect rendered workflow source resolution.
+- Run YAML syntax check with Ruby Psych.
+- Confirm Git diff has no whitespace errors.


### PR DESCRIPTION
## Summary
- align the llama-sycl workflow defaults/fallbacks with the Dockerfile cclecle SET_ROWS source ref
- include the workflow file in the push path filter so this correction rebuilds the GHCR image
- document the issue found from /opt/llama-source-revision

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-llama-sycl-image.yml"); puts "ok"'\n- git diff --check