### PR TITLE
[codex] Fix Renovate aqua checksum automation

### DIFF
--- a/.github/workflows/wc-update-aqua-checksums.yaml
+++ b/.github/workflows/wc-update-aqua-checksums.yaml
@@ -14,13 +14,72 @@ on:
 jobs:
   update-aqua-checksums:
     # Update aqua-checksums.json and push a commit
-    uses: aquaproj/update-checksum-workflow/.github/workflows/update-checksum.yaml@eba908314cdc3b2ab7fb7546950c05a666effbc0 # v1.0.5
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
-      contents: write
-    with:
-      aqua_version: v2.60.1
-      prune: true
-      ref: ${{inputs.ref}}
-    secrets:
-      gh_app_id: ${{secrets.gh_app_id}}
-      gh_app_private_key: ${{secrets.gh_app_private_key}}
+      contents: read
+    steps:
+      - name: Generate token
+        id: generate_token
+        if: github.event_name != 'pull_request_target' || ! github.event.pull_request.head.repo.fork
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{secrets.gh_app_id}}
+          private_key: ${{secrets.gh_app_private_key}}
+          permissions: >-
+            {"contents": "write"}
+          repositories: >-
+            ["${{github.event.repository.name}}"]
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{inputs.ref || github.event.pull_request.head.sha || github.sha}}
+          persist-credentials: false
+
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.60.1
+        env:
+          AQUA_GITHUB_TOKEN: ${{steps.generate_token.outputs.token || github.token}}
+
+      - name: Update checksums
+        run: aqua update-checksum -deep -prune
+        env:
+          AQUA_GITHUB_TOKEN: ${{steps.generate_token.outputs.token || github.token}}
+
+      - name: Detect checksum changes
+        id: changes
+        run: |
+          set -eu
+          changed_files="$(git ls-files --modified --others --exclude-standard -- 'aqua/aqua-checksums.json')"
+          if [ -z "$changed_files" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fail when a fork needs checksum updates
+        if: steps.changes.outputs.changed == 'true' && github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork
+        run: |
+          echo "::error file=aqua/aqua-checksums.json::aqua/aqua-checksums.json is not up to date, and this workflow will not push to a fork."
+          exit 1
+
+      - name: Commit checksum updates
+        if: steps.changes.outputs.changed == 'true' && (github.event_name != 'pull_request_target' || ! github.event.pull_request.head.repo.fork)
+        run: |
+          set -eu
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add aqua/aqua-checksums.json
+          git commit -m "chore(aqua): update aqua/aqua-checksums.json"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"
+          else
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+          fi
+        env:
+          EVENT_NAME: ${{github.event_name}}
+          GITHUB_TOKEN: ${{steps.generate_token.outputs.token}}
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+          HEAD_REPO: ${{github.event.pull_request.head.repo.full_name}}

--- a/docs/project_docs/BOXP-13/plan.md
+++ b/docs/project_docs/BOXP-13/plan.md
@@ -1,0 +1,39 @@
+# BOXP-13 plan
+
+## Goal
+
+`boxp/arch` の Renovate 依存更新 PR で繰り返し発生していた aqua checksum 更新失敗を再発防止し、Kubernetes バージョン更新を Renovate の自動 PR 対象から外す。
+
+## Scope
+
+- `renovate.json5` で Kubernetes 関連の custom regex package を `enabled: false` にする。
+  - `kubernetes/kubernetes`
+  - `cri-o/cri-o`
+  - `kube-vip/kube-vip`
+- `.github/workflows/wc-update-aqua-checksums.yaml` を外部 reusable workflow 呼び出しから repository 内の明示的な job に置き換える。
+- aqua checksum 更新 job が GitHub App token で PR branch に直接 commit/push できるようにする。
+- 原因と運用判断を `BOXP-13` の Notes に残す。
+
+## Root Cause
+
+`update-aqua-checksums` は `aquaproj/update-checksum-workflow` 経由で checksum を生成できていたが、後段の `suzuki-shunsuke/commit-action` が read-only `GITHUB_TOKEN` にフォールバックし、`POST /repos/boxp/arch/git/trees` で `Resource not accessible by integration` の 403 になっていた。
+
+そのため `aqua/aqua-checksums.json` が PR branch に追加 commit されず、OPA 更新 PR では後続の `opa-fmt` も `checksum is required` で失敗していた。formatter 差分そのものが直接の失敗原因ではない。
+
+## Implementation
+
+- `wc-update-aqua-checksums.yaml` で `tibdex/github-app-token` により `contents: write` の GitHub App token を生成する。
+- PR head SHA を checkout し、`aqua update-checksum -deep -prune` を実行する。
+- `aqua/aqua-checksums.json` に差分がある場合、同じ token で head branch へ commit/push する。
+- fork PR で checksum 差分が必要な場合は push せず明示的に fail する。
+- Renovate の Kubernetes 関連 package rules は `enabled: false` とし、既存の自動 PR は close して手動 upgrade project に寄せる。
+
+## Validation
+
+- `npx --yes --package renovate renovate-config-validator renovate.json5`
+- `/tmp/actionlint-boxp13/actionlint .github/workflows/wc-update-aqua-checksums.yaml .github/workflows/test.yaml`
+
+## Follow-up
+
+- この PR が merge された後、Renovate の残り aqua PR は checksum job の再実行または Renovate recreate で処理する。
+- Kubernetes 1.36 以降の upgrade は Renovate PR ではなく、手動 upgrade ticket/project で扱う。

--- a/renovate.json5
+++ b/renovate.json5
@@ -195,21 +195,25 @@
       matchDatasources: ["custom.cursor-agent"],
       extractVersion: "downloads\\.cursor\\.com/lab/(?<version>[^/]+)/\\$\\{OS\\}/\\$\\{ARCH\\}/agent-cli-package\\.tar\\.gz"
     },
