### PR TITLE
[codex] Add task board PR gate retry harness

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -271,6 +271,18 @@
 (defn run-workspace-dir [ticket-id run-id]
   (fs/path (root) "workspaces" ticket-id run-id))
 
+(defn state-path []
+  (fs/path (root) "state.edn"))
+
+(defn runner-state []
+  (read-edn-file (state-path) {}))
+
+(defn write-runner-state! [state]
+  (write-edn-file! (state-path) state))
+
+(defn env-long [k default]
+  (Long/parseLong (env k default)))
+
 (defn seconds-since [instant-str]
   (try
     (let [then (java.time.Instant/parse instant-str)]
@@ -371,6 +383,61 @@
            (take-last 3)
            vec))))
 
+(defn pr-gate-retry-limit []
+  (env-long "CODEX_TASK_BOARD_PR_GATE_RETRY_LIMIT" "2"))
+
+(defn retry-fingerprint [review-gate]
+  (str (:url review-gate) "|" (some-> (:gate review-gate) name) "|" (:message review-gate)))
+
+(defn latest-pr-gate-retry [ticket-id]
+  (let [retries (get-in (runner-state) [:pr-gate-retries ticket-id])]
+    (when (seq retries)
+      (->> (vals retries)
+           (sort-by #(or (:updated-at %) ""))
+           last))))
+
+(defn pr-gate-retry-prompt [ticket-id]
+  (when-let [{:keys [pr-url gate message run-id run-dir count limit]} (latest-pr-gate-retry ticket-id)]
+    (str "Pending PR gate retry instruction:\n"
+         "- Target PR URL: " pr-url "\n"
+         "- Failed gate: " gate "\n"
+         "- Failure reason: " message "\n"
+         "- Retry count for this same PR/gate/reason: " count "/" limit "\n"
+         "- Previous run summary: " run-dir "/summary.edn\n"
+         "- Previous run logs: " run-dir "/events.jsonl and " run-dir "/stderr.log\n"
+         "- Expected completion state: update the same PR until draft/mergeability/CI/codex-review gates pass, then return TASK_BOARD_RESULT: review with the PR URL.\n\n")))
+
+(defn record-pr-gate-failure! [ticket-id run-id review-gate]
+  (let [limit (pr-gate-retry-limit)
+        fingerprint (retry-fingerprint review-gate)
+        path [:pr-gate-retries ticket-id fingerprint]
+        state (runner-state)
+        current (get-in state path)
+        count (inc (long (or (:count current) 0)))
+        record {:pr-url (:url review-gate)
+                :gate (some-> (:gate review-gate) name)
+                :message (:message review-gate)
+                :run-id run-id
+                :run-dir (str (run-dir ticket-id run-id))
+                :count count
+                :limit limit
+                :updated-at (now-str)}
+        next-state (assoc-in state path record)]
+    (write-runner-state! next-state)
+    (assoc review-gate
+           :retry-count count
+           :retry-limit limit
+           :retry-exhausted? (> count limit))))
+
+(defn clear-pr-gate-retries! [ticket-id]
+  (let [state (runner-state)
+        retries (dissoc (:pr-gate-retries state) ticket-id)
+        next-state (if (seq retries)
+                     (assoc state :pr-gate-retries retries)
+                     (dissoc state :pr-gate-retries))]
+    (when (not= state next-state)
+      (write-runner-state! next-state))))
+
 (defn ticket-repos [ticket-id]
   (->> (str/split (or (:repo (ticket-frontmatter ticket-id)) "") #"[,\s]+")
        (map str/trim)
@@ -460,6 +527,7 @@
                     "Current lane: " lane "\n\n"
                     (workspace-prompt workspace) "\n"
                     "Previous run summaries:\n" (pr-str previous) "\n\n"
+                    (or (pr-gate-retry-prompt ticket-id) "")
                     "Ticket contents:\n\n" ticket-text "\n\n")
         review-contract (str "When repository changes are part of the work, create or update a GitHub PR before returning TASK_BOARD_RESULT: review.\n"
                              "If you return TASK_BOARD_RESULT: review, include either a GitHub PR URL or exactly one line TASK_BOARD_REVIEW_PR: none when no repository changes were made.\n")]
@@ -515,9 +583,6 @@
 (defn review-ready? [text]
   (or (github-pr-url? text)
       (no-repo-review-marker? text)))
-
-(defn env-long [k default]
-  (Long/parseLong (env k default)))
 
 (defn pr-gate-timeout-seconds []
   (env-long "CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS" "1800"))
@@ -632,12 +697,14 @@
           {:ok? false
            :gate (:gate merge)
            :url pr-url
+           :retryable? true
            :message (:message merge)}
 
           (= :failed (:state ci))
           {:ok? false
            :gate :ci
            :url pr-url
+           :retryable? true
            :message (:message ci)}
 
           (and (= :passed (:state merge))
@@ -650,6 +717,7 @@
           {:ok? false
            :gate (if (= :pending (:state merge)) (:gate merge) :ci)
            :url pr-url
+           :retryable? true
            :message (str "Timed out waiting for PR gates. " (:message merge) " " (:message ci))}
 
           :else
@@ -692,6 +760,7 @@
       {:ok? false
        :gate :codex-review
        :url pr-url
+       :retryable? false
        :message (str "codex review command failed: " (:err proc))}
 
       (codex-review-clean? last-message)
@@ -703,6 +772,7 @@
       {:ok? false
        :gate :codex-review
        :url pr-url
+       :retryable? true
        :message (str "codex review reported actionable findings"
                      (when-let [summary (not-empty (codex-review-summary last-message))]
                        (str ": " summary)))})))
