### PR TITLE
Build llama-sycl from official llama.cpp

### DIFF
--- a/.github/workflows/build-llama-sycl-image.yml
+++ b/.github/workflows/build-llama-sycl-image.yml
@@ -11,11 +11,11 @@ on:
       llama_repo:
         description: 'llama.cpp source repository'
         required: true
-        default: 'https://github.com/cclecle/llama-cpp-turboquant.git'
+        default: 'https://github.com/ggml-org/llama.cpp.git'
       llama_ref:
         description: 'llama.cpp source ref'
         required: true
-        default: '76d7e0727abd24247bcc8b62b9820e8685efbb7c'
+        default: '8c146a8366304c871efc26057cc90370ccf58dad'
 
 jobs:
   build-and-push:
@@ -35,8 +35,8 @@ jobs:
           INPUT_LLAMA_REPO: ${{ inputs.llama_repo }}
           INPUT_LLAMA_REF: ${{ inputs.llama_ref }}
         run: |
-          repo="${INPUT_LLAMA_REPO:-https://github.com/cclecle/llama-cpp-turboquant.git}"
-          ref="${INPUT_LLAMA_REF:-76d7e0727abd24247bcc8b62b9820e8685efbb7c}"
+          repo="${INPUT_LLAMA_REPO:-https://github.com/ggml-org/llama.cpp.git}"
+          ref="${INPUT_LLAMA_REF:-8c146a8366304c871efc26057cc90370ccf58dad}"
           echo "repo=$repo" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 

--- a/docker/llama-sycl/Dockerfile
+++ b/docker/llama-sycl/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS builder
 
-ARG LLAMA_REPO=https://github.com/cclecle/llama-cpp-turboquant.git
-ARG LLAMA_REF=76d7e0727abd24247bcc8b62b9820e8685efbb7c
+ARG LLAMA_REPO=https://github.com/ggml-org/llama.cpp.git
+ARG LLAMA_REF=8c146a8366304c871efc26057cc90370ccf58dad
 
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -45,17 +45,20 @@ RUN source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 \
     && cmake -S /src/llama.cpp -B /src/llama.cpp/build-sycl -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
       -DGGML_SYCL=ON \
-      -DGGML_SYCL_F16=ON \
+      -DGGML_VULKAN=OFF \
+      -DLLAMA_BUILD_SERVER=ON \
+      -DLLAMA_CURL=OFF \
+      -DGGML_NATIVE=ON \
       -DCMAKE_C_COMPILER=icx \
       -DCMAKE_CXX_COMPILER=icpx \
-    && cmake --build /src/llama.cpp/build-sycl --target llama-ls-sycl-device llama-server -j"$(nproc)" \
+    && cmake --build /src/llama.cpp/build-sycl --target llama-server -j"$(nproc)" \
     && install -d -m 0755 /opt/llama.cpp/bin \
     && cp -a /src/llama.cpp/build-sycl/bin/. /opt/llama.cpp/bin/
 
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
-ARG LLAMA_REPO=https://github.com/cclecle/llama-cpp-turboquant.git
-ARG LLAMA_REF=76d7e0727abd24247bcc8b62b9820e8685efbb7c
+ARG LLAMA_REPO=https://github.com/ggml-org/llama.cpp.git
+ARG LLAMA_REF=8c146a8366304c871efc26057cc90370ccf58dad
 
 LABEL org.opencontainers.image.title="llama-server SYCL" \
       org.opencontainers.image.description="Intel GPU SYCL build of llama-server for lolice local LLM workers" \
@@ -63,7 +66,8 @@ LABEL org.opencontainers.image.title="llama-server SYCL" \
       org.opencontainers.image.revision="${LLAMA_REF}"
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    ONEAPI_DEVICE_SELECTOR=level_zero:0 \
+    ONEAPI_DEVICE_SELECTOR=level_zero:gpu \
+    ZE_ENABLE_PCI_ID_DEVICE_ORDER=1 \
     PATH=/opt/llama.cpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docs/project_docs/BOXP-23-llama-sycl-official/plan.md
+++ b/docs/project_docs/BOXP-23-llama-sycl-official/plan.md
@@ -1,0 +1,24 @@
+# BOXP-23 llama-sycl official llama.cpp build
+
+## Context
+
+`golyat-4` host direct verification showed that official `ggml-org/llama.cpp` commit `8c146a8366304c871efc26057cc90370ccf58dad` builds with oneAPI 2026.0 SYCL and sees the Intel Arc GPU via Level Zero.
+
+The previous `llama-sycl` image defaulted to `cclecle/llama-cpp-turboquant` for experimental TurboQuant SYCL `SET_ROWS` coverage. Current production concerns are output stability and predictable upstream behavior, so the image should default back to official llama.cpp while keeping workflow dispatch override support.
+
+## Plan
+
+1. Change `docker/llama-sycl` defaults to `https://github.com/ggml-org/llama.cpp.git` at verified commit `8c146a8366304c871efc26057cc90370ccf58dad`.
+2. Align CMake flags with the successful host direct build: `GGML_SYCL=ON`, `GGML_VULKAN=OFF`, `LLAMA_BUILD_SERVER=ON`, `LLAMA_CURL=OFF`, `GGML_NATIVE=ON`, `icx` / `icpx`.
+3. Build only `llama-server` because official HEAD does not require the fork-specific `llama-ls-sycl-device` target for production runtime.
+4. Set runtime Level Zero selection explicitly with `ONEAPI_DEVICE_SELECTOR=level_zero:gpu` and `ZE_ENABLE_PCI_ID_DEVICE_ORDER=1`.
+5. Publish `ghcr.io/boxp/arch/llama-sycl` from GitHub Actions, then update lolice production manifests to use the new SYCL image and `--device SYCL0`.
+
+## Host Verification
+
+- Host: `golyat-4`, Ubuntu 24.04.4, Intel oneAPI DPC++/C++ Compiler 2026.0.0.
+- `sycl-ls` showed `[level_zero:gpu][level_zero:0] Intel(R) Arc(TM) Graphics`.
+- `llama-server --list-devices` with `ONEAPI_DEVICE_SELECTOR=level_zero:gpu` showed `SYCL0: Intel(R) Arc(TM) Graphics`.
+- Official build completed with commit `8c146a836`.
+- Smoke prompt returned valid Japanese text without output corruption.
+- Second-run timing after initial SYCL setup: prompt eval `29.11 tok/s`, generation `9.57 tok/s`.


### PR DESCRIPTION
## Summary
- switch llama-sycl defaults from cclecle turboquant fork to official ggml-org/llama.cpp at the host-verified commit
- align SYCL CMake flags with the golyat-4 oneAPI 2026.0 / Level Zero host build
- set runtime Level Zero selector to level_zero:gpu and document the verification

## Verification
- docker buildx build --check docker/llama-sycl
- host direct official SYCL smoke on golyat-4: valid Japanese output, second-run prompt eval 29.11 tok/s, generation 9.57 tok/s