### PR TITLE
[codex] Add fable task board routing

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -20,6 +20,7 @@
 
 (def default-vault "/home/boxp/Documents/obsidian-headless/BOXP")
 (def default-root "/home/boxp/.codex-task-board")
+(def supported-assignees #{"codex" "fable"})
 (def board-mutex (Object.))
 (def log-mutex (Object.))
 
@@ -397,17 +398,18 @@
            last))))
 
 (defn pr-gate-retry-prompt [ticket-id]
-  (when-let [{:keys [pr-url gate message run-id run-dir count limit]} (latest-pr-gate-retry ticket-id)]
+  (when-let [{:keys [pr-url gate message run-id run-dir count limit agent]} (latest-pr-gate-retry ticket-id)]
     (str "Pending PR gate retry instruction:\n"
          "- Target PR URL: " pr-url "\n"
          "- Failed gate: " gate "\n"
          "- Failure reason: " message "\n"
+         "- Retry agent: " (or agent "codex") "\n"
          "- Retry count for this same PR/gate/reason: " count "/" limit "\n"
          "- Previous run summary: " run-dir "/summary.edn\n"
          "- Previous run logs: " run-dir "/events.jsonl and " run-dir "/stderr.log\n"
          "- Expected completion state: update the same PR until draft/mergeability/CI/codex-review gates pass, then return TASK_BOARD_RESULT: review with the PR URL.\n\n")))
 
-(defn record-pr-gate-failure! [ticket-id run-id review-gate]
+(defn record-pr-gate-failure! [ticket-id run-id agent review-gate]
   (let [limit (pr-gate-retry-limit)
         fingerprint (retry-fingerprint review-gate)
         path [:pr-gate-retries ticket-id fingerprint]
@@ -419,6 +421,7 @@
                 :message (:message review-gate)
                 :run-id run-id
                 :run-dir (str (run-dir ticket-id run-id))
+                :agent agent
                 :count count
                 :limit limit
                 :updated-at (now-str)}
@@ -517,17 +520,27 @@
        distinct
        vec))
 
-(defn prompt-for [action ticket-id lane workspace]
+(defn fable-policy-prompt []
+  (str "Fable routing policy:\n"
+       "- You are the Claude Code fable entry point for this Task Board run.\n"
+       "- Minimize fable token and limit consumption. Keep your own work focused on short judgment, routing, review perspective, and concise direction.\n"
+       "- Delegate long investigation, implementation, file editing, and test execution to Codex whenever practical. Use the prepared workspace and repository worktrees from this prompt.\n"
+       "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
+       "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
+
+(defn prompt-for [action ticket-id lane workspace agent]
   (let [ticket-text (slurp (str (ticket-path ticket-id)))
         previous (previous-run-summaries ticket-id)
         common (str "You are running inside codex-workspace as an automated Task Board worker.\n"
                     "Respond in Japanese when editing notes or summaries for the user.\n"
                     "Task Board lane is the source of truth. Do not move Task Board cards directly; the runner will do that after this run.\n"
                     "Ticket: " ticket-id "\n"
+                    "Task Board assignee/agent: " agent "\n"
                     "Current lane: " lane "\n\n"
                     (workspace-prompt workspace) "\n"
                     "Previous run summaries:\n" (pr-str previous) "\n\n"
                     (or (pr-gate-retry-prompt ticket-id) "")
+                    (when (= "fable" agent) (fable-policy-prompt))
                     "Ticket contents:\n\n" ticket-text "\n\n")
         review-contract (str "When repository changes are part of the work, create or update a GitHub PR before returning TASK_BOARD_RESULT: review.\n"
                              "If you return TASK_BOARD_RESULT: review, include either a GitHub PR URL or exactly one line TASK_BOARD_REVIEW_PR: none when no repository changes were made.\n")]
@@ -820,7 +833,21 @@
        :retryable? false
        :message (.getMessage e)})))
 
-(defn run-codex! [ticket-id action lane lock]
+(defn fable-model-args []
+  (let [model (System/getenv "CODEX_TASK_BOARD_FABLE_MODEL")
+        agent (env "CODEX_TASK_BOARD_FABLE_AGENT" "fable")
+        extra (System/getenv "CODEX_TASK_BOARD_FABLE_EXTRA_ARGS")]
+    (cond-> []
+      (seq model)
+      (into ["--model" model])
+
+      (seq agent)
+      (into ["--agent" agent])
+
+      (seq extra)
+      (into (str/split extra #"\s+")))))
+
+(defn run-agent! [ticket-id action lane agent lock]
   (let [run (:run-id lock)
         dir (run-dir ticket-id run)
         workspace (prepare-run-workspace! ticket-id run)
@@ -829,36 +856,55 @@
         stderr-path (fs/path dir "stderr.log")
         last-message-path (fs/path dir "last-message.md")]
     (fs/create-dirs dir)
-    (spit (str prompt-path) (prompt-for action ticket-id lane workspace))
-    (mark-run! ticket-id run :running {:action action :lane lane :started-at (now-str)})
-    (let [args (cond-> ["codex" "exec" "--json" "--cd" (:workspace-dir workspace)
-                        "--skip-git-repo-check"
-                        "--output-last-message" (str last-message-path)]
-                 (= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                 (conj "--dangerously-bypass-approvals-and-sandbox")
+    (spit (str prompt-path) (prompt-for action ticket-id lane workspace agent))
+    (mark-run! ticket-id run :running {:action action :agent agent :lane lane :started-at (now-str)})
+    (let [args (case agent
+                 "fable"
+                 (cond-> ["claude" "--print" "--output-format" "text"]
+                   (= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                   (conj "--dangerously-skip-permissions")
 
-                 (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                 (into ["--sandbox" (env "CODEX_TASK_BOARD_SANDBOX" "workspace-write")
-                        "--add-dir" (vault)])
+                   (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                   (into (mapcat (fn [dir] ["--add-dir" dir])
+                                 (cons (vault) (workspace-add-dirs workspace))))
 
-                 (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
-                 (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
+                   true
+                   (into (fable-model-args)))
 
-                 true
-                 (into (codex-model-profile-args))
+                 (cond-> ["codex" "exec" "--json" "--cd" (:workspace-dir workspace)
+                          "--skip-git-repo-check"
+                          "--output-last-message" (str last-message-path)]
+                   (= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                   (conj "--dangerously-bypass-approvals-and-sandbox")
 
-                 true
-                 (conj "-"))
-          proc @(p/process args {:in (io/file (str prompt-path))
-                                 :out (io/file (str stdout-path))
-                                 :err (io/file (str stderr-path))})
+                   (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                   (into ["--sandbox" (env "CODEX_TASK_BOARD_SANDBOX" "workspace-write")
+                          "--add-dir" (vault)])
+
+                   (not= "true" (env "CODEX_TASK_BOARD_BYPASS_APPROVALS" "true"))
+                   (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
+
+                   true
+                   (into (codex-model-profile-args))
+
+                   true
+                   (conj "-")))
+          proc @(p/process args (cond-> {:in (io/file (str prompt-path))
+                                         :out (io/file (str stdout-path))
+                                         :err (io/file (str stderr-path))}
+                                  (= "fable" agent)
+                                  (assoc :dir (:workspace-dir workspace))))
           exit (:exit proc)
+          _ (when (and (= "fable" agent) (fs/exists? stdout-path))
+              (io/copy (io/file (str stdout-path))
+                       (io/file (str last-message-path))))
           last-message (when (fs/exists? last-message-path)
                          (slurp (str last-message-path)))
           marker (result-marker last-message)]
       (let [status (if (zero? exit) :succeeded :failed)]
         (mark-run! ticket-id run status
                    {:action action
+                    :agent agent
                     :lane lane
                     :exit-code exit
                     :result marker
@@ -866,7 +912,7 @@
       {:exit exit :result marker :run-id run :dir (str dir) :last-message last-message})))
 
 (defn candidate-action [{:keys [lane status]} assignee]
-  (when (= "codex" assignee)
+  (when (contains? supported-assignees assignee)
     (case status
       "backlog" :groom
       "ready" :implement
@@ -940,8 +986,8 @@
               (when (#{"ready" "review" "blocked"} status)
                 (move-card! ticket-id "in-progress")
                 (update-frontmatter! ticket-id {:status "in-progress"}))
-              (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " started from " lane " with action " (name action) "."))
-              (let [{:keys [exit result run-id dir last-message]} (run-codex! ticket-id action effective-lane lock)
+              (append-note! ticket-id (str "Codex task-board run " (:run-id lock) " started from " lane " with action " (name action) " using " assignee "."))
+              (let [{:keys [exit result run-id dir last-message]} (run-agent! ticket-id action effective-lane assignee lock)
                     intended (cond
                                (not (zero? exit)) "blocked"
                                (= :groom action) "ready"
@@ -951,7 +997,7 @@
                                   (let [gate-result (review-gate! dir last-message)]
                                     (if (and (not (:ok? gate-result))
                                              (:retryable? gate-result))
-                                      (record-pr-gate-failure! ticket-id run-id gate-result)
+                                      (record-pr-gate-failure! ticket-id run-id assignee gate-result)
                                       gate-result))
                                   {:ok? true})
                     next-status (final-status action result exit review-gate)]
@@ -961,6 +1007,7 @@
                                                 (= "in-progress" next-status) :retrying
                                                 :else :blocked)
                              {:action action
+                              :agent assignee
                               :lane effective-lane
                               :exit-code exit
                               :result result
@@ -970,7 +1017,7 @@
                   (clear-pr-gate-retries! ticket-id))
                 (move-card! ticket-id next-status)
                 (update-frontmatter! ticket-id (cond-> {:status next-status
-                                                         :assignee (if (= "in-progress" next-status) "codex" "boxp")}
+                                                         :assignee (if (= "in-progress" next-status) assignee "boxp")}
                                                   (= "done" next-status) (assoc :closed (today))))
                 (append-note! ticket-id (final-note run-id next-status result last-message review-gate))
                 true)
@@ -1017,9 +1064,9 @@
         processed (count (filter :started? results))]
     (sync-all!)
     (log! (cond
-            (empty? candidates) "no codex-assigned Task Board tickets"
-            (zero? processed) "no codex-assigned Task Board tickets could start"
-            :else (str "processed " processed " codex-assigned Task Board ticket(s) in parallel")))))
+            (empty? candidates) "no supported-agent-assigned Task Board tickets"
+            (zero? processed) "no supported-agent-assigned Task Board tickets could start"
+            :else (str "processed " processed " supported-agent-assigned Task Board ticket(s) in parallel")))))
 
 (defn loop! []
   (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)))

--- a/docs/project_docs/BOXP-76/plan.md
+++ b/docs/project_docs/BOXP-76/plan.md
@@ -1,0 +1,22 @@
+# BOXP-76: Task Board fable assignee routing
+
+## Goal
+
+Task Board runner が `assignee: fable` のチケットを自動実行対象として検出し、既存の `codex` run と同じ run log / Notes / result marker / lane 遷移を使えるようにする。
+
+## Implementation Plan
+
+1. `codex` と `fable` を許可 assignee として明示する小さな routing layer を追加する。
+2. `fable` run は Claude Code の fable 側へ渡す prompt を生成し、重い調査・実装・検証は必要に応じて Codex へ委譲する方針を prompt に含める。
+3. 実行後の `events.jsonl`、`stderr.log`、`last-message.md`、`summary.edn`、Notes、result marker 判定、PR gate は既存 runner の形式を再利用する。
+4. PR gate retry で in-progress に戻す場合は、次回も元の assignee が維持されるよう run metadata から agent を追跡する。
+5. 既存の `assignee: codex`、Backlog grooming、Ready/In Progress/Review/Blocked 処理、PR URL gate、対象外 assignee の無視をテストで確認する。
+
+## Validation
+
+- `tests/codex-workspace/task-board-runner-test.sh`
+- 追加テスト:
+  - `assignee: fable` が検出され、fable prompt と委譲方針が保存されること。
+  - fable run の result marker と log 形式が既存と同じ場所に残ること。
+  - PR gate retry 時に `assignee: fable` が維持されること。
+  - `codex` / `fable` 以外の assignee が自動実行されないこと。

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -77,6 +77,30 @@ EOF
   chmod +x "${bin_dir}/codex"
 }
 
+make_fake_claude() {
+  local bin_dir="$1"
+  cat >"${bin_dir}/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${CLAUDE_FAKE_ARG_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"${CLAUDE_FAKE_ARG_LOG}"
+fi
+
+prompt="$(cat)"
+ticket="$(printf '%s\n' "${prompt}" | sed -n 's/^Ticket: //p' | head -n 1)"
+if [[ -n "${CLAUDE_FAKE_PROMPT_LOG:-}" ]]; then
+  printf '%s\n' "${prompt}" >>"${CLAUDE_FAKE_PROMPT_LOG}"
+fi
+if [[ -n "${CLAUDE_FAKE_START_LOG:-}" ]]; then
+  printf '%s %s\n' "${ticket}" "$(date +%s)" >>"${CLAUDE_FAKE_START_LOG}"
+fi
+sleep "${CLAUDE_FAKE_SLEEP:-0}"
+printf '%s\n' "${CLAUDE_FAKE_MESSAGE:-TASK_BOARD_RESULT: done}"
+EOF
+  chmod +x "${bin_dir}/claude"
+}
+
 make_fake_gh() {
   local bin_dir="$1"
   cat >"${bin_dir}/gh" <<'EOF'
@@ -236,6 +260,67 @@ test_parallel_codex_runs() {
   assert_file_contains "${vault}/Tickets/BOXP-102.md" '^status: done$'
 }
 
+test_fable_assignee_runs_via_claude() {
+  local tmp vault state bin prompt_log args_log summary last_message events
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  prompt_log="${tmp}/claude-prompt.log"
+  args_log="${tmp}/claude-args.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_claude "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-150|BOXP-150: fable]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-150 in-progress fable
+
+  PATH="${bin}:$PATH" \
+    CLAUDE_FAKE_PROMPT_LOG="${prompt_log}" \
+    CLAUDE_FAKE_ARG_LOG="${args_log}" \
+    CLAUDE_FAKE_MESSAGE='TASK_BOARD_RESULT: done' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-fable.out
+
+  assert_file_contains "${args_log}" '.*--print --output-format text.*--agent fable'
+  assert_file_not_contains "${args_log}" 'BOXP-150'
+  assert_file_contains "${prompt_log}" '^Task Board assignee/agent: fable$'
+  assert_file_contains "${prompt_log}" 'Fable routing policy'
+  assert_file_contains "${prompt_log}" 'Delegate long investigation, implementation, file editing, and test execution to Codex'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-150\|BOXP-150: fable\]\].*status::done'
+  assert_file_contains "${vault}/Tickets/BOXP-150.md" '^status: done$'
+  summary="$(find "${state}/runs/BOXP-150" -name summary.edn -print | sort | tail -n 1)"
+  last_message="$(find "${state}/runs/BOXP-150" -name last-message.md -print | sort | tail -n 1)"
+  events="$(find "${state}/runs/BOXP-150" -name events.jsonl -print | sort | tail -n 1)"
+  assert_file_contains "${summary}" ':agent "fable"'
+  assert_file_contains "${last_message}" '^TASK_BOARD_RESULT: done$'
+  assert_file_contains "${events}" '^TASK_BOARD_RESULT: done$'
+}
+
+test_unsupported_assignee_is_ignored() {
+  local tmp vault state bin codex_log claude_log
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  codex_log="${tmp}/codex-starts.log"
+  claude_log="${tmp}/claude-starts.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  make_fake_claude "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-151|BOXP-151: human]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-151 in-progress boxp
+
+  PATH="${bin}:$PATH" \
+    CODEX_FAKE_START_LOG="${codex_log}" \
+    CLAUDE_FAKE_START_LOG="${claude_log}" \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-unsupported-assignee.out
+
+  [[ ! -e "${codex_log}" ]] || fail "expected codex not to start for unsupported assignee"
+  [[ ! -e "${claude_log}" ]] || fail "expected claude not to start for unsupported assignee"
+  [[ ! -d "${state}/runs/BOXP-151" ]] || fail "expected no run directory for unsupported assignee"
+  assert_file_contains "${vault}/Tickets/BOXP-151.md" '^status: in-progress$'
+  assert_file_contains /tmp/task-board-unsupported-assignee.out 'no supported-agent-assigned Task Board tickets'
+}
+
 test_stale_lock_recovers() {
   local tmp vault state bin old_run
   tmp="$(mktemp -d)"
@@ -338,6 +423,28 @@ test_review_with_conflict_is_blocked() {
   assert_file_contains "${vault}/Tickets/BOXP-403.md" 'Retrying with Codex instruction 1/2'
   assert_run_summary_contains "${state}" BOXP-403 ':gate :conflict'
   assert_run_summary_contains "${state}" BOXP-403 ':status :retrying'
+}
+
+test_fable_review_gate_retry_keeps_fable_assignee() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  mkdir -p "${bin}"
+  make_fake_claude "${bin}"
+  make_fake_gh "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-416|BOXP-416: fable conflict]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-416 in-progress fable boxp/example
+
+  PATH="${bin}:$PATH" GH_FAKE_MERGE_STATE=DIRTY CLAUDE_FAKE_MESSAGE=$'Created PR: https://github.com/boxp/example/pull/123\nTASK_BOARD_RESULT: review' run_tick "${vault}" "${state}" env >/tmp/task-board-fable-review-conflict.out
+
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-416\|BOXP-416: fable conflict\]\].*status::in-progress'
+  assert_file_contains "${vault}/Tickets/BOXP-416.md" '^status: in-progress$'
+  assert_file_contains "${vault}/Tickets/BOXP-416.md" '^assignee: fable$'
+  assert_file_contains "${vault}/Tickets/BOXP-416.md" 'Retrying with Codex instruction 1/2'
+  assert_run_summary_contains "${state}" BOXP-416 ':agent "fable"'
+  assert_file_contains "${state}/state.edn" ':agent "fable"'
 }
 
 test_review_with_ci_failure_is_blocked() {
@@ -605,11 +712,14 @@ test_review_gate_pass_after_retry_moves_review() {
 }
 
 test_parallel_codex_runs
+test_fable_assignee_runs_via_claude
+test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
 test_review_without_repo_marker_skips_pr_gates
 test_review_with_conflict_is_blocked
+test_fable_review_gate_retry_keeps_fable_assignee
 test_review_with_ci_failure_is_blocked
 test_review_with_codex_review_issue_is_blocked
 test_review_with_pr_and_none_marker_checks_pr


### PR DESCRIPTION
## Summary

- Add `assignee: fable` as a supported Task Board runner assignee alongside `codex`.
- Route fable runs through Claude Code with `--agent fable`, while preserving the existing run directory, logs, result marker, Notes, lane transition, and PR gate flow.
- Add fable policy prompt text that tells fable to minimize token/limit usage and delegate heavier investigation, implementation, and validation to Codex when practical.
- Document the implementation plan in `docs/project_docs/BOXP-76/plan.md`.

## Validation

- `tests/codex-workspace/task-board-runner-test.sh`
- `codex review --uncommitted`