-    // Kubernetes components (manual review required)
+    // Kubernetes upgrades are planned and applied manually.
     {
       matchManagers: ["custom.regex"],
       matchPackageNames: ["kubernetes/kubernetes", "cri-o/cri-o"],
       groupName: "Kubernetes components",
+      enabled: false,
       automerge: false,
       prPriority: -10,
-      labels: ["kubernetes", "manual-review-required"]
+      labels: ["kubernetes", "manual-upgrade-only"],
+      description: "Disable Renovate PRs for Kubernetes control-plane and runtime upgrades. These updates are handled by the manual upgrade workflow."
     },
-    // kube-vip (manual review)
+    // kube-vip is upgraded with the Kubernetes maintenance window.
     {
       matchManagers: ["custom.regex"],
       matchPackageNames: ["kube-vip/kube-vip"],
+      enabled: false,
       automerge: false,
-      labels: ["kubernetes", "kube-vip"]
+      labels: ["kubernetes", "manual-upgrade-only", "kube-vip"],
+      description: "Disable Renovate PRs for kube-vip because it is reviewed together with manual Kubernetes upgrades."
     }
   ],
 }


### PR DESCRIPTION
## Summary

- Disable Renovate PRs for Kubernetes-related custom regex packages (`kubernetes/kubernetes`, `cri-o/cri-o`, `kube-vip/kube-vip`) because upgrades are handled manually.
- Replace the external aqua checksum reusable workflow with an in-repo job that generates a GitHub App token, runs `aqua update-checksum -deep -prune`, and pushes checksum commits back to the PR head branch.
- Add the required BOXP-13 plan document.

## Root Cause

`aquaproj/update-checksum-workflow` generated checksum changes, but its downstream commit path fell back to a read-only token and failed with `Resource not accessible by integration` on `POST /repos/boxp/arch/git/trees`. That left Renovate PRs without updated `aqua/aqua-checksums.json`; for OPA updates this also caused `opa-fmt` to fail with `checksum is required` before formatting could run.

## Current PR Cleanup

- `#10653`: pushed checksum commit `9c4630950c805d553ae6d0b5307e9cb8980af80c`; checks passed and PR merged.
- `#10699`: pushed checksum commit `912b4dc1542343bed10bd6f9b6d592d774c158aa`; `opa-fmt` and checksum checks passed and PR merged.
- `#10328`: closed because Kubernetes upgrades are now manual project/ticket work, not Renovate auto-update work.

## Validation

- `npx --yes --package renovate renovate-config-validator renovate.json5`
- `/tmp/actionlint-boxp13/actionlint .github/workflows/wc-update-aqua-checksums.yaml .github/workflows/test.yaml`
