### PR TITLE
[codex] Fix aqua checksum update ref

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,8 +138,6 @@ jobs:
     if: needs.path-filter.outputs.update-aqua-checksums == 'true'
     permissions:
       contents: write
-    with:
-      ref: ${{needs.path-filter.outputs.merge_commit_sha}}
     secrets:
       gh_app_id: ${{secrets.APP_ID}}
       gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
## Summary
- stop passing the temporary merge commit SHA to the aqua checksum update reusable workflow
- let `aquaproj/update-checksum-workflow` use the pull request head SHA for checksum auto-commit jobs

## Root cause
`pull_request_target` jobs currently pass `needs.path-filter.outputs.merge_commit_sha` as the `ref` for `update-aqua-checksums`. The upstream checksum workflow then checks out that synthetic merge commit in detached HEAD state and generates `aqua/aqua-checksums.json`, but its commit action fails with `Resource not accessible by integration` when creating the commit from that merge commit tree.

By omitting `ref`, the upstream workflow falls back to `github.event.pull_request.head.sha`, so checksum update commits target the actual Renovate PR head instead of the merge commit.

## Validation
- `actionlint .github/workflows/test.yaml .github/workflows/wc-update-aqua-checksums.yaml .github/workflows/wc-path-filter.yaml`
- `git diff --check`
