### PR TITLE
BOXP-42: gate task board review PRs

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -532,6 +532,14 @@
       (throw (ex-info (str "command failed: " (str/join " " args) "\n" (:err proc))
                       {:args args :exit (:exit proc) :err (:err proc)})))))
 
+(defn codex-model-profile-args []
+  (cond-> []
+    (seq (System/getenv "CODEX_TASK_BOARD_MODEL"))
+    (conj "--model" (System/getenv "CODEX_TASK_BOARD_MODEL"))
+
+    (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
+    (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))))
+
 (defn pr-view [pr-url]
   (-> (run-string! ["gh" "pr" "view" pr-url "--json" "url,isDraft,mergeStateStatus,statusCheckRollup"] {})
       (json/parse-string true)))
@@ -668,10 +676,14 @@
                     "Return CODEX_REVIEW_RESULT: issues when any actionable finding remains, followed by a concise summary.\n\n"
                     "PR: " pr-url "\n\n"
                     diff)
-        proc @(p/process ["codex" "exec"
-                          "--skip-git-repo-check"
-                          "--output-last-message" (str review-path)
-                          "-"]
+        proc @(p/process (cond-> ["codex" "exec"
+                                  "--skip-git-repo-check"
+                                  "--output-last-message" (str review-path)]
+                           true
+                           (into (codex-model-profile-args))
+
+                           true
+                           (conj "-"))
                          {:in prompt :out :string :err :string})
         last-message (when (fs/exists? review-path)
                        (slurp (str review-path)))]
