### PR TITLE
feat(codex-workspace): install pi agent

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e57
 
 ARG CODEX_VERSION=0.142.2
 ARG EVEN_TERMINAL_VERSION=0.8.1
+ARG PI_AGENT_VERSION=0.80.2
 ARG OBSIDIAN_HEADLESS_VERSION=0.0.12
 ARG GH_VERSION=2.95.0
 ARG GHQ_VERSION=1.10.1
@@ -58,6 +59,7 @@ RUN apt-get update \
 RUN npm install -g \
       "@openai/codex@${CODEX_VERSION}" \
       "@evenrealities/even-terminal@${EVEN_TERMINAL_VERSION}" \
+      "@earendil-works/pi-coding-agent@${PI_AGENT_VERSION}" \
       "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}" \
     && npm cache clean --force
 

--- a/docs/project_docs/BOXP-23-codex-workspace-pi-agent/plan.md
+++ b/docs/project_docs/BOXP-23-codex-workspace-pi-agent/plan.md
@@ -1,0 +1,20 @@
+# BOXP-23 codex-workspace pi agent
+
+## Background
+
+Phase 6 needs the existing `codex-workspace` workload to call `local-llm` through pi agent using the stable `gemma4-26b` model alias.
+
+`boxp/lolice` already exposes `gemma4-26b` from `local-llm`. The current `codex-workspace` image includes Node.js but does not include the `pi` CLI.
+
+## Plan
+
+- Add `PI_AGENT_VERSION=0.80.2`.
+- Install `@earendil-works/pi-coding-agent` globally with the other workspace npm CLIs.
+- Keep GHCR publishing on the existing `Build Codex Workspace Image` workflow.
+- Let `boxp/lolice` follow the published image through its existing `argocd-image-updater` integration.
+
+## Validation
+
+- Dockerfile diff / syntax check.
+- PR `Build Codex Workspace Image` check.
+- After merge, confirm GHCR publish and then verify `pi --version` in the `codex-workspace` Pod.


### PR DESCRIPTION
## Summary
- install `@earendil-works/pi-coding-agent@0.80.2` in the codex-workspace image
- add a project plan for the Phase 6 pi agent integration

## Validation
- `git diff --check`
- PR build check will build the codex-workspace image

## Notes
- GHCR publish remains handled by the existing main-branch image workflow
- lolice will pick up the image through its existing argocd-image-updater integration
