### PR TITLE
[codex] Install kubectl in Codex workspace image

### DIFF
--- a/docker/codex-workspace/Dockerfile
+++ b/docker/codex-workspace/Dockerfile
@@ -12,6 +12,8 @@ ARG BABASHKA_VERSION=1.12.218
 ARG LAZYGIT_VERSION=0.62.2
 ARG YAZI_VERSION=26.5.6
 ARG CURSOR_AGENT_VERSION=2026.06.12-19-59-36-f6aba9a
+ARG KUBECTL_VERSION=1.36.1
+ARG KUSTOMIZE_VERSION=5.8.1
 ARG NODE_MAJOR=24
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -82,6 +84,11 @@ RUN set -eux; \
     unzip -q "$tmp/yazi.zip" -d "$tmp/yazi"; \
     install -m 0755 "$(find "$tmp/yazi" -type f -name yazi | head -n 1)" /usr/local/bin/yazi; \
     install -m 0755 "$(find "$tmp/yazi" -type f -name ya | head -n 1)" /usr/local/bin/ya; \
+    download "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" "$tmp/kubectl"; \
+    install -m 0755 "$tmp/kubectl" /usr/local/bin/kubectl; \
+    download "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" "$tmp/kustomize.tar.gz"; \
+    tar -xzf "$tmp/kustomize.tar.gz" -C "$tmp"; \
+    install -m 0755 "$tmp/kustomize" /usr/local/bin/kustomize; \
     rm -rf "$tmp"
 
 RUN set -eux; \

--- a/docker/codex-workspace/entrypoint.sh
+++ b/docker/codex-workspace/entrypoint.sh
@@ -102,7 +102,8 @@ write_session_env() {
     VISUAL \
     GRAFANA_URL \
     GRAFANA_SERVICE_ACCOUNT_TOKEN \
-    GEMINI_API_KEY; do
+    GEMINI_API_KEY \
+    KUBECONFIG; do
     if [[ -n "${!name:-}" ]]; then
       printf 'export %s=%q\n' "${name}" "${!name}" >>"${env_tmp}"
     fi
@@ -132,7 +133,7 @@ if [[ -n "${EVEN_TERMINAL_TOKEN:-}" ]]; then
 fi
 
 exec /usr/sbin/runuser -u boxp \
-  --whitelist-environment=DOCKER_HOST,DOCKER_BUILDKIT,EDITOR,VISUAL,GRAFANA_URL,GRAFANA_SERVICE_ACCOUNT_TOKEN,GEMINI_API_KEY \
+  --whitelist-environment=DOCKER_HOST,DOCKER_BUILDKIT,EDITOR,VISUAL,GRAFANA_URL,GRAFANA_SERVICE_ACCOUNT_TOKEN,GEMINI_API_KEY,KUBECONFIG \
   -- env HOME=/home/boxp even-terminal \
   --port "${EVEN_TERMINAL_PORT:-3456}" \
   --cwd "${EVEN_TERMINAL_CWD:-/home/boxp}" \

--- a/docs/project_docs/BOXP-37-codex-workspace-kubectl-image/plan.md
+++ b/docs/project_docs/BOXP-37-codex-workspace-kubectl-image/plan.md
@@ -1,0 +1,38 @@
+# BOXP-37 codex-workspace kubectl image
+
+## 目的
+
+Codex workspace image に `kubectl` / `kustomize` を含め、lolice 側の Pod manifest では CLI binary を init container で差し込まない構成にする。
+
+## 実装
+
+- `docker/codex-workspace/Dockerfile` に `KUBECTL_VERSION=1.36.1` と `KUSTOMIZE_VERSION=5.8.1` を追加する。
+- `kubectl` は `dl.k8s.io` の公式 linux/amd64 binary を `/usr/local/bin/kubectl` に install する。
+- `kustomize` は `kubernetes-sigs/kustomize` の release archive から `/usr/local/bin/kustomize` に install する。
+- `docker/codex-workspace/entrypoint.sh` で `KUBECONFIG` を SSH / Even Terminal セッションへ引き継ぐ。
+
+## 検証
+
+実行済み:
+
+```bash
+bash -n docker/codex-workspace/entrypoint.sh
+docker build -t codex-workspace:boxp-37 docker/codex-workspace
+docker run --rm --entrypoint /bin/bash codex-workspace:boxp-37 -lc 'kubectl version --client=true --output=yaml && kustomize version'
+docker run --rm -e KUBECONFIG=/var/run/secrets/codex-workspace/kubeconfig/config codex-workspace:boxp-37 /bin/bash -lc 'grep KUBECONFIG /run/codex-workspace/session-env'
+```
+
+結果:
+
+- `bash -n docker/codex-workspace/entrypoint.sh` は成功。
+- `DOCKER_BUILDKIT=0 docker build -t codex-workspace:boxp-37 docker/codex-workspace` は成功。
+- BuildKit ありの `docker build` は、この worker の Docker buildx component が壊れていたため開始前に失敗した。
+- `kubectl version --client=true --output=yaml` は `v1.36.1` / bundled `kustomizeVersion: v5.8.1` を返した。
+- `kustomize version` は `v5.8.1` を返した。
+- `kubectl kustomize --help` は成功した。
+- entrypoint 起動後の `/run/codex-workspace/session-env` に `export KUBECONFIG=/var/run/secrets/codex-workspace/kubeconfig/config` が書き出されることを確認した。
+
+## 制限事項
+
+- cluster 接続用の ServiceAccount / RBAC / projected token / kubeconfig mount は `boxp/lolice` 側の BOXP-37 manifest で管理する。
+- 実 cluster への `kubectl auth can-i` は image build だけでは検証できないため、lolice 側 Pod rollout 後に確認する。


### PR DESCRIPTION
## Summary
- install kubectl v1.36.1 and kustomize v5.8.1 in the codex-workspace image
- propagate KUBECONFIG into SSH / Even Terminal session env
- document the BOXP-37 image-side plan and validation

## Validation
- bash -n docker/codex-workspace/entrypoint.sh
- DOCKER_BUILDKIT=0 docker build -t codex-workspace:boxp-37 docker/codex-workspace
- docker run --rm --entrypoint /bin/bash codex-workspace:boxp-37 -lc 'kubectl version --client=true --output=yaml && kustomize version && kubectl kustomize --help >/tmp/kubectl-kustomize-help && wc -l /tmp/kubectl-kustomize-help'\n- docker run -d -e KUBECONFIG=/var/run/secrets/codex-workspace/kubeconfig/config codex-workspace:boxp-37; docker exec ... grep KUBECONFIG /run/codex-workspace/session-env