### PR TITLE
BOXP-90: codex-sol に委譲方針プロンプトを追加

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -540,6 +540,16 @@
        "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
        "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
 
+(defn codex-sol-policy-prompt []
+  (str "Codex-sol routing policy:\n"
+       "- You are the codex-sol high-cost entry point for this Task Board run.\n"
+       "- Focus your own effort on task decomposition, results integration, critical decisions, and final review.\n"
+       "- Delegate independent investigation, implementation, and verification to lower-cost models whenever practical. Use the codex (gpt-5.6-terra) assignee as the default delegation route, unless CODEX_TASK_BOARD_MODEL overrides it.\n"
+       "- Do NOT delegate: tasks smaller than the delegation overhead, tasks requiring shared context or elevated permissions, and tasks requiring final judgment or acceptance.\n"
+       "- If a delegated subtask fails, produces insufficient quality, or is unavailable: re-instruct once, verify the result, or handle it directly. Avoid recursive or unbounded delegation chains.\n"
+       "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
+       "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
+
 (defn prompt-for [action ticket-id lane workspace agent]
   (let [ticket-text (slurp (str (ticket-path ticket-id)))
         previous (previous-run-summaries ticket-id)
@@ -553,6 +563,7 @@
                     "Previous run summaries:\n" (pr-str previous) "\n\n"
                     (or (pr-gate-retry-prompt ticket-id) "")
                     (when (= "fable" agent) (fable-policy-prompt))
+                    (when (contains? #{"codex-sol" "codex-full"} agent) (codex-sol-policy-prompt))
                     "Ticket contents:\n\n" ticket-text "\n\n")
         review-contract (str "When repository changes are part of the work, create or update a GitHub PR before returning TASK_BOARD_RESULT: review.\n"
                              "If you return TASK_BOARD_RESULT: review, include either a GitHub PR URL or exactly one line TASK_BOARD_REVIEW_PR: none when no repository changes were made.\n")]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -540,9 +540,9 @@
        "- If Codex is delegated work, preserve the Task Board runner contract: include a concise delegated-work summary in your final response and end with exactly one TASK_BOARD_RESULT marker that the runner can parse.\n"
        "- For repository changes, make sure a GitHub PR URL is included before returning TASK_BOARD_RESULT: review. If no repository changes were made, include TASK_BOARD_REVIEW_PR: none.\n\n"))
 
-(defn codex-sol-policy-prompt []
-  (str "Codex-sol routing policy:\n"
-       "- You are the codex-sol high-cost entry point for this Task Board run.\n"
+(defn codex-sol-policy-prompt [agent]
+  (str "High-cost model routing policy:\n"
+       "- You are the " agent " high-cost entry point for this Task Board run.\n"
        "- Focus your own effort on task decomposition, results integration, critical decisions, and final review.\n"
        "- Delegate independent investigation, implementation, and verification to lower-cost models whenever practical. Use the codex (gpt-5.6-terra) assignee as the default delegation route, unless CODEX_TASK_BOARD_MODEL overrides it.\n"
        "- Do NOT delegate: tasks smaller than the delegation overhead, tasks requiring shared context or elevated permissions, and tasks requiring final judgment or acceptance.\n"
@@ -563,7 +563,7 @@
                     "Previous run summaries:\n" (pr-str previous) "\n\n"
                     (or (pr-gate-retry-prompt ticket-id) "")
                     (when (= "fable" agent) (fable-policy-prompt))
-                    (when (contains? #{"codex-sol" "codex-full"} agent) (codex-sol-policy-prompt))
+                    (when (contains? #{"codex-sol" "codex-full"} agent) (codex-sol-policy-prompt agent))
                     "Ticket contents:\n\n" ticket-text "\n\n")
         review-contract (str "When repository changes are part of the work, create or update a GitHub PR before returning TASK_BOARD_RESULT: review.\n"
                              "If you return TASK_BOARD_RESULT: review, include either a GitHub PR URL or exactly one line TASK_BOARD_REVIEW_PR: none when no repository changes were made.\n")]

--- a/docs/project_docs/BOXP-90-codex-sol-delegation-policy/plan.md
+++ b/docs/project_docs/BOXP-90-codex-sol-delegation-policy/plan.md
@@ -1,0 +1,12 @@
+# BOXP-90: codex-sol 委譲方針プロンプト
+
+## 目的
+
+高コストの `codex-sol` および `codex-full` を Task Board の入口として実行する際、低コストな `codex` への適切な委譲を促す方針をプロンプトへ注入する。
+
+## 実施計画
+
+1. `fable-policy-prompt` と同じ位置に `codex-sol-policy-prompt` を追加する。
+2. `codex-sol` と `codex-full` の実行時にのみ、共通プロンプトへ方針を追加する。
+3. `codex-sol` のプロンプトに方針が含まれ、通常どおり完了処理されることをシェルテストで確認する。
+4. Babashka のユニットテストとシェル統合テストを実行し、PR を作成する。

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -313,7 +313,8 @@ test_codex_sol_assignee_includes_delegation_policy() {
     run_tick "${vault}" "${state}" env >/tmp/task-board-codex-sol.out
 
   assert_file_contains "${prompt_log}" '^Task Board assignee/agent: codex-sol$'
-  assert_file_contains "${prompt_log}" 'Codex-sol routing policy'
+  assert_file_contains "${prompt_log}" 'High-cost model routing policy'
+  assert_file_contains "${prompt_log}" 'You are the codex-sol high-cost entry point'
   assert_file_contains "${prompt_log}" 'Delegate independent investigation, implementation, and verification to lower-cost models whenever practical'
   assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-152\|BOXP-152: codex-sol\]\].*status::done'
   assert_file_contains "${vault}/Tickets/BOXP-152.md" '^status: done$'
@@ -341,7 +342,8 @@ test_codex_full_assignee_includes_delegation_policy() {
     run_tick "${vault}" "${state}" env >/tmp/task-board-codex-full.out
 
   assert_file_contains "${prompt_log}" '^Task Board assignee/agent: codex-full$'
-  assert_file_contains "${prompt_log}" 'Codex-sol routing policy'
+  assert_file_contains "${prompt_log}" 'High-cost model routing policy'
+  assert_file_contains "${prompt_log}" 'You are the codex-full high-cost entry point'
   assert_file_contains "${prompt_log}" 'Delegate independent investigation, implementation, and verification to lower-cost models whenever practical'
   assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-153\|BOXP-153: codex-full\]\].*status::done'
   assert_file_contains "${vault}/Tickets/BOXP-153.md" '^status: done$'

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -775,7 +775,7 @@ test_assignee_model_routing() {
 
 test_assignee_model_tick_routing() {
   local tmp vault state bin args_log assignee expected_model
-  local pairs=("codex-sol:gpt-5.6-sol" "codex-terra:gpt-5.6-terra" "codex-mini:gpt-5.6-luna")
+  local pairs=("codex-sol:gpt-5.6-sol" "codex-full:gpt-5.6-sol" "codex-terra:gpt-5.6-terra" "codex-mini:gpt-5.6-luna")
   for pair in "${pairs[@]}"; do
     assignee="${pair%%:*}"
     expected_model="${pair##*:}"

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -323,6 +323,34 @@ test_codex_sol_assignee_includes_delegation_policy() {
   assert_file_contains "${last_message}" '^TASK_BOARD_RESULT: done$'
 }
 
+test_codex_full_assignee_includes_delegation_policy() {
+  local tmp vault state bin prompt_log summary last_message
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  prompt_log="${tmp}/codex-prompt.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-153|BOXP-153: codex-full]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-153 in-progress codex-full
+
+  PATH="${bin}:$PATH" \
+    CODEX_FAKE_PROMPT_LOG="${prompt_log}" \
+    CODEX_FAKE_MESSAGE='TASK_BOARD_RESULT: done' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-codex-full.out
+
+  assert_file_contains "${prompt_log}" '^Task Board assignee/agent: codex-full$'
+  assert_file_contains "${prompt_log}" 'Codex-sol routing policy'
+  assert_file_contains "${prompt_log}" 'Delegate independent investigation, implementation, and verification to lower-cost models whenever practical'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-153\|BOXP-153: codex-full\]\].*status::done'
+  assert_file_contains "${vault}/Tickets/BOXP-153.md" '^status: done$'
+  summary="$(find "${state}/runs/BOXP-153" -name summary.edn -print | sort | tail -n 1)"
+  last_message="$(find "${state}/runs/BOXP-153" -name last-message.md -print | sort | tail -n 1)"
+  assert_file_contains "${summary}" ':agent "codex-full"'
+  assert_file_contains "${last_message}" '^TASK_BOARD_RESULT: done$'
+}
+
 test_unsupported_assignee_is_ignored() {
   local tmp vault state bin codex_log claude_log
   tmp="$(mktemp -d)"
@@ -767,6 +795,7 @@ test_assignee_model_tick_routing() {
 test_parallel_codex_runs
 test_fable_assignee_runs_via_claude
 test_codex_sol_assignee_includes_delegation_policy
+test_codex_full_assignee_includes_delegation_policy
 test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
 test_review_without_pr_is_blocked

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -295,6 +295,34 @@ test_fable_assignee_runs_via_claude() {
   assert_file_contains "${events}" '^TASK_BOARD_RESULT: done$'
 }
 
+test_codex_sol_assignee_includes_delegation_policy() {
+  local tmp vault state bin prompt_log summary last_message
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  prompt_log="${tmp}/codex-prompt.log"
+  mkdir -p "${bin}"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-152|BOXP-152: codex-sol]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-152 in-progress codex-sol
+
+  PATH="${bin}:$PATH" \
+    CODEX_FAKE_PROMPT_LOG="${prompt_log}" \
+    CODEX_FAKE_MESSAGE='TASK_BOARD_RESULT: done' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-codex-sol.out
+
+  assert_file_contains "${prompt_log}" '^Task Board assignee/agent: codex-sol$'
+  assert_file_contains "${prompt_log}" 'Codex-sol routing policy'
+  assert_file_contains "${prompt_log}" 'Delegate independent investigation, implementation, and verification to lower-cost models whenever practical'
+  assert_file_contains "${vault}/Boards/Task Board.md" '\[\[Tickets/BOXP-152\|BOXP-152: codex-sol\]\].*status::done'
+  assert_file_contains "${vault}/Tickets/BOXP-152.md" '^status: done$'
+  summary="$(find "${state}/runs/BOXP-152" -name summary.edn -print | sort | tail -n 1)"
+  last_message="$(find "${state}/runs/BOXP-152" -name last-message.md -print | sort | tail -n 1)"
+  assert_file_contains "${summary}" ':agent "codex-sol"'
+  assert_file_contains "${last_message}" '^TASK_BOARD_RESULT: done$'
+}
+
 test_unsupported_assignee_is_ignored() {
   local tmp vault state bin codex_log claude_log
   tmp="$(mktemp -d)"
@@ -738,6 +766,7 @@ test_assignee_model_tick_routing() {
 
 test_parallel_codex_runs
 test_fable_assignee_runs_via_claude
+test_codex_sol_assignee_includes_delegation_policy
 test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
 test_review_without_pr_is_blocked


### PR DESCRIPTION
## 概要

codex-sol（および codex-full）は fable と同様に高コストモデルであるため、下位モデルへの委譲を促す方針プロンプトを追加する。

## 変更内容

- `codex-sol-policy-prompt` 関数を追加（`fable-policy-prompt` と同様の構造）
- `codex-sol` および `codex-full` アサイニー実行時にプロンプトに委譲方針を注入
- テストケースを追加

## 委譲方針

- **委譲対象**: 独立した調査・実装・検証タスク（デフォルト委譲先: codex/gpt-5.6-terra）
- **委譲しない**: 委譲オーバーヘッドを下回る小タスク、共有コンテキストや権限が必要なタスク、最終判断が必要なタスク
- **フォールバック**: 失敗時は1回再指示、品質不足・利用不能時は自ら対応。再帰的・無制限な委譲は行わない

Closes #BOXP-90