### PR TITLE
[codex] Add Task Board review PR note

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -503,6 +503,9 @@
 (defn github-pr-url? [text]
   (boolean (re-find #"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+" (or text ""))))
 
+(defn first-github-pr-url [text]
+  (re-find #"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+" (or text "")))
+
 (defn no-repo-review-marker? [text]
   (boolean (re-find #"(?im)^TASK_BOARD_REVIEW_PR:\s*none\s*$" (or text ""))))
 
@@ -585,11 +588,18 @@
       intended)))
 
 (defn final-note [run-id next-status result last-message]
-  (let [base (str "Codex task-board run " run-id " finished with result " next-status ".")]
-    (if (and (= "blocked" next-status)
-             (not (#{"done" "blocked"} result))
-             (not (review-ready? last-message)))
+  (let [base (str "Codex task-board run " run-id " finished with result " next-status ".")
+        pr-url (first-github-pr-url last-message)]
+    (cond
+      (and (= "blocked" next-status)
+           (not (#{"done" "blocked"} result))
+           (not (review-ready? last-message)))
       (str base " Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker, so the runner blocked before moving to review.")
+
+      (and (= "review" next-status) pr-url)
+      (str base " PR: " pr-url)
+
+      :else
       base)))
 
 (defn process-card! [{:keys [ticket-id lane status] :as card}]

--- a/docs/project_docs/BOXP-33-codex-task-board-runner/plan.md
+++ b/docs/project_docs/BOXP-33-codex-task-board-runner/plan.md
@@ -18,9 +18,10 @@ Add a codex-workspace Task Board runner that detects Obsidian tickets assigned t
 10. Close stale ticket locks at tick startup, mark the previous run `interrupted`, and then decide whether to restart or stop from the current Task Board lane and assignee.
 11. Skip missing ticket files and active locked tickets without aborting the whole tick, preserving Task Board lane as the source of truth.
 12. Require Codex to include a GitHub PR URL before moving repository-changing work to `Review`; allow `TASK_BOARD_REVIEW_PR: none` only when no repository changes were made.
-13. Document the system under the Obsidian vault `Projects/codex-task-board-runner/` directory.
-14. Add black-box tests for the runner behavior that had regressed or was ambiguous: parallel starts, stale lock recovery, and review PR gating.
-15. Add a GitHub Actions workflow that runs the runner tests when the runner, tests, or workflow change.
+13. When a run moves to `Review` with a GitHub PR URL, copy that URL into the ticket Notes so the Task Board card has a visible review target.
+14. Document the system under the Obsidian vault `Projects/codex-task-board-runner/` directory.
+15. Add black-box tests for the runner behavior that had regressed or was ambiguous: parallel starts, stale lock recovery, review PR gating, and PR URL Notes copy.
+16. Add a GitHub Actions workflow that runs the runner tests when the runner, tests, or workflow change.
 
 ## Validation
 
@@ -33,6 +34,6 @@ Add a codex-workspace Task Board runner that detects Obsidian tickets assigned t
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` against a temporary vault with comma-separated and space-separated multi-repo frontmatter, confirming per-run git worktrees are prepared.
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` with `CODEX_TASK_BOARD_BYPASS_APPROVALS=false`, confirming the vault and worktree gitdirs are passed through `--add-dir`.
 - `bb docker/codex-workspace/task-board/task_board_runner.bb tick` against a temporary vault where one Codex run returns `review` without a PR marker.
-- `tests/codex-workspace/task-board-runner-test.sh`, which covers parallel fake Codex starts, stale lock recovery, and blocking review without a PR marker.
+- `tests/codex-workspace/task-board-runner-test.sh`, which covers parallel fake Codex starts, stale lock recovery, blocking review without a PR marker, and copying a review PR URL into ticket Notes.
 - `bash -n docker/codex-workspace/entrypoint.sh`.
 - `git diff --check`.

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -196,8 +196,28 @@ test_review_without_pr_is_blocked() {
   assert_file_not_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-301\|BOXP-301: review\]\].*status::review'
 }
 
+test_review_with_pr_url_is_noted() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-401|BOXP-401: review pr]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-401 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-pr.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-401\|BOXP-401: review pr\]\].*status::review'
+  assert_file_contains "${vault}/Tickets/BOXP-401.md" '^status: review$'
+  assert_file_contains "${vault}/Tickets/BOXP-401.md" '^assignee: boxp$'
+  assert_file_contains "${vault}/Tickets/BOXP-401.md" 'PR: https://github.com/boxp/example/pull/123'
+}
+
 test_parallel_codex_runs
 test_stale_lock_recovers
 test_review_without_pr_is_blocked
+test_review_with_pr_url_is_noted
 
 echo "task-board-runner tests passed"


### PR DESCRIPTION
## Summary
- Copy the first GitHub PR URL from a Codex review result into the ticket Notes when moving a ticket to Review.
- Add a black-box runner test for the PR URL Notes copy behavior.
- Update the BOXP-33 runner plan to document the Notes link requirement.

## Validation
- tests/codex-workspace/task-board-runner-test.sh
- bash -n docker/codex-workspace/entrypoint.sh
- bash -n tests/codex-workspace/task-board-runner-test.sh
- git diff --check
- codex review --uncommitted
