### PR TITLE
BOXP-44: Add Claude runner to codex cron

### DIFF
--- a/docker/codex-workspace/cron/run-codex-cron.sh
+++ b/docker/codex-workspace/cron/run-codex-cron.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT
 
 runner="$(printf '%s' "${runner}" | tr '[:upper:]' '[:lower:]')"
 case "${runner}" in
-  codex | cursor) ;;
+  codex | cursor | claude) ;;
   *)
     echo "unsupported codex cron runner '${runner}' for job '${job_name}'" >&2
     exit 2
@@ -55,7 +55,7 @@ case "${runner}" in
 esac
 
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-if [[ "${runner}" == "cursor" ]]; then
+if [[ "${runner}" == "cursor" || "${runner}" == "claude" ]]; then
   stdout_log="${run_dir}/stdout.log"
 else
   stdout_log="${run_dir}/events.jsonl"
@@ -82,13 +82,28 @@ if [[ "${runner}" == "codex" ]]; then
   if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
     args+=(--profile "${CODEX_CRON_PROFILE}")
   fi
-else
+elif [[ "${runner}" == "cursor" ]]; then
   args=(--print --output-format text --trust --workspace "${workdir}")
 
   if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
     args+=(--force --sandbox disabled)
   else
     args+=(--sandbox "${CODEX_CRON_CURSOR_SANDBOX:-enabled}")
+  fi
+
+  if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
+    args+=(--model "${CODEX_CRON_MODEL}")
+  fi
+
+  if [[ -n "${CODEX_CRON_PROFILE:-}" ]]; then
+    echo "CODEX_CRON_PROFILE is only supported by the codex runner" >&2
+    exit 2
+  fi
+else
+  args=(--print --output-format text)
+
+  if [[ "${CODEX_CRON_BYPASS_APPROVALS:-true}" == "true" ]]; then
+    args+=(--dangerously-skip-permissions)
   fi
 
   if [[ -n "${CODEX_CRON_MODEL:-}" ]]; then
@@ -123,13 +138,15 @@ fi
 set +e
 if [[ "${runner}" == "codex" ]]; then
   codex "${args[@]}" - < "${prompt_file}" > "${stdout_log}" 2> "${stderr_log}"
-else
+elif [[ "${runner}" == "cursor" ]]; then
   cursor-agent "${args[@]}" "$(< "${prompt_file}")" > "${stdout_log}" 2> "${stderr_log}"
+else
+  (cd "${workdir}" && claude "${args[@]}" "$(< "${prompt_file}")") > "${stdout_log}" 2> "${stderr_log}"
 fi
 exit_code=$?
 set -e
 
-if [[ "${runner}" == "cursor" && -f "${stdout_log}" ]]; then
+if [[ ("${runner}" == "cursor" || "${runner}" == "claude") && -f "${stdout_log}" ]]; then
   cp "${stdout_log}" "${last_message}"
 fi
 

--- a/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
+++ b/docker/codex-workspace/skills/codex-workspace-cron/SKILL.md
@@ -49,12 +49,16 @@ bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb add \
   --prompt "調査して日本語で報告してください。"
 ```
 
-Use Cursor Agent or a specific model:
+Use Cursor Agent, Claude Code, or a specific model:
 
 ```bash
 bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-report \
   --runner cursor \
   --model claude-opus-4-8-high
+
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-report \
+  --runner claude \
+  --model claude-4.6-sonnet-medium
 ```
 
 Update metadata or prompt:

--- a/docs/project_docs/BOXP-44-claude-cron-runner/plan.md
+++ b/docs/project_docs/BOXP-44-claude-cron-runner/plan.md
@@ -1,0 +1,29 @@
+# BOXP-44 Claude cron runner
+
+`daily-hitohako-news-novel` を Cursor Agent ではなく Claude Code で実行できるように、Codex workspace cron の runner に `claude` を追加する。
+
+## Scope
+
+1. `docker/codex-workspace/cron/run-codex-cron.sh` に `claude` runner を追加する。
+2. `claude` runner は Claude Code CLI を `--print --output-format text` で実行し、job の `model` を `--model` に渡す。
+3. `bypass-approvals` が true の場合は Claude Code の permission bypass を使う。
+4. `cursor` と同様に text output を `stdout.log` に保存し、`last-message.md` にコピーする。
+5. bundled `codex-workspace-cron` skill docs に `claude` runner の例を追加する。
+
+## Validation
+
+1. `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
+2. fake `claude` executable と一時 cron root を使い、`runner: claude` の job が `claude_args` と `last-message.md` を出力することを確認する。
+3. live Obsidian vault の `daily-hitohako-news-novel` は、runner 実装がデプロイされるまで `runner: cursor` のまま維持する。先に `runner: claude` へ変更すると現行 `/opt/codex-workspace/cron/run-codex-cron.sh` が unsupported runner として失敗するため。
+
+## Follow-up
+
+この PR が merge され、codex-workspace image が再デプロイされた後に、以下で job 定義を切り替える。
+
+```bash
+bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-hitohako-news-novel \
+  --runner claude \
+  --model claude-4.6-sonnet-medium
+```
+
+その後、次回 run または手動 run の `metadata.env` で `runner=claude` と `claude_args=... --model claude-4.6-sonnet-medium` を確認する。


### PR DESCRIPTION
## Summary
- add a `claude` runner to `run-codex-cron.sh` for Claude Code non-interactive cron jobs
- pass cron `model` through to `claude --model` and record `claude_args` in metadata
- document the `claude` runner in the bundled codex-workspace-cron skill and add the BOXP-44 plan

## Validation
- `bash -n docker/codex-workspace/cron/run-codex-cron.sh`
- fake `claude` executable with a temporary cron root confirmed `runner=claude`, `claude_args=--print --output-format text --dangerously-skip-permissions --model claude-4.6-sonnet-medium`, workdir `cd`, and `last-message.md` copy
- `git diff --check`

## Notes
- The live `/opt/codex-workspace/cron/run-codex-cron.sh` in the current workspace only supports `codex|cursor` and is root-owned, so `daily-hitohako-news-novel` should remain `runner: cursor` until this image change is deployed.
- After deployment, switch the job with `bb ~/.codex/skills/codex-workspace-cron/scripts/codex_cron_jobs.bb update daily-hitohako-news-novel --runner claude --model claude-4.6-sonnet-medium` and verify the next `metadata.env` contains `runner=claude` and `claude_args=... --model claude-4.6-sonnet-medium`.
