### PR TITLE
[codex] Add Task Board runner tests

### DIFF
--- a/.github/workflows/test-codex-task-board-runner.yml
+++ b/.github/workflows/test-codex-task-board-runner.yml
@@ -1,0 +1,39 @@
+name: Test Codex Task Board Runner
+
+on:
+  pull_request:
+    paths:
+      - docker/codex-workspace/task-board/**
+      - tests/codex-workspace/**
+      - .github/workflows/test-codex-task-board-runner.yml
+  push:
+    branches: [main]
+    paths:
+      - docker/codex-workspace/task-board/**
+      - tests/codex-workspace/**
+      - .github/workflows/test-codex-task-board-runner.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      BABASHKA_VERSION: 1.12.218
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Babashka
+        run: |
+          set -eux
+          tmp="$(mktemp -d)"
+          curl --retry 5 --retry-all-errors --connect-timeout 30 --max-time 300 -fsSL \
+            "https://github.com/babashka/babashka/releases/download/v${BABASHKA_VERSION}/babashka-${BABASHKA_VERSION}-linux-amd64-static.tar.gz" \
+            -o "${tmp}/bb.tar.gz"
+          tar -xzf "${tmp}/bb.tar.gz" -C "${tmp}"
+          sudo install -m 0755 "$(find "${tmp}" -type f -name bb | head -n 1)" /usr/local/bin/bb
+      - run: tests/codex-workspace/task-board-runner-test.sh

--- a/docs/project_docs/BOXP-33-codex-task-board-runner/plan.md
+++ b/docs/project_docs/BOXP-33-codex-task-board-runner/plan.md
@@ -18,6 +18,9 @@ Add a codex-workspace Task Board runner that detects Obsidian tickets assigned t
 10. Close stale ticket locks at tick startup, mark the previous run `interrupted`, and then decide whether to restart or stop from the current Task Board lane and assignee.
 11. Skip missing ticket files and active locked tickets without aborting the whole tick, preserving Task Board lane as the source of truth.
 12. Require Codex to include a GitHub PR URL before moving repository-changing work to `Review`; allow `TASK_BOARD_REVIEW_PR: none` only when no repository changes were made.
+13. Document the system under the Obsidian vault `Projects/codex-task-board-runner/` directory.
+14. Add black-box tests for the runner behavior that had regressed or was ambiguous: parallel starts, stale lock recovery, and review PR gating.
+15. Add a GitHub Actions workflow that runs the runner tests when the runner, tests, or workflow change.
 
 ## Validation
 
@@ -30,5 +33,6 @@ Add a codex-workspace Task Board runner that detects Obsidian tickets assigned t
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` against a temporary vault with comma-separated and space-separated multi-repo frontmatter, confirming per-run git worktrees are prepared.
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` with `CODEX_TASK_BOARD_BYPASS_APPROVALS=false`, confirming the vault and worktree gitdirs are passed through `--add-dir`.
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` against a temporary vault where one Codex run returns `review` without a PR marker.
+- `tests/codex-workspace/task-board-runner-test.sh`, which covers parallel fake Codex starts, stale lock recovery, and blocking review without a PR marker.
 - `bash -n docker/codex-workspace/entrypoint.sh`.
 - `git diff --check`.

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="${ROOT_DIR}/docker/codex-workspace/task-board/task_board_runner.bb"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -Eq "$pattern" "$file" || fail "expected ${file} to match ${pattern}"
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Eq "$pattern" "$file"; then
+    fail "expected ${file} not to match ${pattern}"
+  fi
+}
+
+make_fake_codex() {
+  local bin_dir="$1"
+  cat >"${bin_dir}/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+last_message=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-last-message)
+      last_message="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+prompt="$(mktemp)"
+cat >"${prompt}"
+ticket="$(sed -n 's/^Ticket: //p' "${prompt}" | head -n 1)"
+mkdir -p "$(dirname "${last_message}")"
+if [[ -n "${CODEX_FAKE_START_LOG:-}" ]]; then
+  printf '%s %s\n' "${ticket}" "$(date +%s)" >>"${CODEX_FAKE_START_LOG}"
+fi
+sleep "${CODEX_FAKE_SLEEP:-0}"
+printf '%s\n' "${CODEX_FAKE_MESSAGE:-TASK_BOARD_RESULT: done}" >"${last_message}"
+rm -f "${prompt}"
+EOF
+  chmod +x "${bin_dir}/codex"
+}
+
+write_board() {
+  local vault="$1"
+  local body="$2"
+  mkdir -p "${vault}/Boards" "${vault}/Tickets"
+  cat >"${vault}/Boards/Task Board.md" <<EOF
+# Task Board
+
+## Backlog
+
+## Ready
+
+## In Progress
+${body}
+
+## Blocked
+
+## Review
+
+## Done
+EOF
+}
+
+write_ticket() {
+  local vault="$1"
+  local ticket="$2"
+  local status="$3"
+  local assignee="$4"
+  local repo="${5:-}"
+  cat >"${vault}/Tickets/${ticket}.md" <<EOF
+---
+id: ${ticket}
+type: task
+status: ${status}
+priority: medium
+assignee: ${assignee}
+repo: ${repo}
+closed:
+---
+
+# ${ticket}: test ticket
+
+## Summary
+
+Test ticket.
+
+## Acceptance Criteria
+
+- [ ] Done
+
+## Context
+
+Test context.
+
+## Plan
+
+- [ ] Run
+
+## Notes
+EOF
+}
+
+run_tick() {
+  local vault="$1"
+  local state_root="$2"
+  shift 2
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+  CODEX_TASK_BOARD_ROOT="${state_root}" \
+  CODEX_TASK_BOARD_LOCK_STALE_SECONDS="${CODEX_TASK_BOARD_LOCK_STALE_SECONDS:-1800}" \
+  "$@" bb "${RUNNER}" tick
+}
+
+test_parallel_codex_runs() {
+  local tmp vault state bin log first_start second_start start_delta
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  log="${tmp}/starts.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-101|BOXP-101: first]] #ticket status::in-progress
+- [ ] [[Tickets/BOXP-102|BOXP-102: second]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-101 in-progress codex
+  write_ticket "${vault}" BOXP-102 in-progress codex
+
+  PATH="${bin}:$PATH" CODEX_FAKE_START_LOG="${log}" CODEX_FAKE_SLEEP=2 run_tick "${vault}" "${state}" env >/tmp/task-board-parallel.out
+
+  [[ "$(wc -l <"${log}")" -eq 2 ]] || fail "expected two fake codex starts"
+  first_start="$(awk 'NR == 1 {print $2}' "${log}")"
+  second_start="$(awk 'NR == 2 {print $2}' "${log}")"
+  start_delta=$((second_start - first_start))
+  [[ "${start_delta#-}" -le 1 ]] || fail "expected fake codex starts within 1s, got ${start_delta}s"
+  assert_file_contains "${vault}/Boards/Task Board.md" 'status::done'
+  assert_file_contains "${vault}/Tickets/BOXP-101.md" '^status: done$'
+  assert_file_contains "${vault}/Tickets/BOXP-102.md" '^status: done$'
+}
+
+test_stale_lock_recovers() {
+  local tmp vault state bin old_run
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  old_run="20260703T000000Z"
+  mkdir -p "${bin}" "${state}/locks" "${state}/runs/BOXP-201/${old_run}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-201|BOXP-201: stale]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-201 in-progress codex
+  cat >"${state}/locks/BOXP-201.edn" <<EOF
+{:ticket "BOXP-201" :run-id "${old_run}" :action :implement :lane "In Progress" :heartbeat-at "2000-01-01T00:00:00Z"}
+EOF
+
+  PATH="${bin}:$PATH" CODEX_TASK_BOARD_LOCK_STALE_SECONDS=1 run_tick "${vault}" "${state}" env >/tmp/task-board-stale.out
+
+  assert_file_contains "${state}/runs/BOXP-201/${old_run}/summary.edn" ':status :interrupted'
+  assert_file_contains "${vault}/Tickets/BOXP-201.md" 'marked interrupted after heartbeat timeout'
+  assert_file_contains "${vault}/Tickets/BOXP-201.md" '^status: done$'
+  [[ ! -e "${state}/locks/BOXP-201.edn" ]] || fail "expected stale lock to be released"
+}
+
+test_review_without_pr_is_blocked() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-301|BOXP-301: review]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-301 in-progress codex
+
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE='TASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '## Blocked'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-301\|BOXP-301: review\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-301.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-301.md" 'Review was requested without a GitHub PR URL'
+  assert_file_not_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-301\|BOXP-301: review\]\].*status::review'
+}
+
+test_parallel_codex_runs
+test_stale_lock_recovers
+test_review_without_pr_is_blocked
+
+echo "task-board-runner tests passed"


### PR DESCRIPTION
## Summary

- Add black-box tests for the Codex Task Board runner using a temporary vault and fake `codex` executable.
- Cover the ambiguous/high-risk behaviors from BOXP-33: parallel ticket starts, stale lock recovery, and blocking review transitions without a PR marker.
- Add a dedicated GitHub Actions workflow that installs Babashka 1.12.218 and runs the runner test when runner/test/workflow files change.
- Update the repo plan to include the Obsidian Projects documentation and the new test/CI follow-up.

## Notes

The user-facing system documentation was added in the Obsidian vault at `Projects/codex-task-board-runner/README.md` and `todo.md`. Those files are outside this GitHub repository and are not part of this PR diff.

## Validation

- `tests/codex-workspace/task-board-runner-test.sh`
- `bash -n docker/codex-workspace/entrypoint.sh`
- `git diff --check`
- `codex review --uncommitted` (initial review found a test side effect; fixed by avoiding local repo worktree creation in the review-gating test)
- `codex review --uncommitted` (final review: no issues found)
