### PR TITLE
Add TheTom Vulkan llama-server image

### DIFF
--- a/.github/workflows/build-llama-vulkan-image.yml
+++ b/.github/workflows/build-llama-vulkan-image.yml
@@ -1,0 +1,71 @@
+name: Build llama-server Vulkan Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['docker/llama-vulkan/**', '.github/workflows/build-llama-vulkan-image.yml']
+  pull_request:
+    paths: ['docker/llama-vulkan/**', '.github/workflows/build-llama-vulkan-image.yml']
+  workflow_dispatch:
+    inputs:
+      llama_repo:
+        description: 'llama.cpp source repository'
+        required: true
+        default: 'https://github.com/TheTom/llama-cpp-turboquant.git'
+      llama_ref:
+        description: 'llama.cpp source ref'
+        required: true
+        default: 'a33ef00b13476e9c609caecc3c1c015b8615011d'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve source
+        id: source
+        env:
+          INPUT_LLAMA_REPO: ${{ inputs.llama_repo }}
+          INPUT_LLAMA_REF: ${{ inputs.llama_ref }}
+        run: |
+          repo="${INPUT_LLAMA_REPO:-https://github.com/TheTom/llama-cpp-turboquant.git}"
+          ref="${INPUT_LLAMA_REF:-a33ef00b13476e9c609caecc3c1c015b8615011d}"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/boxp/arch/llama-vulkan
+          tags: |
+            type=raw,value={{date 'YYYYMMDDHHmm'}},enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: docker/llama-vulkan
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          build-args: |
+            LLAMA_REPO=${{ steps.source.outputs.repo }}
+            LLAMA_REF=${{ steps.source.outputs.ref }}

