### PR TITLE
[codex] Document and test Task Board runner

### DIFF
--- a/docs/project_docs/BOXP-33-codex-task-board-system/plan.md
+++ b/docs/project_docs/BOXP-33-codex-task-board-system/plan.md
@@ -1,0 +1,19 @@
+# BOXP-33: Codex Task Board system
+
+## Goal
+
+Obsidian Task Board の `assignee: codex` チケットを codex-workspace runner が検出し、Task Board レーンを source of truth として要件整理、実装、レビュー待ち、停止、完了まで進める。
+
+## Plan
+
+1. Task Board runner の仕様を `docs/project_docs/BOXP-33-codex-task-board-system/spec.md` に集約する。
+2. runner の巨大化した振る舞いを black-box テストで固定する。
+3. temporary vault と fake `codex` を使い、実ファイルの Task Board / ticket / lock / run summary を検証する。
+4. 並列起動、active lock skip、stale lock recovery、review PR marker gate、lane/source-of-truth sync をテスト対象にする。
+5. CI へ載せやすいよう、テストは単独の Babashka script として `bb tests/task_board_runner_test.bb` で実行できる形にする。
+
+## Validation
+
+- `bb tests/task_board_runner_test.bb`
+- `bash -n docker/codex-workspace/entrypoint.sh`
+- `git diff --check`

--- a/docs/project_docs/BOXP-33-codex-task-board-system/spec.md
+++ b/docs/project_docs/BOXP-33-codex-task-board-system/spec.md
@@ -1,0 +1,69 @@
+# Codex Task Board system
+
+## Source of Truth
+
+Task Board のレーンを状態の source of truth とする。runner は tick の開始時に board を読み、カードが置かれているレーンから正規 `status` を決める。チケット frontmatter `status` とカード内 `status::` が異なる場合は、レーンに合わせて補正する。
+
+runner は Task Board カードを処理結果に応じて移動するが、Codex prompt には「カードを直接移動しない」ことを明記する。並列 run 中の board 書き戻しは runner 内で直列化し、移動直前に board を読み直して対象カードだけを移動する。
+
+## Trigger
+
+チケット frontmatter `assignee: codex` を Codex 起動トリガーにする。`assignee` が `codex` 以外の場合、runner は Codex run を開始しない。
+
+| レーン | assignee | runner action |
+| --- | --- | --- |
+| Backlog | codex | 要件整理 run を開始し、完了後 Ready へ移動する |
+| Ready | codex | 再開指示として In Progress へ移動し、実装 run を開始する |
+| In Progress | codex | 実装 run を開始する |
+| Review | codex | レビュー対応として In Progress へ移動し、修正 run を開始する |
+| Blocked | codex | ブロッカー再調査として In Progress へ移動し、再試行 run を開始する |
+| Done | any | Codex run は開始しない |
+
+Codex run 終了時、runner は `assignee: boxp` に戻し、人間の確認点に置く。完了時は `closed: YYYY-MM-DD` と card `done::YYYY-MM-DD` を設定する。
+
+## Parallelism and Locking
+
+1 tick で見つかった候補チケットはチケットごとに独立した Codex process として並列起動する。同じチケットだけは `/home/boxp/.codex-task-board/locks/<ticket>.edn` による ticket lock で二重実行を防ぐ。
+
+active lock があるチケットはそのチケットだけ skip し、他チケットの並列起動を止めない。lock は `ticket`, `run-id`, `action`, `lane`, `host`, `pid`, `started-at`, `heartbeat-at` を保持する。
+
+## Stale Lock Recovery
+
+runner は tick 冒頭と lock 取得時に stale lock を判定する。`heartbeat-at` が `CODEX_TASK_BOARD_LOCK_STALE_SECONDS` を超えて古い場合、前回 run summary を `interrupted` に更新し、Notes に heartbeat timeout を記録して lock を削除する。
+
+stale lock の削除後は、古い run state ではなく現在の Task Board レーンと `assignee` を読み直して処理を決める。壊れた lock EDN は当該 lock だけを隔離対象として削除し、他チケットの処理は継続する。
+
+## Run Workspace
+
+各 run は `/home/boxp/.codex-task-board/workspaces/<ticket>/<run-id>/` を作業ディレクトリにする。チケット frontmatter `repo:` に `owner/name` がある場合、runner は `/home/boxp/ghq/github.com/<owner>/<name>` から per-run git worktree を作る。
+
+local checkout が存在しない、または worktree 作成に失敗した場合、runner は即 blocked にせず、その事実を prompt に含めて Codex に準備を委ねる。
+
+## Review Gate
+
+repository 変更を伴う作業を Review に進める場合、Codex は GitHub PR URL を final message に含める。repository 変更がない review の場合だけ、`TASK_BOARD_REVIEW_PR: none` を明示できる。
+
+runner は `TASK_BOARD_RESULT: review` を受け取っても、GitHub PR URL または `TASK_BOARD_REVIEW_PR: none` が見つからない場合は Review へ移動せず Blocked へ戻し、Notes に理由を残す。
+
+## Persistence
+
+runner state は home PVC 上の `/home/boxp/.codex-task-board` に保存する。
+
+```text
+/home/boxp/.codex-task-board/
+├── locks/
+│   └── BOXP-40.edn
+├── runs/
+│   └── BOXP-40/
+│       └── 20260703T120000Z/
+│           ├── prompt.md
+│           ├── events.jsonl
+│           ├── stderr.log
+│           ├── last-message.md
+│           └── summary.edn
+└── workspaces/
+    └── BOXP-40/
+        └── 20260703T120000Z/
+```
+
+チケット Notes には、人間が Task Board 上で判断できる開始、停止、完了、PR、検証結果、次アクションだけを追記する。