@@ -742,10 +812,12 @@
         :else
         {:ok? false
          :gate :pr-url
+         :retryable? false
          :message "Review was requested without a GitHub PR URL or TASK_BOARD_REVIEW_PR: none marker."}))
     (catch Exception e
       {:ok? false
        :gate :pr-gate
+       :retryable? false
        :message (.getMessage e)})))
 
 (defn run-codex! [ticket-id action lane lock]
@@ -809,8 +881,17 @@
                    (= :groom action) "ready"
                    (#{"done" "review" "blocked"} result) result
                    :else "review")]
-    (if (and (= "review" intended) (not (:ok? review-gate)))
+    (cond
+      (and (= "review" intended)
+           (not (:ok? review-gate))
+           (:retryable? review-gate)
+           (not (:retry-exhausted? review-gate)))
+      "in-progress"
+
+      (and (= "review" intended) (not (:ok? review-gate)))
       "blocked"
+
+      :else
       intended)))
 
 (defn final-note [run-id next-status result last-message review-gate]
@@ -826,6 +907,18 @@
            (when-let [url (:url review-gate)]
              (str " for " url))
            ": " (:message review-gate))
+
+      (and (= "in-progress" next-status)
+           (not (:ok? review-gate))
+           (:retryable? review-gate))
+      (str base " Review gate failed"
+           (when-let [gate (:gate review-gate)]
+             (str " (" (name gate) ")"))
+           (when-let [url (:url review-gate)]
+             (str " for " url))
+           ": " (:message review-gate)
+           " Retrying with Codex instruction "
+           (:retry-count review-gate) "/" (:retry-limit review-gate) ".")
 
       (and (= "review" next-status) (seq pr-urls))
       (str base " PR: " (str/join ", " pr-urls) ". Review gates passed: " (:message review-gate))