@@ -760,11 +772,8 @@
                  (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
                  (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
 
-                 (seq (System/getenv "CODEX_TASK_BOARD_MODEL"))
-                 (conj "--model" (System/getenv "CODEX_TASK_BOARD_MODEL"))
-
-                 (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
-                 (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))
+                 true
+                 (into (codex-model-profile-args))
 
                  true
                  (conj "-"))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -504,8 +504,10 @@
 (defn github-pr-url? [text]
   (boolean (re-find #"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+" (or text ""))))
 
-(defn first-github-pr-url [text]
-  (re-find #"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+" (or text "")))
+(defn github-pr-urls [text]
+  (->> (re-seq #"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+" (or text ""))
+       distinct
+       vec))
 
 (defn no-repo-review-marker? [text]
   (boolean (re-find #"(?im)^TASK_BOARD_REVIEW_PR:\s*none\s*$" (or text ""))))
@@ -659,7 +661,7 @@
 
 (defn run-codex-review! [run-dir pr-url]
   (let [diff (run-string! ["gh" "pr" "diff" pr-url] {})
-        review-path (fs/path run-dir "codex-review.md")
+        review-path (fs/path run-dir (str "codex-review-" (last (str/split pr-url #"/")) ".md"))
         prompt (str "CODEX_REVIEW_GATE\n"
                     "Review this GitHub PR diff for actionable bugs, regressions, missing tests, or acceptance-criteria gaps.\n"
                     "Return CODEX_REVIEW_RESULT: clean only if there are no actionable findings.\n"
@@ -695,23 +697,40 @@
 
 (defn review-gate! [run-dir last-message]
   (try
-    (cond
-      (first-github-pr-url last-message)
-      (let [pr-url (first-github-pr-url last-message)
-            pr-state (wait-for-pr-state! pr-url)]
-        (if-not (:ok? pr-state)
-          pr-state
-          (let [review (run-codex-review! run-dir pr-url)]
-            (update review :message #(str (:message pr-state) " " %)))))
+    (let [pr-urls (github-pr-urls last-message)]
+      (cond
+        (seq pr-urls)
+        (loop [remaining pr-urls
+               passed []]
+          (if-let [pr-url (first remaining)]
+            (let [pr-state (wait-for-pr-state! pr-url)]
+              (if-not (:ok? pr-state)
+                (assoc pr-state
+                       :checked-pr-urls passed
+                       :pr-urls pr-urls)
+                (let [review (run-codex-review! run-dir pr-url)
+                      passed-message (str pr-url ": " (:message pr-state) " " (:message review))]
+                  (if-not (:ok? review)
+                    (assoc review
+                           :checked-pr-urls passed
+                           :pr-urls pr-urls
+                           :message (str pr-url ": " (:message pr-state) " " (:message review)))
+                    (recur (rest remaining) (conj passed passed-message))))))
+            {:ok? true
+             :pr-urls pr-urls
+             :message (str "All PR gates passed for "
+                           (count pr-urls)
+                           " PR(s): "
+                           (str/join " | " passed))}))
 
-      (no-repo-review-marker? last-message)
-      {:ok? true
-       :message "TASK_BOARD_REVIEW_PR: none was provided; PR gates were skipped because no repository changes were reported."}
+        (no-repo-review-marker? last-message)
+        {:ok? true
+         :message "TASK_BOARD_REVIEW_PR: none was provided; PR gates were skipped because no repository changes were reported."}
 
-      :else
-      {:ok? false
-       :gate :pr-url
-       :message "Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker."})
+        :else
+        {:ok? false
+         :gate :pr-url
+         :message "Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker."}))
     (catch Exception e
       {:ok? false
        :gate :pr-gate
@@ -793,7 +812,7 @@
 
 (defn final-note [run-id next-status result last-message review-gate]
   (let [base (str "Codex task-board run " run-id " finished with result " next-status ".")
-        pr-url (first-github-pr-url last-message)]
+        pr-urls (github-pr-urls last-message)]
     (cond
       (and (= "blocked" next-status)
            (not (#{"done" "blocked"} result))
@@ -801,10 +820,12 @@
       (str base " Review gate failed"
            (when-let [gate (:gate review-gate)]
              (str " (" (name gate) ")"))
+           (when-let [url (:url review-gate)]
+             (str " for " url))
            ": " (:message review-gate))
 
-      (and (= "review" next-status) pr-url)
-      (str base " PR: " pr-url ". Review gates passed: " (:message review-gate))
+      (and (= "review" next-status) (seq pr-urls))
+      (str base " PR: " (str/join ", " pr-urls) ". Review gates passed: " (:message review-gate))
 
       :else
       base)))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -743,52 +743,46 @@
         prompt-path (fs/path dir "prompt.md")
         stdout-path (fs/path dir "events.jsonl")
         stderr-path (fs/path dir "stderr.log")
-        last-message-path (fs/path dir "last-message.md")
-        stop? (atom false)
-        hb (heartbeat! ticket-id lock stop?)]
+        last-message-path (fs/path dir "last-message.md")]
     (fs/create-dirs dir)
     (spit (str prompt-path) (prompt-for action ticket-id lane workspace))
     (mark-run! ticket-id run :running {:action action :lane lane :started-at (now-str)})
-    (try
-      (let [args (cond-> ["codex" "exec" "--json" "--cd" (:workspace-dir workspace)
-                          "--skip-git-repo-check"
-                          "--output-last-message" (str last-message-path)]
-                   (= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                   (conj "--dangerously-bypass-approvals-and-sandbox")
+    (let [args (cond-> ["codex" "exec" "--json" "--cd" (:workspace-dir workspace)
+                        "--skip-git-repo-check"
+                        "--output-last-message" (str last-message-path)]
+                 (= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                 (conj "--dangerously-bypass-approvals-and-sandbox")
 
-                   (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                   (into ["--sandbox" (env "CODEX_TASK_BOARD_SANDBOX" "workspace-write")
-                          "--add-dir" (vault)])
+                 (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                 (into ["--sandbox" (env "CODEX_TASK_BOARD_SANDBOX" "workspace-write")
+                        "--add-dir" (vault)])
 
-                   (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                   (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
+                 (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                 (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
 
-                   (seq (System/getenv "CODEX_TASK_BOARD_MODEL"))
-                   (conj "--model" (System/getenv "CODEX_TASK_BOARD_MODEL"))
+                 (seq (System/getenv "CODEX_TASK_BOARD_MODEL"))
+                 (conj "--model" (System/getenv "CODEX_TASK_BOARD_MODEL"))
 
-                   (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
-                   (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))
+                 (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
+                 (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))
 
-                   true
-                   (conj "-"))
-            proc @(p/process args {:in (io/file (str prompt-path))
-                                   :out (io/file (str stdout-path))
-                                   :err (io/file (str stderr-path))})
-            exit (:exit proc)
-            last-message (when (fs/exists? last-message-path)
-                           (slurp (str last-message-path)))
-            marker (result-marker last-message)]
-        (let [status (if (zero? exit) :succeeded :failed)]
-          (mark-run! ticket-id run status
-                     {:action action
-                      :lane lane
-                      :exit-code exit
-                      :result marker
-                      :finished-at (now-str)}))
-        {:exit exit :result marker :run-id run :dir (str dir) :last-message last-message})
-      (finally
-        (reset! stop? true)
-        @hb))))
+                 true
+                 (conj "-"))
+          proc @(p/process args {:in (io/file (str prompt-path))
+                                 :out (io/file (str stdout-path))
+                                 :err (io/file (str stderr-path))})
+          exit (:exit proc)
+          last-message (when (fs/exists? last-message-path)
+                         (slurp (str last-message-path)))
+          marker (result-marker last-message)]
+      (let [status (if (zero? exit) :succeeded :failed)]
+        (mark-run! ticket-id run status
+                   {:action action
+                    :lane lane
+                    :exit-code exit
+                    :result marker
+                    :finished-at (now-str)}))
+      {:exit exit :result marker :run-id run :dir (str dir) :last-message last-message})))
 
 (defn candidate-action [{:keys [lane status]} assignee]
   (when (= "codex" assignee)
@@ -838,42 +832,46 @@
       (let [effective-lane (if (#{"ready" "review" "blocked"} status) "In Progress" lane)
             lock (acquire-lock! ticket-id action effective-lane)]
         (when lock
-          (try
-            (when (#{"ready" "review" "blocked"} status)
-              (move-card! ticket-id "in-progress")
-              (update-frontmatter! ticket-id {:status "in-progress"}))
-            (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " started from " lane " with action " (name action) "."))
-            (let [{:keys [exit result run-id dir last-message]} (run-codex! ticket-id action effective-lane lock)
-                  intended (cond
-                             (not (zero? exit)) "blocked"
-                             (= :groom action) "ready"
-                             (#{"done" "review" "blocked"} result) result
-                             :else "review")
-                  review-gate (if (= "review" intended)
-                                (review-gate! dir last-message)
-                                {:ok? true})
-                  next-status (final-status action result exit review-gate)]
-              (when (= "review" intended)
-                (mark-run! ticket-id run-id (if (:ok? review-gate) :succeeded :blocked)
-                           {:action action
-                            :lane effective-lane
-                            :exit-code exit
-                            :result result
-                            :review-gate review-gate
-                            :finished-at (now-str)}))
-              (move-card! ticket-id next-status)
-              (update-frontmatter! ticket-id (cond-> {:status next-status
-                                                       :assignee "boxp"}
-                                                (= "done" next-status) (assoc :closed (today))))
-              (append-note! ticket-id (final-note run-id next-status result last-message review-gate))
-              true)
-            (catch Exception e
-              (move-card! ticket-id "blocked")
-              (update-frontmatter! ticket-id {:status "blocked" :assignee "boxp"})
-              (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " failed: " (.getMessage e)))
-              true)
-            (finally
-              (release-lock! ticket-id))))))))
+          (let [stop? (atom false)
+                hb (heartbeat! ticket-id lock stop?)]
+            (try
+              (when (#{"ready" "review" "blocked"} status)
+                (move-card! ticket-id "in-progress")
+                (update-frontmatter! ticket-id {:status "in-progress"}))
+              (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " started from " lane " with action " (name action) "."))
+              (let [{:keys [exit result run-id dir last-message]} (run-codex! ticket-id action effective-lane lock)
+                    intended (cond
+                               (not (zero? exit)) "blocked"
+                               (= :groom action) "ready"
+                               (#{"done" "review" "blocked"} result) result
+                               :else "review")
+                    review-gate (if (= "review" intended)
+                                  (review-gate! dir last-message)
+                                  {:ok? true})
+                    next-status (final-status action result exit review-gate)]
+                (when (= "review" intended)
+                  (mark-run! ticket-id run-id (if (:ok? review-gate) :succeeded :blocked)
+                             {:action action
+                              :lane effective-lane
+                              :exit-code exit
+                              :result result
+                              :review-gate review-gate
+                              :finished-at (now-str)}))
+                (move-card! ticket-id next-status)
+                (update-frontmatter! ticket-id (cond-> {:status next-status
+                                                         :assignee "boxp"}
+                                                  (= "done" next-status) (assoc :closed (today))))
+                (append-note! ticket-id (final-note run-id next-status result last-message review-gate))
+                true)
+              (catch Exception e
+                (move-card! ticket-id "blocked")
+                (update-frontmatter! ticket-id {:status "blocked" :assignee "boxp"})
+                (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " failed: " (.getMessage e)))
+                true)
+              (finally
+                (reset! stop? true)
+                @hb
+                (release-lock! ticket-id)))))))))
 
 (defn ticket-assignee [ticket-id]
   (let [path (ticket-path ticket-id)]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -2,6 +2,7 @@
 
 (require '[babashka.fs :as fs]
          '[babashka.process :as p]
+         '[cheshire.core :as json]
          '[clojure.edn :as edn]
          '[clojure.java.io :as io]
          '[clojure.string :as str])
@@ -513,6 +514,209 @@
   (or (github-pr-url? text)
       (no-repo-review-marker? text)))
 
+(defn env-long [k default]
+  (Long/parseLong (env k default)))
+
+(defn pr-gate-timeout-seconds []
+  (env-long "CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS" "1800"))
+
+(defn pr-gate-poll-seconds []
+  (env-long "CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS" "15"))
+
+(defn run-string! [args opts]
+  (let [proc @(p/process args (merge {:out :string :err :string} opts))]
+    (if (zero? (:exit proc))
+      (:out proc)
+      (throw (ex-info (str "command failed: " (str/join " " args) "\n" (:err proc))
+                      {:args args :exit (:exit proc) :err (:err proc)})))))
+
+(defn pr-view [pr-url]
+  (-> (run-string! ["gh" "pr" "view" pr-url "--json" "url,isDraft,mergeStateStatus,statusCheckRollup"] {})
+      (json/parse-string true)))
+
+(defn check-name [check]
+  (or (:name check)
+      (:context check)
+      (:workflowName check)
+      (:displayName check)
+      "unknown check"))
+
+(def successful-check-conclusions
+  #{"SUCCESS" "SKIPPED" "NEUTRAL"})
+
+(defn check-completed? [check]
+  (or (= "COMPLETED" (some-> (:status check) str/upper-case))
+      (contains? #{"SUCCESS" "FAILURE" "ERROR"}
+                 (some-> (:state check) str/upper-case))))
+
+(defn check-successful? [check]
+  (and (check-completed? check)
+       (or (contains? successful-check-conclusions
+                     (some-> (:conclusion check) str/upper-case))
+           (= "SUCCESS" (some-> (:state check) str/upper-case)))))
+
+(defn check-failed? [check]
+  (and (check-completed? check)
+       (not (check-successful? check))))
+
+(defn ci-state [checks]
+  (let [checks (vec checks)
+        failed (filter check-failed? checks)
+        pending (remove check-completed? checks)]
+    (cond
+      (empty? checks)
+      {:state :pending
+       :message "No CI checks have been reported for this PR yet."}
+
+      (seq failed)
+      {:state :failed
+       :message (str "CI checks failed: "
+                     (str/join ", " (map (fn [check]
+                                            (str (check-name check) "=" (:conclusion check)))
+                                          failed)))}
+
+      (seq pending)
+      {:state :pending
+       :message (str "CI checks still pending: "
+                     (str/join ", " (map check-name pending)))}
+
+      :else
+      {:state :passed
+       :message (str "CI checks passed: " (str/join ", " (map check-name checks)))})))
+
+(defn merge-state [pr]
+  (let [state (some-> (:mergeStateStatus pr) str/upper-case)]
+    (cond
+      (:isDraft pr)
+      {:state :failed
+       :gate :mergeability
+       :message "GitHub reports this PR is still a draft."}
+
+      (= "DIRTY" state)
+      {:state :failed
+       :gate :conflict
+       :message "GitHub reports mergeStateStatus=DIRTY, which indicates conflicts with the base branch."}
+
+      (#{"UNKNOWN" "BEHIND"} state)
+      {:state :pending
+       :gate :mergeability
+       :message (str "GitHub mergeStateStatus=" state " is not ready yet.")}
+
+      (#{"CLEAN" "HAS_HOOKS" "BLOCKED" "UNSTABLE"} state)
+      {:state :passed
+       :message (str "GitHub mergeStateStatus=" state ".")}
+
+      :else
+      {:state :failed
+       :gate :mergeability
+       :message (str "GitHub mergeStateStatus=" (or state "missing") " is not review-ready.")})))
+
+(defn wait-for-pr-state! [pr-url]
+  (let [deadline (+ (System/currentTimeMillis) (* 1000 (pr-gate-timeout-seconds)))]
+    (loop []
+      (let [pr (pr-view pr-url)
+            merge (merge-state pr)
+            ci (ci-state (:statusCheckRollup pr))]
+        (cond
+          (= :failed (:state merge))
+          {:ok? false
+           :gate (:gate merge)
+           :url pr-url
+           :message (:message merge)}
+
+          (= :failed (:state ci))
+          {:ok? false
+           :gate :ci
+           :url pr-url
+           :message (:message ci)}
+
+          (and (= :passed (:state merge))
+               (= :passed (:state ci)))
+          {:ok? true
+           :url pr-url
+           :message (str (:message merge) " " (:message ci))}
+
+          (> (System/currentTimeMillis) deadline)
+          {:ok? false
+           :gate (if (= :pending (:state merge)) (:gate merge) :ci)
+           :url pr-url
+           :message (str "Timed out waiting for PR gates. " (:message merge) " " (:message ci))}
+
+          :else
+          (do
+            (Thread/sleep (* 1000 (pr-gate-poll-seconds)))
+            (recur)))))))
+
+(defn codex-review-clean? [text]
+  (boolean (re-find #"(?im)^CODEX_REVIEW_RESULT:\s*clean\s*$" (or text ""))))
+
+(defn codex-review-summary [text]
+  (->> (str/split-lines (or text ""))
+       (remove #(re-find #"(?im)^CODEX_REVIEW_RESULT:" %))
+       (remove str/blank?)
+       (take 6)
+       (str/join " ")))
+
+(defn run-codex-review! [run-dir pr-url]
+  (let [diff (run-string! ["gh" "pr" "diff" pr-url] {})
+        review-path (fs/path run-dir "codex-review.md")
+        prompt (str "CODEX_REVIEW_GATE\n"
+                    "Review this GitHub PR diff for actionable bugs, regressions, missing tests, or acceptance-criteria gaps.\n"
+                    "Return CODEX_REVIEW_RESULT: clean only if there are no actionable findings.\n"
+                    "Return CODEX_REVIEW_RESULT: issues when any actionable finding remains, followed by a concise summary.\n\n"
+                    "PR: " pr-url "\n\n"
+                    diff)
+        proc @(p/process ["codex" "exec"
+                          "--skip-git-repo-check"
+                          "--output-last-message" (str review-path)
+                          "-"]
+                         {:in prompt :out :string :err :string})
+        last-message (when (fs/exists? review-path)
+                       (slurp (str review-path)))]
+    (cond
+      (not (zero? (:exit proc)))
+      {:ok? false
+       :gate :codex-review
+       :url pr-url
+       :message (str "codex review command failed: " (:err proc))}
+
+      (codex-review-clean? last-message)
+      {:ok? true
+       :url pr-url
+       :message "codex review reported no actionable findings."}
+
+      :else
+      {:ok? false
+       :gate :codex-review
+       :url pr-url
+       :message (str "codex review reported actionable findings"
+                     (when-let [summary (not-empty (codex-review-summary last-message))]
+                       (str ": " summary)))})))
+
+(defn review-gate! [run-dir last-message]
+  (try
+    (cond
+      (first-github-pr-url last-message)
+      (let [pr-url (first-github-pr-url last-message)
+            pr-state (wait-for-pr-state! pr-url)]
+        (if-not (:ok? pr-state)
+          pr-state
+          (let [review (run-codex-review! run-dir pr-url)]
+            (update review :message #(str (:message pr-state) " " %)))))
+
+      (no-repo-review-marker? last-message)
+      {:ok? true
+       :message "TASK_BOARD_REVIEW_PR: none was provided; PR gates were skipped because no repository changes were reported."}
+
+      :else
+      {:ok? false
+       :gate :pr-url
+       :message "Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker."})
+    (catch Exception e
+      {:ok? false
+       :gate :pr-gate
+       :message (.getMessage e)})))
+
 (defn run-codex! [ticket-id action lane lock]
   (let [run (:run-id lock)
         dir (run-dir ticket-id run)
@@ -577,27 +781,30 @@
       "blocked" :blocked-retry
       nil)))
 
-(defn final-status [action result exit last-message]
+(defn final-status [action result exit review-gate]
   (let [intended (cond
                    (not (zero? exit)) "blocked"
                    (= :groom action) "ready"
                    (#{"done" "review" "blocked"} result) result
                    :else "review")]
-    (if (and (= "review" intended) (not (review-ready? last-message)))
+    (if (and (= "review" intended) (not (:ok? review-gate)))
       "blocked"
       intended)))
 
-(defn final-note [run-id next-status result last-message]
+(defn final-note [run-id next-status result last-message review-gate]
   (let [base (str "Codex task-board run " run-id " finished with result " next-status ".")
         pr-url (first-github-pr-url last-message)]
     (cond
       (and (= "blocked" next-status)
            (not (#{"done" "blocked"} result))
-           (not (review-ready? last-message)))
-      (str base " Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker, so the runner blocked before moving to review.")
+           (not (:ok? review-gate)))
+      (str base " Review gate failed"
+           (when-let [gate (:gate review-gate)]
+             (str " (" (name gate) ")"))
+           ": " (:message review-gate))
 
       (and (= "review" next-status) pr-url)
-      (str base " PR: " pr-url)
+      (str base " PR: " pr-url ". Review gates passed: " (:message review-gate))
 
       :else
       base)))
@@ -615,13 +822,29 @@
               (move-card! ticket-id "in-progress")
               (update-frontmatter! ticket-id {:status "in-progress"}))
             (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " started from " lane " with action " (name action) "."))
-            (let [{:keys [exit result run-id last-message]} (run-codex! ticket-id action effective-lane lock)
-                  next-status (final-status action result exit last-message)]
+            (let [{:keys [exit result run-id dir last-message]} (run-codex! ticket-id action effective-lane lock)
+                  intended (cond
+                             (not (zero? exit)) "blocked"
+                             (= :groom action) "ready"
+                             (#{"done" "review" "blocked"} result) result
+                             :else "review")
+                  review-gate (if (= "review" intended)
+                                (review-gate! dir last-message)
+                                {:ok? true})
+                  next-status (final-status action result exit review-gate)]
+              (when (= "review" intended)
+                (mark-run! ticket-id run-id (if (:ok? review-gate) :succeeded :blocked)
+                           {:action action
+                            :lane effective-lane
+                            :exit-code exit
+                            :result result
+                            :review-gate review-gate
+                            :finished-at (now-str)}))
               (move-card! ticket-id next-status)
               (update-frontmatter! ticket-id (cond-> {:status next-status
                                                        :assignee "boxp"}
                                                 (= "done" next-status) (assoc :closed (today))))
-              (append-note! ticket-id (final-note run-id next-status result last-message))
+              (append-note! ticket-id (final-note run-id next-status result last-message review-gate))
               true)
             (catch Exception e
               (move-card! ticket-id "blocked")

--- a/docs/project_docs/BOXP-42-pr-review-gates/plan.md
+++ b/docs/project_docs/BOXP-42-pr-review-gates/plan.md
@@ -1,0 +1,19 @@
+# BOXP-42: Task Board runner PR review gates
+
+## Goal
+
+Ensure repository-changing Task Board runs only move to `Review` after the created PR is ready for human review.
+
+## Plan
+
+1. Preserve the existing `TASK_BOARD_REVIEW_PR: none` path for review transitions with no repository changes.
+2. For review transitions with a GitHub PR URL, query GitHub mergeability before moving the ticket.
+3. Wait for associated PR checks to finish and require successful, skipped, or neutral conclusions.
+4. Run a Codex review pass against the PR diff and require an explicit clean result.
+5. Block the ticket, update Notes, and record the failed gate in the run summary when any gate fails.
+6. Extend the runner black-box tests with conflict, CI failure, Codex review issue, all gates passing, and no-repo review cases.
+
+## Validation
+
+- `tests/codex-workspace/task-board-runner-test.sh`
+- `git diff --check`

--- a/docs/project_docs/BOXP-42-pr-review-gates/plan.md
+++ b/docs/project_docs/BOXP-42-pr-review-gates/plan.md
@@ -8,10 +8,11 @@ Ensure repository-changing Task Board runs only move to `Review` after the creat
 
 1. Preserve the existing `TASK_BOARD_REVIEW_PR: none` path for review transitions with no repository changes.
 2. For review transitions with a GitHub PR URL, query GitHub mergeability before moving the ticket.
-3. Wait for associated PR checks to finish and require successful, skipped, or neutral conclusions.
-4. Run a Codex review pass against the PR diff and require an explicit clean result.
-5. Block the ticket, update Notes, and record the failed gate in the run summary when any gate fails.
-6. Extend the runner black-box tests with conflict, CI failure, Codex review issue, all gates passing, and no-repo review cases.
+3. When a run reports multiple GitHub PR URLs, gate every distinct PR URL before moving the ticket.
+4. Wait for associated PR checks to finish and require successful, skipped, or neutral conclusions.
+5. Run a Codex review pass against each PR diff and require an explicit clean result.
+6. Block the ticket, update Notes, and record the failed gate and PR URL in the run summary when any gate fails.
+7. Extend the runner black-box tests with conflict, CI failure, Codex review issue, all gates passing, multiple PRs, and no-repo review cases.
 
 ## Validation
 

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -78,6 +78,14 @@ make_fake_gh() {
 set -euo pipefail
 
 if [[ "$1 $2" == "pr view" && "$3" =~ ^https://github.com/boxp/example/pull/[0-9]+$ ]]; then
+  if [[ -n "${GH_FAKE_LOCK_MTIME_LOG:-}" && -n "${GH_FAKE_LOCK_FILE:-}" ]]; then
+    before="$(stat -c %Y "${GH_FAKE_LOCK_FILE}")"
+    sleep "${GH_FAKE_PR_VIEW_SLEEP_SECONDS:-0}"
+    after="$(stat -c %Y "${GH_FAKE_LOCK_FILE}")"
+    printf '%s %s\n' "${before}" "${after}" >>"${GH_FAKE_LOCK_MTIME_LOG}"
+  elif [[ -n "${GH_FAKE_PR_VIEW_SLEEP_SECONDS:-}" ]]; then
+    sleep "${GH_FAKE_PR_VIEW_SLEEP_SECONDS}"
+  fi
   pr_number="${3##*/}"
   checks_var="GH_FAKE_CHECKS_${pr_number}"
   if [[ -n "${GH_FAKE_CHECKS:-}" ]]; then
@@ -422,6 +430,31 @@ test_review_with_multiple_pr_urls_blocks_on_second_failure() {
   assert_file_contains "${vault}/Tickets/BOXP-411.md" 'integration=FAILURE'
 }
 
+test_review_gate_keeps_lock_heartbeat_active() {
+  local tmp vault state bin log before after
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  log="${tmp}/lock-mtime.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-412|BOXP-412: gate heartbeat]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-412 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" \
+    GH_FAKE_LOCK_FILE="${state}/locks/BOXP-412.edn" \
+    GH_FAKE_LOCK_MTIME_LOG="${log}" \
+    GH_FAKE_PR_VIEW_SLEEP_SECONDS=2 \
+    CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-review-gate-heartbeat.out
+
+  read -r before after <"${log}"
+  [[ "${after}" -gt "${before}" ]] || fail "expected lock heartbeat to update during PR gate, got ${before} -> ${after}"
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-412\|BOXP-412: gate heartbeat\]\].*status::review'
+}
+
 test_review_with_empty_ci_rollup_times_out() {
   local tmp vault state bin
   tmp="$(mktemp -d)"
@@ -493,6 +526,7 @@ test_review_with_codex_review_issue_is_blocked
 test_review_with_pr_and_none_marker_checks_pr
 test_review_with_multiple_pr_urls_checks_all
 test_review_with_multiple_pr_urls_blocks_on_second_failure
+test_review_gate_keeps_lock_heartbeat_active
 test_review_with_empty_ci_rollup_times_out
 test_review_with_draft_pr_is_blocked
 test_review_with_behind_merge_state_times_out

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -23,6 +23,16 @@ assert_file_not_contains() {
   fi
 }
 
+assert_run_summary_contains() {
+  local state="$1"
+  local ticket="$2"
+  local pattern="$3"
+  local summary
+  summary="$(find "${state}/runs/${ticket}" -name summary.edn -print | head -n 1)"
+  [[ -n "${summary}" ]] || fail "expected summary for ${ticket}"
+  assert_file_contains "${summary}" "${pattern}"
+}
+
 make_fake_codex() {
   local bin_dir="$1"
   cat >"${bin_dir}/codex" <<'EOF'
@@ -46,6 +56,11 @@ prompt="$(mktemp)"
 cat >"${prompt}"
 ticket="$(sed -n 's/^Ticket: //p' "${prompt}" | head -n 1)"
 mkdir -p "$(dirname "${last_message}")"
+if grep -q '^CODEX_REVIEW_GATE$' "${prompt}"; then
+  printf '%s\n' "${CODEX_FAKE_REVIEW_MESSAGE:-CODEX_REVIEW_RESULT: clean}" >"${last_message}"
+  rm -f "${prompt}"
+  exit 0
+fi
 if [[ -n "${CODEX_FAKE_START_LOG:-}" ]]; then
   printf '%s %s\n' "${ticket}" "$(date +%s)" >>"${CODEX_FAKE_START_LOG}"
 fi
@@ -54,6 +69,40 @@ printf '%s\n' "${CODEX_FAKE_MESSAGE:-TASK_BOARD_RESULT: done}" >"${last_message}
 rm -f "${prompt}"
 EOF
   chmod +x "${bin_dir}/codex"
+}
+
+make_fake_gh() {
+  local bin_dir="$1"
+  cat >"${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1 $2 $3" == "pr view https://github.com/boxp/example/pull/123" ]]; then
+  if [[ -n "${GH_FAKE_CHECKS:-}" ]]; then
+    checks="${GH_FAKE_CHECKS}"
+  else
+    checks='[{"name":"runner test","status":"COMPLETED","conclusion":"SUCCESS"}]'
+  fi
+  cat <<JSON
+{
+  "url": "https://github.com/boxp/example/pull/123",
+  "isDraft": ${GH_FAKE_IS_DRAFT:-false},
+  "mergeStateStatus": "${GH_FAKE_MERGE_STATE:-CLEAN}",
+  "statusCheckRollup": ${checks}
+}
+JSON
+  exit 0
+fi
+
+if [[ "$1 $2 $3" == "pr diff https://github.com/boxp/example/pull/123" ]]; then
+  printf '%s\n' "${GH_FAKE_DIFF:-diff --git a/file b/file}"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+  chmod +x "${bin_dir}/gh"
 }
 
 write_board() {
@@ -204,20 +253,185 @@ test_review_with_pr_url_is_noted() {
   bin="${tmp}/bin"
   mkdir -p "${bin}"
   make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
   write_board "${vault}" "- [ ] [[Tickets/BOXP-401|BOXP-401: review pr]] #ticket status::in-progress"
   write_ticket "${vault}" BOXP-401 in-progress codex boxp/example
 
-  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-pr.out
+  PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS=1 CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS=1 CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-pr.out
 
   assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-401\|BOXP-401: review pr\]\].*status::review'
   assert_file_contains "${vault}/Tickets/BOXP-401.md" '^status: review$'
   assert_file_contains "${vault}/Tickets/BOXP-401.md" '^assignee: boxp$'
   assert_file_contains "${vault}/Tickets/BOXP-401.md" 'PR: https://github.com/boxp/example/pull/123'
+  assert_file_contains "${vault}/Tickets/BOXP-401.md" 'Review gates passed'
+}
+
+test_review_without_repo_marker_skips_pr_gates() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-402|BOXP-402: no repo review]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-402 in-progress codex
+
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'TASK_BOARD_REVIEW_PR: none\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-none.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-402\|BOXP-402: no repo review\]\].*status::review'
+  assert_file_contains "${vault}/Tickets/BOXP-402.md" '^status: review$'
+}
+
+test_review_with_conflict_is_blocked() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-403|BOXP-403: conflict]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-403 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_MERGE_STATE=DIRTY CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-conflict.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-403\|BOXP-403: conflict\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-403.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-403.md" 'Review gate failed \(conflict\)'
+  assert_run_summary_contains "${state}" BOXP-403 ':gate :conflict'
+}
+
+test_review_with_ci_failure_is_blocked() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-404|BOXP-404: ci fail]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-404 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_CHECKS='[{"name":"unit","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-ci.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-404\|BOXP-404: ci fail\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-404.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-404.md" 'Review gate failed \(ci\)'
+  assert_file_contains "${vault}/Tickets/BOXP-404.md" 'unit=FAILURE'
+}
+
+test_review_with_codex_review_issue_is_blocked() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-405|BOXP-405: review issue]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-405 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_FAKE_REVIEW_MESSAGE=$'CODEX_REVIEW_RESULT: issues\n- missing regression test' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-issue.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-405\|BOXP-405: review issue\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-405.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-405.md" 'Review gate failed \(codex-review\)'
+  assert_file_contains "${vault}/Tickets/BOXP-405.md" 'missing regression test'
+}
+
+test_review_with_pr_and_none_marker_checks_pr() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-406|BOXP-406: pr wins]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-406 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'TASK_BOARD_REVIEW_PR: none\nCreated PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-pr-wins.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-406\|BOXP-406: pr wins\]\].*status::review'
+  assert_file_contains "${vault}/Tickets/BOXP-406.md" 'Review gates passed'
+}
+
+test_review_with_empty_ci_rollup_times_out() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-407|BOXP-407: no checks yet]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-407 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS=1 CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS=1 GH_FAKE_CHECKS='[]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-empty-ci.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-407\|BOXP-407: no checks yet\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-407.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-407.md" 'Review gate failed \(ci\)'
+  assert_file_contains "${vault}/Tickets/BOXP-407.md" 'No CI checks have been reported'
+}
+
+test_review_with_draft_pr_is_blocked() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-408|BOXP-408: draft pr]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-408 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_IS_DRAFT=true CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-draft.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-408\|BOXP-408: draft pr\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-408.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-408.md" 'Review gate failed \(mergeability\)'
+  assert_file_contains "${vault}/Tickets/BOXP-408.md" 'still a draft'
+}
+
+test_review_with_behind_merge_state_times_out() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-409|BOXP-409: behind]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-409 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS=1 CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS=1 GH_FAKE_MERGE_STATE=BEHIND CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-behind.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-409\|BOXP-409: behind\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-409.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-409.md" 'Review gate failed \(mergeability\)'
+  assert_file_contains "${vault}/Tickets/BOXP-409.md" 'mergeStateStatus=BEHIND'
 }
 
 test_parallel_codex_runs
 test_stale_lock_recovers
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
+test_review_without_repo_marker_skips_pr_gates
+test_review_with_conflict_is_blocked
+test_review_with_ci_failure_is_blocked
+test_review_with_codex_review_issue_is_blocked
+test_review_with_pr_and_none_marker_checks_pr
+test_review_with_empty_ci_rollup_times_out
+test_review_with_draft_pr_is_blocked
+test_review_with_behind_merge_state_times_out
 
 echo "task-board-runner tests passed"

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -40,6 +40,9 @@ make_fake_codex() {
 set -euo pipefail
 
 last_message=""
+if [[ -n "${CODEX_FAKE_ARG_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"${CODEX_FAKE_ARG_LOG}"
+fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output-last-message)
@@ -455,6 +458,30 @@ test_review_gate_keeps_lock_heartbeat_active() {
   assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-412\|BOXP-412: gate heartbeat\]\].*status::review'
 }
 
+test_review_gate_passes_codex_model_profile_to_review() {
+  local tmp vault state bin log
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  log="${tmp}/codex-args.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-413|BOXP-413: review codex config]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-413 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_MODEL=gpt-test \
+    CODEX_TASK_BOARD_PROFILE=review-profile \
+    CODEX_FAKE_ARG_LOG="${log}" \
+    CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-review-codex-config.out
+
+  assert_file_contains "${log}" 'codex-review-123\.md.*--model gpt-test.*--profile review-profile'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-413\|BOXP-413: review codex config\]\].*status::review'
+}
+
 test_review_with_empty_ci_rollup_times_out() {
   local tmp vault state bin
   tmp="$(mktemp -d)"
@@ -527,6 +554,7 @@ test_review_with_pr_and_none_marker_checks_pr
 test_review_with_multiple_pr_urls_checks_all
 test_review_with_multiple_pr_urls_blocks_on_second_failure
 test_review_gate_keeps_lock_heartbeat_active
+test_review_gate_passes_codex_model_profile_to_review
 test_review_with_empty_ci_rollup_times_out
 test_review_with_draft_pr_is_blocked
 test_review_with_behind_merge_state_times_out

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -77,25 +77,45 @@ make_fake_gh() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$1 $2 $3" == "pr view https://github.com/boxp/example/pull/123" ]]; then
+if [[ "$1 $2" == "pr view" && "$3" =~ ^https://github.com/boxp/example/pull/[0-9]+$ ]]; then
+  pr_number="${3##*/}"
+  checks_var="GH_FAKE_CHECKS_${pr_number}"
   if [[ -n "${GH_FAKE_CHECKS:-}" ]]; then
     checks="${GH_FAKE_CHECKS}"
+  elif [[ -n "${!checks_var:-}" ]]; then
+    checks="${!checks_var}"
   else
     checks='[{"name":"runner test","status":"COMPLETED","conclusion":"SUCCESS"}]'
   fi
+  draft_var="GH_FAKE_IS_DRAFT_${pr_number}"
+  merge_var="GH_FAKE_MERGE_STATE_${pr_number}"
+  draft="${GH_FAKE_IS_DRAFT:-false}"
+  merge_state="${GH_FAKE_MERGE_STATE:-CLEAN}"
+  if [[ -n "${!draft_var:-}" ]]; then
+    draft="${!draft_var}"
+  fi
+  if [[ -n "${!merge_var:-}" ]]; then
+    merge_state="${!merge_var}"
+  fi
   cat <<JSON
 {
-  "url": "https://github.com/boxp/example/pull/123",
-  "isDraft": ${GH_FAKE_IS_DRAFT:-false},
-  "mergeStateStatus": "${GH_FAKE_MERGE_STATE:-CLEAN}",
+  "url": "${3}",
+  "isDraft": ${draft},
+  "mergeStateStatus": "${merge_state}",
   "statusCheckRollup": ${checks}
 }
 JSON
   exit 0
 fi
 
-if [[ "$1 $2 $3" == "pr diff https://github.com/boxp/example/pull/123" ]]; then
-  printf '%s\n' "${GH_FAKE_DIFF:-diff --git a/file b/file}"
+if [[ "$1 $2" == "pr diff" && "$3" =~ ^https://github.com/boxp/example/pull/[0-9]+$ ]]; then
+  pr_number="${3##*/}"
+  diff_var="GH_FAKE_DIFF_${pr_number}"
+  diff="${GH_FAKE_DIFF:-diff --git a/file b/file}"
+  if [[ -n "${!diff_var:-}" ]]; then
+    diff="${!diff_var}"
+  fi
+  printf '%s\n' "${diff}"
   exit 0
 fi
 
@@ -361,6 +381,47 @@ test_review_with_pr_and_none_marker_checks_pr() {
   assert_file_contains "${vault}/Tickets/BOXP-406.md" 'Review gates passed'
 }
 
+test_review_with_multiple_pr_urls_checks_all() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-410|BOXP-410: multiple prs]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-410 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'Created PRs:\nhttps://github.com/boxp/example/pull/123\nhttps://github.com/boxp/example/pull/456\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-multiple-prs.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-410\|BOXP-410: multiple prs\]\].*status::review'
+  assert_file_contains "${vault}/Tickets/BOXP-410.md" '^status: review$'
+  assert_file_contains "${vault}/Tickets/BOXP-410.md" 'PR: https://github.com/boxp/example/pull/123, https://github.com/boxp/example/pull/456'
+  assert_file_contains "${vault}/Tickets/BOXP-410.md" 'All PR gates passed for 2 PR\(s\)'
+}
+
+test_review_with_multiple_pr_urls_blocks_on_second_failure() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-411|BOXP-411: second pr fails]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-411 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_CHECKS_456='[{"name":"integration","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PRs:\nhttps://github.com/boxp/example/pull/123\nhttps://github.com/boxp/example/pull/456\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-multiple-prs-fail.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-411\|BOXP-411: second pr fails\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-411.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-411.md" 'Review gate failed \(ci\)'
+  assert_file_contains "${vault}/Tickets/BOXP-411.md" 'https://github.com/boxp/example/pull/456'
+  assert_file_contains "${vault}/Tickets/BOXP-411.md" 'integration=FAILURE'
+}
+
 test_review_with_empty_ci_rollup_times_out() {
   local tmp vault state bin
   tmp="$(mktemp -d)"
@@ -430,6 +491,8 @@ test_review_with_conflict_is_blocked
 test_review_with_ci_failure_is_blocked
 test_review_with_codex_review_issue_is_blocked
 test_review_with_pr_and_none_marker_checks_pr
+test_review_with_multiple_pr_urls_checks_all
+test_review_with_multiple_pr_urls_blocks_on_second_failure
 test_review_with_empty_ci_rollup_times_out
 test_review_with_draft_pr_is_blocked
 test_review_with_behind_merge_state_times_out


### PR DESCRIPTION
## Summary
- add Review transition gates for PR mergeability, CI checks, and Codex review
- block tickets before Review with gate-specific Notes and run summary details when gates fail
- preserve TASK_BOARD_REVIEW_PR: none for no-repository-change reviews
- add BOXP-42 plan doc under docs/project_docs/BOXP-42-pr-review-gates/plan.md

## Validation
- tests/codex-workspace/task-board-runner-test.sh
- git diff --check
- codex review --uncommitted (no findings after fixes)
