### PR TITLE
[codex] Fix codex workspace agent environment

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -124,6 +124,8 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     CHROME_BIN=/usr/bin/chromium \
     PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
+    EDITOR=vim \
+    VISUAL=vim \
     PATH=/home/boxp/.local/bin:/home/boxp/go/bin:/usr/local/bin:/usr/bin:/bin
 
 COPY entrypoint.sh /usr/local/bin/codex-workspace-entrypoint

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -137,19 +137,6 @@ write_session_env() {
 if [ -r /run/codex-workspace/session-env ]; then
   . /run/codex-workspace/session-env
 fi
-
-if [ -n "${BASH_VERSION:-}" ]; then
-  y() {
-    local tmp cwd
-    tmp="$(mktemp -t "yazi-cwd.XXXXXX")" || return
-    command yazi "$@" --cwd-file="$tmp"
-    IFS= read -r -d '' cwd <"$tmp" || true
-    rm -f -- "$tmp"
-    if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && [ -d "$cwd" ]; then
-      builtin cd -- "$cwd"
-    fi
-  }
-fi
 EOF
   chmod 0644 "${profile_file}"
 }

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -4,9 +4,70 @@ set -euo pipefail
 install -d -m 0755 /run/sshd
 install -d -o boxp -g boxp -m 0755 /home/boxp
 /usr/sbin/runuser -u boxp -- install -d -m 0700 /home/boxp/.ssh
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex
 /usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.codex/skills
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.pi/agent/extensions
+/usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/.local/bin
 /usr/sbin/runuser -u boxp -- install -d -m 0755 "/home/boxp/Documents/obsidian-headless/BOXP/Infrastructure/Codex Cron"
 /usr/sbin/runuser -u boxp -- install -d -m 0755 /home/boxp/ghq