@@ -855,20 +948,29 @@
                                (#{"done" "review" "blocked"} result) result
                                :else "review")
                     review-gate (if (= "review" intended)
-                                  (review-gate! dir last-message)
+                                  (let [gate-result (review-gate! dir last-message)]
+                                    (if (and (not (:ok? gate-result))
+                                             (:retryable? gate-result))
+                                      (record-pr-gate-failure! ticket-id run-id gate-result)
+                                      gate-result))
                                   {:ok? true})
                     next-status (final-status action result exit review-gate)]
                 (when (= "review" intended)
-                  (mark-run! ticket-id run-id (if (:ok? review-gate) :succeeded :blocked)
+                  (mark-run! ticket-id run-id (cond
+                                                (:ok? review-gate) :succeeded
+                                                (= "in-progress" next-status) :retrying
+                                                :else :blocked)
                              {:action action
                               :lane effective-lane
                               :exit-code exit
                               :result result
                               :review-gate review-gate
                               :finished-at (now-str)}))
+                (when (:ok? review-gate)
+                  (clear-pr-gate-retries! ticket-id))
                 (move-card! ticket-id next-status)
                 (update-frontmatter! ticket-id (cond-> {:status next-status
-                                                         :assignee "boxp"}
+                                                         :assignee (if (= "in-progress" next-status) "codex" "boxp")}
                                                   (= "done" next-status) (assoc :closed (today))))
                 (append-note! ticket-id (final-note run-id next-status result last-message review-gate))
                 true)

--- a/docs/project_docs/BOXP-54-pr-gate-retry-harness/plan.md
+++ b/docs/project_docs/BOXP-54-pr-gate-retry-harness/plan.md
@@ -1,0 +1,14 @@
+# BOXP-54 PR gate retry harness plan
+
+## Goal
+
+Task Board runner の PR review gate が agent で修正可能な失敗を即 `Blocked` にせず、同じチケットの Codex run へ修正指示として再投入できるようにする。
+
+## Plan
+
+- 現行 runner の PR gate と lane 遷移を確認する。
+- PR gate 失敗を retry 可能 / human blocker に分類する。
+- retry 状態を `/home/boxp/.codex-task-board/state.edn` に保存し、同一 PR/gate/reason の連続失敗上限を設ける。
+- retry prompt に PR URL、gate、失敗理由、前回 run の summary/log 参照、期待する完了状態を含める。
+- runner 実装、black-box test、仕様文書を更新する。
+- focused test を実行し、draft / codex-review finding / 上限到達 / gate 通過を検証する。

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -28,7 +28,7 @@ assert_run_summary_contains() {
   local ticket="$2"
   local pattern="$3"
   local summary
-  summary="$(find "${state}/runs/${ticket}" -name summary.edn -print | head -n 1)"
+  summary="$(find "${state}/runs/${ticket}" -name summary.edn -print | sort | tail -n 1)"
   [[ -n "${summary}" ]] || fail "expected summary for ${ticket}"
   assert_file_contains "${summary}" "${pattern}"
 }
@@ -58,6 +58,9 @@ done
 prompt="$(mktemp)"
 cat >"${prompt}"
 ticket="$(sed -n 's/^Ticket: //p' "${prompt}" | head -n 1)"
+if [[ -n "${CODEX_FAKE_PROMPT_LOG:-}" ]]; then
+  cat "${prompt}" >>"${CODEX_FAKE_PROMPT_LOG}"
+fi
 mkdir -p "$(dirname "${last_message}")"
 if grep -q '^CODEX_REVIEW_GATE$' "${prompt}"; then
   printf '%s\n' "${CODEX_FAKE_REVIEW_MESSAGE:-CODEX_REVIEW_RESULT: clean}" >"${last_message}"