--- a/tests/task_board_runner_test.bb
+++ b/tests/task_board_runner_test.bb
@@ -1,0 +1,259 @@
+#!/usr/bin/env bb
+
+(require '[babashka.fs :as fs]
+         '[babashka.process :as p]
+         '[clojure.edn :as edn]
+         '[clojure.string :as str])
+
+(def repo-root (str (fs/absolutize ".")))
+(def runner (fs/path repo-root "docker/codex-workspace/task-board/task_board_runner.bb"))
+
+(defn assert! [message pred]
+  (when-not pred
+    (throw (ex-info message {}))))
+
+(defn read-lines [path]
+  (str/split-lines (slurp (str path))))
+
+(defn make-temp-root []
+  (fs/create-temp-dir {:prefix "task-board-runner-test-"}))
+
+(defn write-file! [path text]
+  (fs/create-dirs (fs/parent path))
+  (spit (str path) text))
+
+(defn ticket-frontmatter [vault ticket-id]
+  (let [lines (read-lines (fs/path vault "Tickets" (str ticket-id ".md")))
+        fm (->> lines
+                (drop 1)
+                (take-while #(not= "---" %)))]
+    (into {} (keep (fn [line]
+                     (when-let [[_ k v] (re-matches #"([^:]+):\s*(.*)" line)]
+                       [(keyword k) v]))
+                   fm))))
+
+(defn board-text [vault]
+  (slurp (str (fs/path vault "Boards" "Task Board.md"))))
+
+(defn lane-section [vault lane]
+  (let [lines (read-lines (fs/path vault "Boards" "Task Board.md"))
+        start (first (keep-indexed (fn [idx line]
+                                     (when (= line (str "## " lane)) idx))
+                                   lines))
+        end (when start
+              (or (first (keep-indexed (fn [idx line]
+                                          (when (and (> idx start)
+                                                     (str/starts-with? line "## "))
+                                            idx))
+                                        lines))
+                  (count lines)))]
+    (when start
+      (str/join "\n" (subvec (vec lines) (inc start) end)))))
+
+(defn ticket-in-lane? [vault lane ticket-id]
+  (str/includes? (or (lane-section vault lane) "") ticket-id))
+
+(defn lock-path [root ticket-id]
+  (fs/path root "locks" (str ticket-id ".edn")))
+
+(defn summary-path [root ticket-id run-id]
+  (fs/path root "runs" ticket-id run-id "summary.edn"))
+
+(defn write-board! [vault lane->ticket-ids]
+  (let [lanes ["Backlog" "Ready" "In Progress" "Blocked" "Review" "Done"]
+        body (str/join
+              "\n\n"
+              (map (fn [lane]
+                     (let [status ({"Backlog" "backlog"
+                                    "Ready" "ready"
+                                    "In Progress" "in-progress"
+                                    "Blocked" "blocked"
+                                    "Review" "review"
+                                    "Done" "done"} lane)]
+                       (str "## " lane "\n"
+                            (str/join
+                             "\n"
+                             (map (fn [ticket-id]
+                                    (str "- [ ] [[Tickets/" ticket-id "|" ticket-id ": test]] #ticket status::" status " priority::medium"))
+                                  (get lane->ticket-ids lane []))))))
+                   lanes))]
+    (write-file! (fs/path vault "Boards" "Task Board.md") (str body "\n"))))
+
+(defn write-ticket! [vault ticket-id {:keys [status assignee repo]}]
+  (write-file!
+   (fs/path vault "Tickets" (str ticket-id ".md"))
+   (str "---\n"
+        "id: " ticket-id "\n"
+        "status: " status "\n"
+        "priority: medium\n"
+        "assignee: " assignee "\n"
+        "repo: " (or repo "") "\n"
+        "closed: \n"
+        "---\n\n"
+        "# " ticket-id "\n\n"
+        "## Summary\n\n"
+        "Test ticket.\n\n"
+        "## Acceptance Criteria\n\n"
+        "- [ ] Tested.\n\n"
+        "## Context\n\n"
+        "Temporary vault.\n\n"
+        "## Plan\n\n"
+        "- [ ] Run Codex.\n\n"
+        "## Notes\n")))
+
+(defn write-fake-codex! [bin-dir sleep-ms final-message]
+  (let [script (fs/path bin-dir "codex")]
+    (write-file!
+     script
+     (str "#!/usr/bin/env bash\n"
+          "set -euo pipefail\n"
+          "last_message=''\n"
+          "while (($#)); do\n"
+          "  case \"$1\" in\n"
+          "    --output-last-message) last_message=\"$2\"; shift 2 ;;\n"
+          "    *) shift ;;\n"
+          "  esac\n"
+          "done\n"
+          "prompt=\"$(cat)\"\n"
+          "ticket=\"$(printf '%s' \"$prompt\" | sed -n 's/^Ticket: //p' | head -n1)\"\n"
+          "date +%s%3N >> \"${FAKE_CODEX_LOG}\"\n"
+          "printf 'start %s\\n' \"$ticket\" >> \"${FAKE_CODEX_LOG}\"\n"
+          "sleep " (/ sleep-ms 1000.0) "\n"
+          "cat > \"$last_message\" <<'EOF'\n"
+          final-message "\n"
+          "EOF\n"
+          "printf '{\"type\":\"done\",\"ticket\":\"%s\"}\\n' \"$ticket\"\n"
+          "printf 'end %s\\n' \"$ticket\" >> \"${FAKE_CODEX_LOG}\"\n"))
+    (fs/set-posix-file-permissions script "rwxr-xr-x")))
+
+(defn run-tick! [root vault bin-dir extra-env]
+  (let [env (merge (into {} (System/getenv))
+                   {"CODEX_TASK_BOARD_ROOT" (str root)
+                    "CODEX_TASK_BOARD_VAULT" (str vault)
+                    "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"
+                    "PATH" (str bin-dir ":" (System/getenv "PATH"))}
+                   extra-env)
+        proc @(p/process ["bb" (str runner) "tick"]
+                         {:env env :out :string :err :string})]
+    (assert! (str "runner exited non-zero\nstdout:\n" (:out proc) "\nstderr:\n" (:err proc))
+             (zero? (:exit proc)))
+    proc))
+
+(defn setup-case! [tickets lane->ticket-ids final-message sleep-ms]
+  (let [root (make-temp-root)
+        vault (fs/path root "vault")
+        state (fs/path root "state")
+        bin-dir (fs/path root "bin")
+        log-path (fs/path root "fake-codex.log")]
+    (fs/create-dirs bin-dir)
+    (write-board! vault lane->ticket-ids)
+    (doseq [[ticket-id attrs] tickets]
+      (write-ticket! vault ticket-id attrs))
+    (write-fake-codex! bin-dir sleep-ms final-message)
+    {:root state :vault vault :bin-dir bin-dir :log-path log-path}))
+
+(defn test-parallel-runs []
+  (let [{:keys [root vault bin-dir log-path]}
+        (setup-case!
+         {"BOXP-101" {:status "ready" :assignee "codex"}
+          "BOXP-102" {:status "ready" :assignee "codex"}}
+         {"Ready" ["BOXP-101" "BOXP-102"]}
+         "Finished.\nTASK_BOARD_REVIEW_PR: none\nTASK_BOARD_RESULT: review"
+         1200)
+        started (System/nanoTime)]
+    (run-tick! root vault bin-dir {"FAKE_CODEX_LOG" (str log-path)})
+    (let [elapsed-ms (/ (- (System/nanoTime) started) 1000000.0)
+          log (slurp (str log-path))
+          review-section (lane-section vault "Review")]
+      (assert! (str "expected parallel runtime, got " elapsed-ms "ms")
+               (< elapsed-ms 2300))
+      (assert! "first ticket did not start" (str/includes? log "start BOXP-101"))
+      (assert! "second ticket did not start" (str/includes? log "start BOXP-102"))
+      (assert! "BOXP-101 was not moved to Review" (str/includes? review-section "BOXP-101"))
+      (assert! "BOXP-102 was not moved to Review" (str/includes? review-section "BOXP-102"))
+      (assert! "assignee was not returned to boxp"
+               (= "boxp" (:assignee (ticket-frontmatter vault "BOXP-101")))))))
+
+(defn test-active-lock-skips-only-that-ticket []
+  (let [{:keys [root vault bin-dir log-path]}
+        (setup-case!
+         {"BOXP-201" {:status "ready" :assignee "codex"}
+          "BOXP-202" {:status "ready" :assignee "codex"}}
+         {"Ready" ["BOXP-201" "BOXP-202"]}
+         "Finished.\nTASK_BOARD_REVIEW_PR: none\nTASK_BOARD_RESULT: review"
+         100)]
+    (write-file! (lock-path root "BOXP-201")
+                 (str (pr-str {:ticket "BOXP-201"
+                               :run-id "active-run"
+                               :heartbeat-at (str (java.time.Instant/now))})
+                      "\n"))
+    (run-tick! root vault bin-dir {"FAKE_CODEX_LOG" (str log-path)})
+    (let [log (slurp (str log-path))
+          board (board-text vault)]
+      (assert! "locked ticket should not start" (not (str/includes? log "start BOXP-201")))
+      (assert! "unlocked ticket should start" (str/includes? log "start BOXP-202"))
+      (assert! "locked ticket should remain in Ready" (ticket-in-lane? vault "Ready" "BOXP-201"))
+      (assert! "unlocked ticket should move to Review" (ticket-in-lane? vault "Review" "BOXP-202")))))
+
+(defn test-stale-lock-recovers []
+  (let [{:keys [root vault bin-dir log-path]}
+        (setup-case!
+         {"BOXP-301" {:status "ready" :assignee "codex"}}
+         {"Ready" ["BOXP-301"]}
+         "Done.\nTASK_BOARD_RESULT: done"
+         50)
+        old-run-id "old-run"]
+    (write-file! (lock-path root "BOXP-301")
+                 (str (pr-str {:ticket "BOXP-301"
+                               :run-id old-run-id
+                               :heartbeat-at "2000-01-01T00:00:00Z"})
+                      "\n"))
+    (run-tick! root vault bin-dir {"FAKE_CODEX_LOG" (str log-path)
+                                   "CODEX_TASK_BOARD_LOCK_STALE_SECONDS" "1"})
+    (let [summary (edn/read-string (slurp (str (summary-path root "BOXP-301" old-run-id))))
+          board (board-text vault)]
+      (assert! "old run was not marked interrupted" (= :interrupted (:status summary)))
+      (assert! "ticket did not restart after stale lock" (str/includes? (slurp (str log-path)) "start BOXP-301"))
+      (assert! "ticket was not moved to Done" (ticket-in-lane? vault "Done" "BOXP-301")))))
+
+(defn test-review-without-pr-marker_blocks []
+  (let [{:keys [root vault bin-dir log-path]}
+        (setup-case!
+         {"BOXP-401" {:status "ready" :assignee "codex"}}
+         {"Ready" ["BOXP-401"]}
+         "Needs review.\nTASK_BOARD_RESULT: review"
+         50)]
+    (run-tick! root vault bin-dir {"FAKE_CODEX_LOG" (str log-path)})
+    (let [board (board-text vault)
+          ticket (slurp (str (fs/path vault "Tickets/BOXP-401.md")))]
+      (assert! "ticket should be blocked when review lacks PR marker"
+               (ticket-in-lane? vault "Blocked" "BOXP-401"))
+      (assert! "blocked note should explain missing PR marker"
+               (str/includes? ticket "Review was requested without a GitHub PR URL")))))
+
+(defn test-lane-source-of-truth-sync []
+  (let [{:keys [root vault bin-dir log-path]}
+        (setup-case!
+         {"BOXP-501" {:status "in-progress" :assignee "boxp"}}
+         {"Ready" ["BOXP-501"]}
+         "Unused.\nTASK_BOARD_RESULT: done"
+         10)]
+    (run-tick! root vault bin-dir {"FAKE_CODEX_LOG" (str log-path)})
+    (let [fm (ticket-frontmatter vault "BOXP-501")
+          board (board-text vault)]
+      (assert! "frontmatter should sync to board lane" (= "ready" (:status fm)))
+      (assert! "card status should remain ready" (re-find #"BOXP-501: test.*status::ready" board))
+      (assert! "codex should not run for non-codex assignee" (not (fs/exists? log-path))))))
+
+(def tests
+  [["parallel runs" test-parallel-runs]
+   ["active lock skips only that ticket" test-active-lock-skips-only-that-ticket]
+   ["stale lock recovers" test-stale-lock-recovers]
+   ["review without PR marker blocks" test-review-without-pr-marker_blocks]
+   ["lane source of truth sync" test-lane-source-of-truth-sync]])
+
+(doseq [[name f] tests]
+  (print (str name " ... "))
+  (flush)
+  (f)
+  (println "ok"))


### PR DESCRIPTION
## Summary
- add BOXP-33 Codex Task Board system spec under docs/project_docs
- add a Babashka black-box test suite for the Task Board runner using a temporary vault and fake codex executable
- cover parallel ticket runs, active lock skip, stale lock recovery, review PR marker blocking, and lane-as-source-of-truth sync

## Validation
- bb tests/task_board_runner_test.bb
- bash -n docker/codex-workspace/entrypoint.sh
- git diff --check
- codex review --uncommitted