+
+export EDITOR="${EDITOR:-vim}"
+export VISUAL="${VISUAL:-vim}"
+
+configure_codex() {
+  local config=/home/boxp/.codex/config.toml
+  local tmp="${config}.tmp"
+
+  /usr/sbin/runuser -u boxp -- touch "${config}"
+  {
+    printf 'check_for_update_on_startup = false\n'
+    sed -E '/^[[:space:]]*check_for_update_on_startup[[:space:]]*=/d' "${config}"
+  } >"${tmp}"
+  mv "${tmp}" "${config}"
+  chown boxp:boxp "${config}"
+  chmod 0600 "${config}"
+}
+
+move_pi_extension_entry() {
+  local entry="$1"
+  local name dest i
+
+  name="$(basename "${entry}")"
+  dest="/home/boxp/.pi/agent/extensions/${name}"
+  i=1
+  while [[ -e "${dest}" ]]; do
+    dest="/home/boxp/.pi/agent/extensions/${name}.legacy-${i}"
+    i=$((i + 1))
+  done
+  mv "${entry}" "${dest}"
+}
+
+configure_pi_agent() {
+  local entry name lower
+
+  if [[ -d /home/boxp/.pi/agent/hooks ]]; then
+    while IFS= read -r -d '' entry; do
+      move_pi_extension_entry "${entry}"
+    done < <(find /home/boxp/.pi/agent/hooks -mindepth 1 -maxdepth 1 -print0)
+    rmdir /home/boxp/.pi/agent/hooks 2>/dev/null || true
+  fi
+
+  if [[ -d /home/boxp/.pi/agent/tools ]]; then
+    while IFS= read -r -d '' entry; do
+      name="$(basename "${entry}")"
+      lower="${name,,}"
+      case "${lower}" in
+        fd|rg|fd.exe|rg.exe|.*)
+          continue
+          ;;
+      esac
+      move_pi_extension_entry "${entry}"
+    done < <(find /home/boxp/.pi/agent/tools -mindepth 1 -maxdepth 1 -print0)
+    rmdir /home/boxp/.pi/agent/tools 2>/dev/null || true
+  fi
+
+  chown -R boxp:boxp /home/boxp/.pi/agent
+}
 
 start_moshi_hook() {
   if [[ "${MOSHI_HOOK_ENABLED:-1}" == "0" ]]; then
@@ -37,6 +98,9 @@ if [[ -d /opt/codex-workspace/skills ]]; then
     /opt/codex-workspace/skills/. /home/boxp/.codex/skills/
 fi
 
+configure_codex
+configure_pi_agent
+
 if [[ -f /tmp/authorized_keys/authorized_keys ]]; then
   /usr/sbin/runuser -u boxp -- install -m 0600 \
     /tmp/authorized_keys/authorized_keys /home/boxp/.ssh/authorized_keys
@@ -56,6 +120,8 @@ write_session_env() {
   for name in \
     DOCKER_HOST \
     DOCKER_BUILDKIT \
+    EDITOR \
+    VISUAL \
     GRAFANA_URL \
     GRAFANA_SERVICE_ACCOUNT_TOKEN \
     GEMINI_API_KEY; do
@@ -70,6 +136,19 @@ write_session_env() {
   cat >"${profile_file}" <<'EOF'
 if [ -r /run/codex-workspace/session-env ]; then
   . /run/codex-workspace/session-env
+fi
+
+if [ -n "${BASH_VERSION:-}" ]; then
+  y() {
+    local tmp cwd
+    tmp="$(mktemp -t "yazi-cwd.XXXXXX")" || return
+    command yazi "$@" --cwd-file="$tmp"
+    IFS= read -r -d '' cwd <"$tmp" || true
+    rm -f -- "$tmp"
+    if [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && [ -d "$cwd" ]; then
+      builtin cd -- "$cwd"
+    fi
+  }
 fi
 EOF
   chmod 0644 "${profile_file}"
@@ -89,7 +168,7 @@ if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then
 fi
 
 exec /usr/sbin/runuser -u boxp \
-  --whitelist-environment=DOCKER_HOST,DOCKER_BUILDKIT,GRAFANA_URL,GRAFANA_SERVICE_ACCOUNT_TOKEN,GEMINI_API_KEY \
+  --whitelist-environment=DOCKER_HOST,DOCKER_BUILDKIT,EDITOR,VISUAL,GRAFANA_URL,GRAFANA_SERVICE_ACCOUNT_TOKEN,GEMINI_API_KEY \
   -- env HOME=/home/boxp even-terminal \
   --port "${EVEN_TERMINAL_PORT:-3456}" \
   --cwd "${EVEN_TERMINAL_CWD:-/home/boxp}" \

--- a/docs/project_docs/BOXP-27-29-codex-workspace-env/plan.md
+++ b/docs/project_docs/BOXP-27-29-codex-workspace-env/plan.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-Codex workspace image startup should avoid noisy update prompts, load pi agent extensions from the current `extensions/` directory layout, and provide predictable editor and Yazi shell integration.
+Codex workspace image startup should avoid noisy update prompts, load pi agent extensions from the current `extensions/` directory layout, and provide predictable editor defaults.
 
 This covers:
 
 - BOXP-27: Disable Codex startup update checks in the container-managed Codex install.
 - BOXP-28: Move pi agent extension materialization away from legacy paths that trigger the `Move your extensions to the extensions/ directory.` warning.
-- BOXP-29: Set `EDITOR`/`VISUAL` to `vim` and provide a `y` command that opens Yazi with cwd synchronization.
+- BOXP-29: Set `EDITOR`/`VISUAL` to `vim` so Codex and pi open Vim for external editing.
 
 ## Scope
 
@@ -17,11 +17,10 @@ This covers:
   - Ensure `~/.codex/config.toml` contains `check_for_update_on_startup = false`.
   - Move legacy pi `hooks/` entries, and custom `tools/` entries, into `~/.pi/agent/extensions/` when they exist.
   - Export `EDITOR=vim` and `VISUAL=vim` into login/session environments and the `even-terminal` process.
-  - Add the Yazi-recommended `y()` shell wrapper so terminal sessions can open Yazi and sync the shell cwd on exit.
 
 ## Implementation Plan
 
-1. Add minimal startup initialization for Codex config, pi extension directory layout, and shell-level Yazi integration.
+1. Add minimal startup initialization for Codex config and pi extension directory layout.
 2. Extend the session environment allowlist and profile script so SSH sessions, Codex, pi, and even-terminal receive the same editor environment.
 3. Keep existing Codex skill installation behavior unchanged.
 
@@ -36,9 +35,9 @@ This covers:
 
 - Codex supports `check_for_update_on_startup = false` for centrally managed installs.
 - pi agent 0.80.2 emits the `Move your extensions to the extensions/ directory.` warning when legacy `hooks/` exists or `tools/` contains custom entries. The entrypoint migrates those entries into `~/.pi/agent/extensions/`.
-- Yazi 26.5.6 accepts `yazi [ENTRIES]...` and supports `--cwd-file`; the provided `y()` wrapper follows the official shell-wrapper pattern and keeps shell cwd in sync after exiting Yazi.
+- Yazi shell integration is intentionally left out of this change. A `y()` wrapper would only sync shell cwd after Yazi exits and is not required for Codex or pi editor behavior.
 
 ## Risks
 
 - Codex config schema may change in future releases. The selected key is documented as `check_for_update_on_startup`.
-- Codex `file_opener` only supports editor URI schemes such as VS Code, Cursor, and Windsurf, not arbitrary commands. Yazi integration is therefore provided as a shell command instead of a Codex citation opener.
+- Codex `file_opener` only supports editor URI schemes such as VS Code, Cursor, and Windsurf, not arbitrary commands. This change does not configure Yazi as a Codex citation opener.

--- a/docs/project_docs/BOXP-27-29-codex-workspace-env/plan.md
+++ b/docs/project_docs/BOXP-27-29-codex-workspace-env/plan.md
@@ -1,0 +1,44 @@
+# BOXP-27-29 codex-workspace environment cleanup
+
+## Summary
+
+Codex workspace image startup should avoid noisy update prompts, load pi agent extensions from the current `extensions/` directory layout, and provide predictable editor and Yazi shell integration.
+
+This covers:
+
+- BOXP-27: Disable Codex startup update checks in the container-managed Codex install.
+- BOXP-28: Move pi agent extension materialization away from legacy paths that trigger the `Move your extensions to the extensions/ directory.` warning.
+- BOXP-29: Set `EDITOR`/`VISUAL` to `vim` and provide a `y` command that opens Yazi with cwd synchronization.
+
+## Scope
+
+- `docker/codex-workspace/entrypoint.sh`
+  - Create and preserve user config directories for Codex and pi agent.
+  - Ensure `~/.codex/config.toml` contains `check_for_update_on_startup = false`.
+  - Move legacy pi `hooks/` entries, and custom `tools/` entries, into `~/.pi/agent/extensions/` when they exist.
+  - Export `EDITOR=vim` and `VISUAL=vim` into login/session environments and the `even-terminal` process.
+  - Add the Yazi-recommended `y()` shell wrapper so terminal sessions can open Yazi and sync the shell cwd on exit.
+
+## Implementation Plan
+
+1. Add minimal startup initialization for Codex config, pi extension directory layout, and shell-level Yazi integration.
+2. Extend the session environment allowlist and profile script so SSH sessions, Codex, pi, and even-terminal receive the same editor environment.
+3. Keep existing Codex skill installation behavior unchanged.
+
+## Verification
+
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `git diff --check`
+- Review rendered entrypoint logic for idempotency and ownership.
+- Confirm no unrelated files are changed.
+
+## Notes
+
+- Codex supports `check_for_update_on_startup = false` for centrally managed installs.
+- pi agent 0.80.2 emits the `Move your extensions to the extensions/ directory.` warning when legacy `hooks/` exists or `tools/` contains custom entries. The entrypoint migrates those entries into `~/.pi/agent/extensions/`.
+- Yazi 26.5.6 accepts `yazi [ENTRIES]...` and supports `--cwd-file`; the provided `y()` wrapper follows the official shell-wrapper pattern and keeps shell cwd in sync after exiting Yazi.
+
+## Risks
+
+- Codex config schema may change in future releases. The selected key is documented as `check_for_update_on_startup`.
+- Codex `file_opener` only supports editor URI schemes such as VS Code, Cursor, and Windsurf, not arbitrary commands. Yazi integration is therefore provided as a shell command instead of a Codex citation opener.


### PR DESCRIPTION
## Summary

- disable Codex startup update checks for the container-managed codex-workspace install
- migrate legacy pi agent extension directories into `~/.pi/agent/extensions/`
- set `EDITOR`/`VISUAL` to `vim` for Codex, pi, and terminal sessions
- add the BOXP-27~29 implementation plan under `docs/project_docs/BOXP-27-29-codex-workspace-env/plan.md`

## Context

BOXP-27~29 cover codex-workspace startup noise and default editor ergonomics. The image pins Codex and pi agent versions, so startup update prompts are not useful inside the container. pi agent 0.80.2 warns when legacy `hooks/` or custom `tools/` entries remain outside the current `extensions/` layout.

Yazi shell integration is intentionally not included in this PR. A `y()` wrapper would only sync shell cwd after Yazi exits and is unrelated to making Codex or pi open Vim as their external editor.

## Verification

- `bash -n docker/codex-workspace/entrypoint.sh`
- `git diff --check`
- `codex review --uncommitted`