@@ -328,10 +331,13 @@ test_review_with_conflict_is_blocked() {
 
   PATH="${bin}:$PATH" GH_FAKE_MERGE_STATE=DIRTY CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-conflict.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-403\|BOXP-403: conflict\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-403.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-403\|BOXP-403: conflict\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-403.md" '^status: in-progress$'
+  assert_file_contains "${vault}/Tickets/BOXP-403.md" '^assignee: codex$'
   assert_file_contains "${vault}/Tickets/BOXP-403.md" 'Review gate failed \(conflict\)'
+  assert_file_contains "${vault}/Tickets/BOXP-403.md" 'Retrying with Codex instruction 1/2'
   assert_run_summary_contains "${state}" BOXP-403 ':gate :conflict'
+  assert_run_summary_contains "${state}" BOXP-403 ':status :retrying'
 }
 
 test_review_with_ci_failure_is_blocked() {
@@ -348,8 +354,8 @@ test_review_with_ci_failure_is_blocked() {
 
   PATH="${bin}:$PATH" GH_FAKE_CHECKS='[{"name":"unit","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-ci.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-404\|BOXP-404: ci fail\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-404.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-404\|BOXP-404: ci fail\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-404.md" '^status: in-progress$'
   assert_file_contains "${vault}/Tickets/BOXP-404.md" 'Review gate failed \(ci\)'
   assert_file_contains "${vault}/Tickets/BOXP-404.md" 'unit=FAILURE'
 }
@@ -368,8 +374,8 @@ test_review_with_codex_review_issue_is_blocked() {
 
   PATH="${bin}:$PATH" CODEX_FAKE_REVIEW_MESSAGE=$'CODEX_REVIEW_RESULT: issues\n- missing regression test' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-issue.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-405\|BOXP-405: review issue\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-405.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-405\|BOXP-405: review issue\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-405.md" '^status: in-progress$'
   assert_file_contains "${vault}/Tickets/BOXP-405.md" 'Review gate failed \(codex-review\)'
   assert_file_contains "${vault}/Tickets/BOXP-405.md" 'missing regression test'
 }
@@ -426,8 +432,8 @@ test_review_with_multiple_pr_urls_blocks_on_second_failure() {
 
   PATH="${bin}:$PATH" GH_FAKE_CHECKS_456='[{"name":"integration","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PRs:\nhttps://github.com/boxp/example/pull/123\nhttps://github.com/boxp/example/pull/456\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-multiple-prs-fail.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-411\|BOXP-411: second pr fails\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-411.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-411\|BOXP-411: second pr fails\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-411.md" '^status: in-progress$'
   assert_file_contains "${vault}/Tickets/BOXP-411.md" 'Review gate failed \(ci\)'
   assert_file_contains "${vault}/Tickets/BOXP-411.md" 'https://github.com/boxp/example/pull/456'
   assert_file_contains "${vault}/Tickets/BOXP-411.md" 'integration=FAILURE'
@@ -496,18 +502,19 @@ test_review_with_empty_ci_rollup_times_out() {
 
   PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS=1 CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS=1 GH_FAKE_CHECKS='[]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-empty-ci.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-407\|BOXP-407: no checks yet\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-407.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-407\|BOXP-407: no checks yet\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-407.md" '^status: in-progress$'
   assert_file_contains "${vault}/Tickets/BOXP-407.md" 'Review gate failed \(ci\)'
   assert_file_contains "${vault}/Tickets/BOXP-407.md" 'No CI checks have been reported'
 }
 
-test_review_with_draft_pr_is_blocked() {
-  local tmp vault state bin
+test_review_with_draft_pr_is_retried() {
+  local tmp vault state bin prompt_log
   tmp="$(mktemp -d)"
   vault="${tmp}/vault"
   state="${tmp}/state"
   bin="${tmp}/bin"
+  prompt_log="${tmp}/prompts.log"
   mkdir -p "${bin}"
   make_fake_codex "${bin}"
   make_fake_gh "${bin}"
@@ -516,10 +523,20 @@ test_review_with_draft_pr_is_blocked() {
 
   PATH="${bin}:$PATH" GH_FAKE_IS_DRAFT=true CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-draft.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-408\|BOXP-408: draft pr\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-408.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-408\|BOXP-408: draft pr\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-408.md" '^status: in-progress$'
+  assert_file_contains "${vault}/Tickets/BOXP-408.md" '^assignee: codex$'
   assert_file_contains "${vault}/Tickets/BOXP-408.md" 'Review gate failed \(mergeability\)'
   assert_file_contains "${vault}/Tickets/BOXP-408.md" 'still a draft'
+
+  PATH="${bin}:$PATH" GH_FAKE_IS_DRAFT=true CODEX_FAKE_PROMPT_LOG="${prompt_log}" CODEX_FAKE_MESSAGE=$'TASK_BOARD_RESULT: blocked' run_tick "${vault}" "${state}" env >/tmp/task-board-review-draft-retry-prompt.out
+
+  assert_file_contains "${prompt_log}" 'Pending PR gate retry instruction'
+  assert_file_contains "${prompt_log}" 'Target PR URL: https://github.com/boxp/example/pull/123'
+  assert_file_contains "${prompt_log}" 'Failed gate: mergeability'
+  assert_file_contains "${prompt_log}" 'Failure reason: GitHub reports this PR is still a draft'
+  assert_file_contains "${prompt_log}" 'Previous run summary: .*/summary.edn'
+  assert_file_contains "${prompt_log}" 'Expected completion state: update the same PR'
 }
 
 test_review_with_behind_merge_state_times_out() {
@@ -536,10 +553,55 @@ test_review_with_behind_merge_state_times_out() {
 
   PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_TIMEOUT_SECONDS=1 CODEX_TASK_BOARD_PR_GATE_POLL_SECONDS=1 GH_FAKE_MERGE_STATE=BEHIND CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-behind.out
 
-  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-409\|BOXP-409: behind\]\].*status::blocked'
-  assert_file_contains "${vault}/Tickets/BOXP-409.md" '^status: blocked$'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-409\|BOXP-409: behind\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-409.md" '^status: in-progress$'
   assert_file_contains "${vault}/Tickets/BOXP-409.md" 'Review gate failed \(mergeability\)'
   assert_file_contains "${vault}/Tickets/BOXP-409.md" 'mergeStateStatus=BEHIND'
+}
+
+test_review_gate_retry_limit_blocks() {
+  local tmp vault state bin i
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-414|BOXP-414: retry limit]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-414 in-progress codex boxp/example
+
+  for i in 1 2 3; do
+    PATH="${bin}:$PATH" CODEX_TASK_BOARD_PR_GATE_RETRY_LIMIT=2 GH_FAKE_CHECKS='[{"name":"unit","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-retry-limit-"${i}".out
+  done
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-414\|BOXP-414: retry limit\]\].*status::blocked'
+  assert_file_contains "${vault}/Tickets/BOXP-414.md" '^status: blocked$'
+  assert_file_contains "${vault}/Tickets/BOXP-414.md" '^assignee: boxp$'
+  assert_file_contains "${vault}/Tickets/BOXP-414.md" 'Review gate failed \(ci\)'
+  assert_run_summary_contains "${state}" BOXP-414 ':retry-exhausted\? true'
+}
+
+test_review_gate_pass_after_retry_moves_review() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-415|BOXP-415: pass after retry]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-415 in-progress codex boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_CHECKS='[{"name":"unit","status":"COMPLETED","conclusion":"FAILURE"}]' CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-retry-then-pass-1.out
+  PATH="${bin}:$PATH" CODEX_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-review-retry-then-pass-2.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-415\|BOXP-415: pass after retry\]\].*status::review'
+  assert_file_contains "${vault}/Tickets/BOXP-415.md" '^status: review$'
+  assert_file_contains "${vault}/Tickets/BOXP-415.md" 'PR: https://github.com/boxp/example/pull/123'
+  assert_file_contains "${vault}/Tickets/BOXP-415.md" 'Review gates passed'
+  assert_file_not_contains "${state}/state.edn" 'BOXP-415'
 }
 
 test_parallel_codex_runs
@@ -556,7 +618,9 @@ test_review_with_multiple_pr_urls_blocks_on_second_failure
 test_review_gate_keeps_lock_heartbeat_active
 test_review_gate_passes_codex_model_profile_to_review
 test_review_with_empty_ci_rollup_times_out
-test_review_with_draft_pr_is_blocked
+test_review_with_draft_pr_is_retried
 test_review_with_behind_merge_state_times_out
+test_review_gate_retry_limit_blocks
+test_review_gate_pass_after_retry_moves_review
 
 echo "task-board-runner tests passed"


### PR DESCRIPTION
## Summary

- Add a retry harness for retryable PR gate failures instead of immediately moving tickets to Blocked.
- Persist same PR/gate/reason retry counts in task board state with a configurable retry limit.
- Include explicit retry context in the next Codex prompt and expand black-box coverage.

## Validation

- tests/codex-workspace/task-board-runner-test.sh

## Notes

- Updated the vault spec at Projects/codex-task-board-runner/spec.md outside this repository workspace.