--- a/docker/llama-vulkan/Dockerfile
+++ b/docker/llama-vulkan/Dockerfile
@@ -1,0 +1,100 @@
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
+
+ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
+ARG LLAMA_REF=a33ef00b13476e9c609caecc3c1c015b8615011d
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      cmake \
+      curl \
+      git \
+      glslang-tools \
+      glslc \
+      gnupg \
+      libvulkan-dev \
+      ninja-build \
+      pkg-config \
+      spirv-headers \
+      software-properties-common \
+      vulkan-tools \
+    && add-apt-repository -y ppa:kobuk-team/intel-graphics \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      clinfo \
+      intel-ocloc \
+      intel-opencl-icd \
+      libshaderc1 \
+      libze-intel-gpu1 \
+      libze1 \
+      mesa-vulkan-drivers \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    git clone --filter=blob:none --no-checkout "${LLAMA_REPO}" /src/llama.cpp; \
+    cd /src/llama.cpp; \
+    git checkout "${LLAMA_REF}"; \
+    git rev-parse HEAD > /opt/llama-source-revision
+
+RUN cmake -S /src/llama.cpp -B /src/llama.cpp/build-vulkan -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DGGML_VULKAN=ON \
+      -DGGML_SYCL=OFF \
+    && cmake --build /src/llama.cpp/build-vulkan --target llama-server -j"$(nproc)" \
+    && install -d -m 0755 /opt/llama.cpp/bin \
+    && cp -a /src/llama.cpp/build-vulkan/bin/. /opt/llama.cpp/bin/
+
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+
+ARG LLAMA_REPO=https://github.com/TheTom/llama-cpp-turboquant.git
+ARG LLAMA_REF=a33ef00b13476e9c609caecc3c1c015b8615011d
+
+LABEL org.opencontainers.image.title="llama-server Vulkan" \
+      org.opencontainers.image.description="Intel GPU Vulkan build of llama-server for lolice local LLM workers" \
+      org.opencontainers.image.source="${LLAMA_REPO}" \
+      org.opencontainers.image.revision="${LLAMA_REF}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/opt/llama.cpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      libgomp1 \
+      libvulkan1 \
+      software-properties-common \
+      tini \
+      vulkan-tools \
+    && add-apt-repository -y ppa:kobuk-team/intel-graphics \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      clinfo \
+      intel-ocloc \
+      intel-opencl-icd \
+      libshaderc1 \
+      libze-intel-gpu1 \
+      libze1 \
+      mesa-vulkan-drivers \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/llama.cpp /opt/llama.cpp
+COPY --from=builder /opt/llama-source-revision /opt/llama-source-revision
+COPY entrypoint.sh /usr/local/bin/llama-vulkan-entrypoint
+
+RUN echo /opt/llama.cpp/bin > /etc/ld.so.conf.d/llama-vulkan.conf \
+    && ldconfig \
+    && chmod 0755 /usr/local/bin/llama-vulkan-entrypoint \
+    && useradd --create-home --shell /usr/sbin/nologin llama
+
+USER llama
+WORKDIR /models
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/llama-vulkan-entrypoint"]
+CMD ["llama-server", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/llama-vulkan/entrypoint.sh
+++ b/docker/llama-vulkan/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec "$@"

--- a/docs/project_docs/BOXP-23-llama-vulkan-thetom/plan.md
+++ b/docs/project_docs/BOXP-23-llama-vulkan-thetom/plan.md
@@ -1,0 +1,24 @@
+# BOXP-23 llama-server TheTom Vulkan image
+
+## Context
+
+`golyat-4` production currently runs `ghcr.io/boxp/arch/llama-sycl:latest`, but the SYCL/cclecle path has shown unstable behavior around `q8_0` and `turbo3` V cache.
+
+Host smoke on `golyat-4` showed that TheTom `llama-cpp-turboquant` commit `a33ef00b13476e9c609caecc3c1c015b8615011d` can build with `GGML_VULKAN=ON`, detect `Vulkan0: Intel(R) Graphics (ARL)`, and serve a short Gemma4 request with `--cache-type-v turbo3`.
+
+## Plan
+
+1. Publish a separate image, `ghcr.io/boxp/arch/llama-vulkan`, so `argocd-image-updater` cannot accidentally roll a Vulkan-only image under the existing SYCL runtime args.
+2. Build the image from TheTom Vulkan:
+   - source: `https://github.com/TheTom/llama-cpp-turboquant.git`
+   - ref: `a33ef00b13476e9c609caecc3c1c015b8615011d`
+   - CMake: `-DGGML_VULKAN=ON`, `-DGGML_SYCL=OFF`
+3. Install Vulkan runtime packages in the runtime stage, and remove oneAPI runtime requirements from the image entrypoint path.
+4. Validate Dockerfile syntax with BuildKit check before opening the PR.
+5. After merge, let the new GitHub Actions workflow push `latest`; `boxp/lolice` should switch the `local-llm` image name and ImageUpdater target in the same PR that switches runtime args to `Vulkan0`.
+
+## Validation
+
+- `docker buildx build --check docker/llama-vulkan`
+- GitHub Actions `Build llama-server Vulkan Image`
+- Kubernetes `local-llm` rollout after ImageUpdater digest update


### PR DESCRIPTION
## Summary
- add a separate `ghcr.io/boxp/arch/llama-vulkan` image build
- build TheTom `llama-cpp-turboquant` commit `a33ef00b13476e9c609caecc3c1c015b8615011d` with `GGML_VULKAN=ON` and `GGML_SYCL=OFF`
- keep the existing `llama-sycl` image untouched so ImageUpdater cannot roll a Vulkan-only image under SYCL runtime args

## Validation
- `docker buildx build --check docker/llama-vulkan`
- `docker buildx build docker/llama-vulkan -t ghcr.io/boxp/arch/llama-vulkan:local --load`
- `docker run --rm ghcr.io/boxp/arch/llama-vulkan:local sh -lc 'cat /opt/llama-source-revision && llama-server --version && llama-server --help | grep -E "cache-type-v|models-preset|models-max" | head -20'`\n\n## Rollout order\nMerge this first and wait for `ghcr.io/boxp/arch/llama-vulkan:latest` to be published before merging the matching `boxp/lolice` runtime PR.