### PR TITLE
BOXP-77: GPT-5.6 (Sol/Terra/Luna) 対応 assignee ルーティング

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -620,15 +620,18 @@
 (defn codex-model-profile-args
   ([] (codex-model-profile-args nil))
   ([assignee]
-   (let [env-model (System/getenv "CODEX_TASK_BOARD_MODEL")
-         default-model (get assignee->model assignee)
+   (let [env-model (env "CODEX_TASK_BOARD_MODEL" nil)
+         env-profile (env "CODEX_TASK_BOARD_PROFILE" nil)]
+     (codex-model-profile-args assignee env-model env-profile)))
+  ([assignee env-model env-profile]
+   (let [default-model (get assignee->model assignee)
          model (or (seq env-model) default-model)]
      (cond-> []
        model
        (conj "--model" (if (seq env-model) env-model default-model))
 
-       (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
-       (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))))))
+       (seq env-profile)
+       (conj "--profile" env-profile)))))
 
 (defn pr-view [pr-url]
   (-> (run-string! ["gh" "pr" "view" pr-url "--json" "url,isDraft,mergeStateStatus,statusCheckRollup"] {})
@@ -1095,20 +1098,30 @@
   (println "usage: task_board_runner.bb <tick|loop|sync>")
   (System/exit 2))
 
+(defn arg-value [args flag]
+  (let [idx (.indexOf args flag)]
+    (when (>= idx 0) (nth args (inc idx)))))
+
 (defn run-tests! []
   (let [failures (atom [])]
     (doseq [[assignee expected-model] [["codex"      "gpt-5.6-sol"]
                                        ["codex-sol"  "gpt-5.6-sol"]
                                        ["codex-full" "gpt-5.6-terra"]
                                        ["codex-mini" "gpt-5.6-luna"]]]
-      (let [args (codex-model-profile-args assignee)
-            model-idx (.indexOf args "--model")
-            actual-model (when (>= model-idx 0) (nth args (inc model-idx)))]
+      (let [args (codex-model-profile-args assignee nil nil)
+            actual-model (arg-value args "--model")]
         (if (= actual-model expected-model)
           (println (str "PASS: " assignee " -> " actual-model))
           (do
             (println (str "FAIL: " assignee " expected=" expected-model " actual=" actual-model))
             (swap! failures conj assignee)))))
+    (let [args (codex-model-profile-args "codex-full" "gpt-test-override" nil)
+          actual-model (arg-value args "--model")]
+      (if (= actual-model "gpt-test-override")
+        (println (str "PASS: CODEX_TASK_BOARD_MODEL overrides assignee model -> " actual-model))
+        (do
+          (println (str "FAIL: CODEX_TASK_BOARD_MODEL override expected=gpt-test-override actual=" actual-model))
+          (swap! failures conj "CODEX_TASK_BOARD_MODEL override"))))
     (if (seq @failures)
       (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))
       (println "All assignee model tests passed."))))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -24,9 +24,10 @@
 
 (def assignee->model
   ;; GPT-5.6 performance order: Sol > Terra > Luna.
-  ;; codex / codex-sol / codex-full all route to Sol (highest-performance tier).
-  ;; codex-terra routes to Terra (mid-tier), codex-mini routes to Luna (lightweight).
-  {"codex"       "gpt-5.6-sol"
+  ;; codex (default) / codex-terra route to Terra (GPT-5.5-equivalent, cost-efficient default).
+  ;; codex-sol / codex-full route to Sol (highest-performance, complex tasks only).
+  ;; codex-mini routes to Luna (lightweight tier).
+  {"codex"       "gpt-5.6-terra"
    "codex-sol"   "gpt-5.6-sol"
    "codex-full"  "gpt-5.6-sol"
    "codex-terra" "gpt-5.6-terra"
@@ -535,7 +536,7 @@
   (str "Fable routing policy:\n"
        "- You are the Claude Code fable entry point for this Task Board run.\n"
        "- Minimize fable token and limit consumption. Keep your own work focused on short judgment, routing, review perspective, and concise direction.\n"
-       "- Delegate long investigation, implementation, file editing, and test execution to Codex whenever practical. If no explicit Codex model is supplied, use the default Codex route: gpt-5.6-sol, unless CODEX_TASK_BOARD_MODEL overrides it. Use the prepared workspace and repository worktrees from this prompt.\n"
+       "- Delegate long investigation, implementation, file editing, and test execution to Codex whenever practical. If no explicit Codex model is supplied, use the default Codex route: gpt-5.6-terra (GPT-5.5-equivalent, cost-efficient), unless CODEX_TASK_BOARD_MODEL overrides it. Reserve gpt-5.6-sol (via codex-sol/codex-full assignees) for high-complexity tasks. Use the prepared workspace and repository worktrees from this prompt.\n"
        "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
        "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
 
@@ -1113,11 +1114,11 @@
 
 (defn run-tests! []
   (let [failures (atom [])]
-    (doseq [[assignee expected-model] [["codex"      "gpt-5.6-sol"]
-                                       ["codex-sol"  "gpt-5.6-sol"]
-                                       ["codex-full" "gpt-5.6-sol"]
+    (doseq [[assignee expected-model] [["codex"       "gpt-5.6-terra"]
+                                       ["codex-sol"   "gpt-5.6-sol"]
+                                       ["codex-full"  "gpt-5.6-sol"]
                                        ["codex-terra" "gpt-5.6-terra"]
-                                       ["codex-mini" "gpt-5.6-luna"]]]
+                                       ["codex-mini"  "gpt-5.6-luna"]]]
       (let [actual-model (get-codex-model assignee nil)]
         (if (= actual-model expected-model)
           (println (str "PASS: " assignee " -> " actual-model))
@@ -1134,10 +1135,10 @@
     ;; Verify run-codex-review! default: codex-model-profile-args "codex" without env override
     (let [args (codex-model-profile-args "codex" nil nil)
           actual-model (arg-value args "--model")]
-      (if (= actual-model "gpt-5.6-sol")
+      (if (= actual-model "gpt-5.6-terra")
         (println (str "PASS: codex-review gate default model -> " actual-model))
         (do
-          (println (str "FAIL: codex-review gate default model expected=gpt-5.6-sol actual=" actual-model))
+          (println (str "FAIL: codex-review gate default model expected=gpt-5.6-terra actual=" actual-model))
           (swap! failures conj "codex-review default model"))))
     (if (seq @failures)
       (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -782,7 +782,7 @@
                                   "--skip-git-repo-check"
                                   "--output-last-message" (str review-path)]
                            true
-                           (into (codex-model-profile-args))
+                           (into (codex-model-profile-args "codex"))
 
                            true
                            (conj "-"))
@@ -1128,6 +1128,14 @@
         (do
           (println (str "FAIL: CODEX_TASK_BOARD_MODEL override expected=gpt-test-override actual=" actual-model))
           (swap! failures conj "CODEX_TASK_BOARD_MODEL override"))))
+    ;; Verify run-codex-review! default: codex-model-profile-args "codex" without env override
+    (let [args (codex-model-profile-args "codex" nil nil)
+          actual-model (arg-value args "--model")]
+      (if (= actual-model "gpt-5.6-sol")
+        (println (str "PASS: codex-review gate default model -> " actual-model))
+        (do
+          (println (str "FAIL: codex-review gate default model expected=gpt-5.6-sol actual=" actual-model))
+          (swap! failures conj "codex-review default model"))))
     (if (seq @failures)
       (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))
       (println "All assignee model tests passed."))))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -24,12 +24,13 @@
 
 (def assignee->model
   ;; GPT-5.6 performance order: Sol > Terra > Luna.
-  ;; codex-full is kept as a compatibility alias for the highest-performance route.
-  {"codex"      "gpt-5.6-sol"
-   "codex-sol"  "gpt-5.6-sol"
-   "codex-full" "gpt-5.6-sol"
+  ;; codex / codex-sol / codex-full all route to Sol (highest-performance tier).
+  ;; codex-terra routes to Terra (mid-tier), codex-mini routes to Luna (lightweight).
+  {"codex"       "gpt-5.6-sol"
+   "codex-sol"   "gpt-5.6-sol"
+   "codex-full"  "gpt-5.6-sol"
    "codex-terra" "gpt-5.6-terra"
-   "codex-mini" "gpt-5.6-luna"})
+   "codex-mini"  "gpt-5.6-luna"})
 
 (def board-mutex (Object.))
 (def log-mutex (Object.))
@@ -855,6 +856,8 @@
        :message (.getMessage e)})))
 
 (defn fable-model-args []
+  ;; Fable runs via the `claude` CLI. Model defaults to claude CLI's built-in default
+  ;; (claude-sonnet-4-6) unless CODEX_TASK_BOARD_FABLE_MODEL overrides it.
   (let [model (System/getenv "CODEX_TASK_BOARD_FABLE_MODEL")
         agent (env "CODEX_TASK_BOARD_FABLE_AGENT" "fable")
         extra (System/getenv "CODEX_TASK_BOARD_FABLE_EXTRA_ARGS")]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -20,7 +20,14 @@
 
 (def default-vault "/home/boxp/Documents/obsidian-headless/BOXP")
 (def default-root "/home/boxp/.codex-task-board")
-(def supported-assignees #{"codex" "fable"})
+(def supported-assignees #{"codex" "codex-sol" "codex-full" "codex-mini" "fable"})
+
+(def assignee->model
+  {"codex"      "gpt-5.6-sol"
+   "codex-sol"  "gpt-5.6-sol"
+   "codex-full" "gpt-5.6-sol"
+   "codex-mini" "gpt-5.6-luna"})
+
 (def board-mutex (Object.))
 (def log-mutex (Object.))
 
@@ -610,13 +617,18 @@
       (throw (ex-info (str "command failed: " (str/join " " args) "\n" (:err proc))
                       {:args args :exit (:exit proc) :err (:err proc)})))))
 
-(defn codex-model-profile-args []
-  (cond-> []
-    (seq (System/getenv "CODEX_TASK_BOARD_MODEL"))
-    (conj "--model" (System/getenv "CODEX_TASK_BOARD_MODEL"))
+(defn codex-model-profile-args
+  ([] (codex-model-profile-args nil))
+  ([assignee]
+   (let [env-model (System/getenv "CODEX_TASK_BOARD_MODEL")
+         default-model (get assignee->model assignee)
+         model (or (seq env-model) default-model)]
+     (cond-> []
+       model
+       (conj "--model" (if (seq env-model) env-model default-model))
 
-    (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
-    (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))))
+       (seq (System/getenv "CODEX_TASK_BOARD_PROFILE"))
+       (conj "--profile" (System/getenv "CODEX_TASK_BOARD_PROFILE"))))))
 
 (defn pr-view [pr-url]
   (-> (run-string! ["gh" "pr" "view" pr-url "--json" "url,isDraft,mergeStateStatus,statusCheckRollup"] {})
@@ -885,7 +897,7 @@
                    (into (mapcat (fn [dir] ["--add-dir" dir]) (workspace-add-dirs workspace)))
 
                    true
-                   (into (codex-model-profile-args))
+                   (into (codex-model-profile-args agent))
 
                    true
                    (conj "-")))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -20,12 +20,15 @@
 
 (def default-vault "/home/boxp/Documents/obsidian-headless/BOXP")
 (def default-root "/home/boxp/.codex-task-board")
-(def supported-assignees #{"codex" "codex-sol" "codex-full" "codex-mini" "fable"})
+(def supported-assignees #{"codex" "codex-sol" "codex-full" "codex-terra" "codex-mini" "fable"})
 
 (def assignee->model
+  ;; GPT-5.6 performance order: Sol > Terra > Luna.
+  ;; codex-full is kept as a compatibility alias for the highest-performance route.
   {"codex"      "gpt-5.6-sol"
    "codex-sol"  "gpt-5.6-sol"
-   "codex-full" "gpt-5.6-terra"
+   "codex-full" "gpt-5.6-sol"
+   "codex-terra" "gpt-5.6-terra"
    "codex-mini" "gpt-5.6-luna"})
 
 (def board-mutex (Object.))
@@ -531,7 +534,7 @@
   (str "Fable routing policy:\n"
        "- You are the Claude Code fable entry point for this Task Board run.\n"
        "- Minimize fable token and limit consumption. Keep your own work focused on short judgment, routing, review perspective, and concise direction.\n"
-       "- Delegate long investigation, implementation, file editing, and test execution to Codex whenever practical. Use the prepared workspace and repository worktrees from this prompt.\n"
+       "- Delegate long investigation, implementation, file editing, and test execution to Codex whenever practical. If no explicit Codex model is supplied, use the default Codex route: gpt-5.6-sol, unless CODEX_TASK_BOARD_MODEL overrides it. Use the prepared workspace and repository worktrees from this prompt.\n"
        "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
        "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
 
@@ -617,6 +620,10 @@
       (throw (ex-info (str "command failed: " (str/join " " args) "\n" (:err proc))
                       {:args args :exit (:exit proc) :err (:err proc)})))))
 
+(defn get-codex-model [assignee env-model]
+  (or (when (seq env-model) env-model)
+      (get assignee->model assignee)))
+
 (defn codex-model-profile-args
   ([] (codex-model-profile-args nil))
   ([assignee]
@@ -624,11 +631,10 @@
          env-profile (env "CODEX_TASK_BOARD_PROFILE" nil)]
      (codex-model-profile-args assignee env-model env-profile)))
   ([assignee env-model env-profile]
-   (let [default-model (get assignee->model assignee)
-         model (or (seq env-model) default-model)]
+   (let [model (get-codex-model assignee env-model)]
      (cond-> []
        model
-       (conj "--model" (if (seq env-model) env-model default-model))
+       (conj "--model" model)
 
        (seq env-profile)
        (conj "--profile" env-profile)))))
@@ -1106,10 +1112,10 @@
   (let [failures (atom [])]
     (doseq [[assignee expected-model] [["codex"      "gpt-5.6-sol"]
                                        ["codex-sol"  "gpt-5.6-sol"]
-                                       ["codex-full" "gpt-5.6-terra"]
+                                       ["codex-full" "gpt-5.6-sol"]
+                                       ["codex-terra" "gpt-5.6-terra"]
                                        ["codex-mini" "gpt-5.6-luna"]]]
-      (let [args (codex-model-profile-args assignee nil nil)
-            actual-model (arg-value args "--model")]
+      (let [actual-model (get-codex-model assignee nil)]
         (if (= actual-model expected-model)
           (println (str "PASS: " assignee " -> " actual-model))
           (do

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -25,7 +25,7 @@
 (def assignee->model
   {"codex"      "gpt-5.6-sol"
    "codex-sol"  "gpt-5.6-sol"
-   "codex-full" "gpt-5.6-sol"
+   "codex-full" "gpt-5.6-terra"
    "codex-mini" "gpt-5.6-luna"})
 
 (def board-mutex (Object.))
@@ -1095,8 +1095,27 @@
   (println "usage: task_board_runner.bb <tick|loop|sync>")
   (System/exit 2))
 
+(defn run-tests! []
+  (let [failures (atom [])]
+    (doseq [[assignee expected-model] [["codex"      "gpt-5.6-sol"]
+                                       ["codex-sol"  "gpt-5.6-sol"]
+                                       ["codex-full" "gpt-5.6-terra"]
+                                       ["codex-mini" "gpt-5.6-luna"]]]
+      (let [args (codex-model-profile-args assignee)
+            model-idx (.indexOf args "--model")
+            actual-model (when (>= model-idx 0) (nth args (inc model-idx)))]
+        (if (= actual-model expected-model)
+          (println (str "PASS: " assignee " -> " actual-model))
+          (do
+            (println (str "FAIL: " assignee " expected=" expected-model " actual=" actual-model))
+            (swap! failures conj assignee)))))
+    (if (seq @failures)
+      (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))
+      (println "All assignee model tests passed."))))
+
 (case (or (first *command-line-args*) "tick")
   "tick" (tick!)
   "loop" (loop!)
   "sync" (do (ensure-root!) (sync-all!))
+  "test" (run-tests!)
   (usage))

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -711,6 +711,10 @@ test_review_gate_pass_after_retry_moves_review() {
   assert_file_not_contains "${state}/state.edn" 'BOXP-415'
 }
 
+test_assignee_model_routing() {
+  bb "${RUNNER}" test
+}
+
 test_parallel_codex_runs
 test_fable_assignee_runs_via_claude
 test_unsupported_assignee_is_ignored
@@ -732,5 +736,6 @@ test_review_with_draft_pr_is_retried
 test_review_with_behind_merge_state_times_out
 test_review_gate_retry_limit_blocks
 test_review_gate_pass_after_retry_moves_review
+test_assignee_model_routing
 
 echo "task-board-runner tests passed"

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -715,6 +715,27 @@ test_assignee_model_routing() {
   bb "${RUNNER}" test
 }
 
+test_assignee_model_tick_routing() {
+  local tmp vault state bin args_log assignee expected_model
+  local pairs=("codex-sol:gpt-5.6-sol" "codex-terra:gpt-5.6-terra" "codex-mini:gpt-5.6-luna")
+  for pair in "${pairs[@]}"; do
+    assignee="${pair%%:*}"
+    expected_model="${pair##*:}"
+    tmp="$(mktemp -d)"
+    vault="${tmp}/vault"
+    state="${tmp}/state"
+    bin="${tmp}/bin"
+    args_log="${tmp}/codex-args.log"
+    mkdir -p "${bin}"
+    make_fake_codex "${bin}"
+    make_fake_gh "${bin}"
+    write_board "${vault}" "- [ ] [[Tickets/BOXP-500|BOXP-500: model tick]] #ticket status::in-progress"
+    write_ticket "${vault}" BOXP-500 in-progress "${assignee}"
+    PATH="${bin}:$PATH" CODEX_FAKE_ARG_LOG="${args_log}" run_tick "${vault}" "${state}" env >"/tmp/task-board-model-tick-${assignee}.out"
+    assert_file_contains "${args_log}" "exec.*--model ${expected_model}"
+  done
+}
+
 test_parallel_codex_runs
 test_fable_assignee_runs_via_claude
 test_unsupported_assignee_is_ignored
@@ -737,5 +758,6 @@ test_review_with_behind_merge_state_times_out
 test_review_gate_retry_limit_blocks
 test_review_gate_pass_after_retry_moves_review
 test_assignee_model_routing
+test_assignee_model_tick_routing
 
 echo "task-board-runner tests passed"


### PR DESCRIPTION
## Summary

- GPT-5.6 の3モデル（Sol/Terra/Luna）に対応した assignee ルーティングを `task_board_runner.bb` に追加
- `supported-assignees` に `codex-sol` / `codex-full` / `codex-terra` / `codex-mini` を追加
- `assignee->model` マップで各アサイニーのデフォルトモデルを管理（Sol > Terra > Luna の性能序列に忠実）
  - `codex` / `codex-terra` → `gpt-5.6-terra`（GPT-5.5 相当・デフォルト・コスト効率良好）
  - `codex-sol` / `codex-full` → `gpt-5.6-sol`（最高性能・高難度タスク専用）
  - `codex-mini` → `gpt-5.6-luna`（軽量モデル）
- 既存の `assignee: codex` は `gpt-5.6-terra` にフォールバック（後方互換・GPT-5.5 相当）
- `CODEX_TASK_BOARD_MODEL` 環境変数が設定されている場合は引き続きそちらが優先される
- `fable-policy-prompt` のデフォルト Codex route を `gpt-5.6-terra` に更新（sol→terra）

## Acceptance Criteria チェック

- [x] gpt-5.6 の Sol / Terra / Luna の API モデル名が確定・記録済み（`assignee->model` マップに記載）
- [x] `candidate-action` が `codex-sol` / `codex-terra` / `codex-full` / `codex-mini` を認識（`supported-assignees` に追加済み）
- [x] `codex` / `codex-terra` assignee は `gpt-5.6-terra`（GPT-5.5 相当）にフォールバック（後方互換）
- [x] `codex-sol` は `gpt-5.6-sol`（名前通り）
- [x] Fable ルーティング（`fable-policy-prompt`）のデフォルト Codex route が `gpt-5.6-terra` に更新済み
- [ ] 試験チケットでの動作確認（次ステップ）

## Test plan

- [x] `bb task_board_runner.bb test` で全アサイニーのモデルルーティングが正しいことを確認
- [x] `codex` → `gpt-5.6-terra` のデフォルトマッピングを検証
- [x] `codex-sol` → `gpt-5.6-sol`（高難度専用）を検証
- [x] `CODEX_TASK_BOARD_MODEL` 設定時に env var が優先されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)