### PR TITLE
[codex] Remove moshi hook from codex workspace

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -11,7 +11,6 @@ ARG CEEKER_VERSION=0.3.7
 ARG BABASHKA_VERSION=1.12.218
 ARG LAZYGIT_VERSION=0.62.2
 ARG YAZI_VERSION=26.5.6
-ARG MOSHI_HOOK_VERSION=0.2.27
 ARG CURSOR_AGENT_VERSION=2026.06.12-19-59-36-f6aba9a
 ARG NODE_MAJOR=24
 
@@ -57,10 +56,6 @@ RUN npm install -g \
       "@earendil-works/pi-coding-agent@${PI_AGENT_VERSION}" \
       "obsidian-headless@${OBSIDIAN_HEADLESS_VERSION}" \
     && npm cache clean --force
-
-RUN curl -fsSL https://getmoshi.app/install.sh \
-      | INSTALL_DIR=/usr/local/bin MOSHI_HOOK_VERSION="${MOSHI_HOOK_VERSION}" sh \
-    && moshi-hook version
 
 RUN set -eux; \
     download() { curl --retry 5 --retry-all-errors --connect-timeout 30 --max-time 300 -fsSL "$1" -o "$2"; }; \

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -71,30 +71,6 @@ configure_pi_agent() {
   chown -R boxp:boxp /home/boxp/.pi/agent
 }
 
-start_moshi_hook() {
-  if [[ "${MOSHI_HOOK_ENABLED:-1}" == "0" ]]; then
-    return
-  fi
-
-  if ! command -v moshi-hook >/dev/null 2>&1; then
-    echo "moshi-hook is not installed; skipping Moshi hook setup" >&2
-    return
-  fi
-
-  if [[ -n "${MOSHI_PAIRING_TOKEN:-}" ]]; then
-    /usr/sbin/runuser -u boxp -- env HOME=/home/boxp PATH="${PATH}" \
-      moshi-hook pair --token "${MOSHI_PAIRING_TOKEN}" --store file \
-      || echo "moshi-hook pair failed; continuing workspace startup" >&2
-  fi
-
-  /usr/sbin/runuser -u boxp -- env HOME=/home/boxp PATH="${PATH}" \
-    moshi-hook install \
-    || echo "moshi-hook install failed; continuing workspace startup" >&2
-
-  /usr/sbin/runuser -u boxp -- env HOME=/home/boxp PATH="${PATH}" \
-    moshi-hook serve &
-}
-
 if [[ -d /opt/codex-workspace/skills ]]; then
   /usr/sbin/runuser -u boxp -- cp -R --no-preserve=mode,ownership \
     /opt/codex-workspace/skills/. /home/boxp/.codex/skills/
@@ -147,7 +123,6 @@ write_session_env
 
 ssh-keygen -A
 /usr/sbin/sshd -D -e -p "${SSHD_PORT:-2222}" &
-start_moshi_hook
 
 cd /home/boxp
 

--- a/docs/project_docs/BOXP-28-pi-agent-extensions-warning/plan.md
+++ b/docs/project_docs/BOXP-28-pi-agent-extensions-warning/plan.md
@@ -1,0 +1,17 @@
+# BOXP-28: pi agent legacy extension warning
+
+## Goal
+
+Stop codex-workspace startup from recreating pi agent legacy extension layout entries that trigger the `Move your extensions to the extensions/ directory.` warning.
+
+## Plan
+
+1. Keep startup migration for existing `~/.pi/agent/hooks/` entries into `~/.pi/agent/extensions/`.
+2. Keep startup migration for custom entries in `~/.pi/agent/tools/`, while leaving managed `fd` / `rg` binaries in place.
+3. Remove `moshi-hook` from the codex-workspace image and entrypoint because it is no longer needed and can recreate legacy hook entries after migration.
+4. Validate the shell entrypoint and diff hygiene.
+
+## Validation
+
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- remove moshi-hook installation from the codex-workspace image
- stop entrypoint from running moshi-hook pair/install/serve on startup
- keep the pi agent legacy hooks/tools migration and add the BOXP-28 plan document

## Why
Moshi is no longer needed in codex-workspace, and `moshi-hook install` can recreate legacy `~/.pi/agent/hooks/` entries after the startup migration runs. That keeps triggering pi agent's `Move your extensions to the extensions/ directory.` warning.

## Validation
- `bash -n docker/codex-workspace/entrypoint.sh`
- `git diff --check`
- `rg -n "moshi-hook|MOSHI_HOOK|MOSHI_PAIRING|MOSHI_" docker/codex-workspace -S`
- `codex review --uncommitted`