### PR TITLE
feat(task-board): BOXP-89 non-blocking poll loop for concurrent ticket handling

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -1238,8 +1238,15 @@
       (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))
       (println "All tests passed."))))
 
+(defn drain-in-flight! []
+  (doseq [[ticket-id f] @in-flight-futures]
+    (try @f
+         (catch Exception e
+           (log! (str "error completing " ticket-id ": " (.getMessage e))))))
+  (reset! in-flight-futures {}))
+
 (case (or (first *command-line-args*) "tick")
-  "tick" (tick!)
+  "tick" (do (tick!) (drain-in-flight!) (sync-all!))
   "loop" (loop!)
   "sync" (do (ensure-root!) (sync-all!))
   "test" (run-tests!)

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -1071,27 +1071,56 @@
                    (some? (candidate-action card (ticket-assignee ticket-id)))))
          vec)))
 
+;; Map of ticket-id -> future for currently running process-card! calls.
+;; Persists across tick! invocations so the loop can detect new candidates
+;; without blocking on already-running tickets.
+(def in-flight-futures (atom {}))
+
+(defn collect-completed-futures! []
+  (let [snapshot @in-flight-futures
+        completed (filter (fn [[_id f]] (future-done? f)) snapshot)
+        completed-ids (mapv first completed)]
+    (doseq [[ticket-id f] completed]
+      (try @f
+           (catch Exception e
+             (log! (str "in-flight future for " ticket-id " completed with error: " (.getMessage e))))))
+    (when (seq completed-ids)
+      (swap! in-flight-futures #(apply dissoc % completed-ids)))
+    completed-ids))
+
 (defn tick! []
   (ensure-root!)
   (cleanup-stale-locks!)
   (sync-all!)
-  (let [candidates (candidate-cards)
-        runs (doall
-              (for [card candidates]
-                (future
-                  (log! (str "processing " (:ticket-id card) " from " (:lane card)))
-                  (let [started? (process-card! card)]
-                    (when-not started?
-                      (log! (str "candidate could not start, leaving it for a future tick: " (:ticket-id card))))
-                    {:ticket-id (:ticket-id card)
-                     :started? (boolean started?)}))))
-        results (doall (map deref runs))
-        processed (count (filter :started? results))]
+  (let [done (collect-completed-futures!)
+        in-flight-ids (set (keys @in-flight-futures))
+        candidates (candidate-cards)
+        new-candidates (remove #(contains? in-flight-ids (:ticket-id %)) candidates)]
+    (doseq [card new-candidates]
+      (let [f (future
+                (log! (str "processing " (:ticket-id card) " from " (:lane card)))
+                (let [started? (process-card! card)]
+                  (when-not started?
+                    (log! (str "candidate could not start, leaving it for a future tick: " (:ticket-id card))))
+                  {:ticket-id (:ticket-id card)
+                   :started? (boolean started?)}))]
+        (swap! in-flight-futures assoc (:ticket-id card) f)))
     (sync-all!)
+    (when (seq done)
+      (log! (str "collected " (count done) " completed ticket(s): " (str/join ", " done))))
     (log! (cond
-            (empty? candidates) "no supported-agent-assigned Task Board tickets"
-            (zero? processed) "no supported-agent-assigned Task Board tickets could start"
-            :else (str "processed " processed " supported-agent-assigned Task Board ticket(s) in parallel")))))
+            (empty? candidates)
+            "no supported-agent-assigned Task Board tickets"
+
+            (and (empty? new-candidates) (seq in-flight-ids))
+            (str (count in-flight-ids) " ticket(s) already in flight, no new candidates this tick")
+
+            (empty? new-candidates)
+            "no supported-agent-assigned Task Board tickets could start"
+
+            :else
+            (str "started " (count new-candidates) " new ticket(s), "
+                 (count @in-flight-futures) " total in flight")))))
 
 (defn loop! []
   (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)))
@@ -1140,9 +1169,74 @@
         (do
           (println (str "FAIL: codex-review gate default model expected=gpt-5.6-terra actual=" actual-model))
           (swap! failures conj "codex-review default model"))))
+
+    ;; Test: collect-completed-futures! collects done futures and leaves pending ones
+    (reset! in-flight-futures {})
+    (let [p (promise)
+          f-pending (future @p)
+          f-done (future 42)]
+      (Thread/sleep 50)
+      (swap! in-flight-futures assoc "TEST-DONE" f-done "TEST-PENDING" f-pending)
+      (let [done (collect-completed-futures!)]
+        (cond
+          (not= ["TEST-DONE"] done)
+          (do (println (str "FAIL: collect-completed-futures! done expected=[TEST-DONE] got=" done))
+              (swap! failures conj "collect-completed-futures! done list"))
+
+          (not (contains? @in-flight-futures "TEST-PENDING"))
+          (do (println "FAIL: collect-completed-futures! removed pending future")
+              (swap! failures conj "collect-completed-futures! pending kept"))
+
+          (contains? @in-flight-futures "TEST-DONE")
+          (do (println "FAIL: collect-completed-futures! kept done future")
+              (swap! failures conj "collect-completed-futures! done removed"))
+
+          :else
+          (println "PASS: collect-completed-futures! collects done and keeps pending")))
+      (deliver p :done)
+      @f-pending)
+    (reset! in-flight-futures {})
+
+    ;; Test: tick! starts new candidates alongside already in-flight tickets
+    ;; and does NOT restart in-flight tickets
+    (reset! in-flight-futures {})
+    (let [p-a (promise)
+          f-a (future @p-a)
+          started-ids (atom [])
+          test-candidates [{:ticket-id "TEST-A" :lane "In Progress" :status "in-progress"}
+                           {:ticket-id "TEST-B" :lane "In Progress" :status "in-progress"}]]
+      (swap! in-flight-futures assoc "TEST-A" f-a)
+      (with-redefs [candidate-cards (fn [] test-candidates)
+                    ensure-root! (fn [] nil)
+                    cleanup-stale-locks! (fn [] nil)
+                    sync-all! (fn [] nil)
+                    process-card! (fn [{:keys [ticket-id]}]
+                                    (swap! started-ids conj ticket-id)
+                                    true)]
+        (tick!)
+        ;; Wait for started futures to complete within the with-redefs scope
+        ;; so process-card! is still redefined when futures execute
+        (Thread/sleep 200))
+      (doseq [[_ f] @in-flight-futures]
+        (when (future-done? f) (try @f (catch Exception _))))
+      (cond
+        (not (contains? (set @started-ids) "TEST-B"))
+        (do (println "FAIL: tick! did not start new candidate TEST-B while TEST-A was in flight")
+            (swap! failures conj "tick! starts new candidate alongside in-flight"))
+
+        (contains? (set @started-ids) "TEST-A")
+        (do (println "FAIL: tick! restarted in-flight ticket TEST-A")
+            (swap! failures conj "tick! skips in-flight ticket"))
+
+        :else
+        (println "PASS: tick! starts new candidates without restarting in-flight tickets"))
+      (deliver p-a :done)
+      @f-a)
+    (reset! in-flight-futures {})
+
     (if (seq @failures)
       (do (println (str "FAILED: " (count @failures) " test(s) failed")) (System/exit 1))
-      (println "All assignee model tests passed."))))
+      (println "All tests passed."))))
 
 (case (or (first *command-line-args*) "tick")
   "tick" (tick!)

--- a/docs/project_docs/BOXP-89/plan.md
+++ b/docs/project_docs/BOXP-89/plan.md
@@ -1,0 +1,40 @@
+# BOXP-89: task board runnerが新しく追加されたタスクに即対応するようにしたい
+
+## 問題
+
+現行の `tick!` 関数は、全候補チケットを `future` で起動した後、
+`(doall (map deref runs))` で全 future の完了を待つ。
+`loop!` は `tick!` が戻ってから `sleep` するため、
+実行中のチケットが長時間かかると、その間に追加された新規チケットを次のポーリングまで検出できない。
+
+## 解決方針
+
+`in-flight-futures` atom（`ticket-id -> future` のマップ）を導入し、
+実行中 future をまたいで管理する。
+
+各 `tick!` 呼び出しで：
+1. 完了済み future を回収して `in-flight-futures` から除去する
+2. Task Board を走査して新規候補を取得する
+3. すでに `in-flight-futures` にあるチケットは除外し、新規候補のみ future を起動する
+4. 起動した future を `in-flight-futures` に登録する
+
+`loop!` は `tick!` の完了を待つだけで、future の完了は待たない。
+これにより `CODEX_TASK_BOARD_POLL_SECONDS` ごとに新規チケットを検出できる。
+
+## 変更ファイル
+
+- `docker/codex-workspace/task-board/task_board_runner.bb`
+  - `in-flight-futures` atom を追加
+  - `collect-completed-futures!` 関数を追加
+  - `tick!` を非ブロッキング版に書き換え
+  - `loop!` を簡略化（tick! の完了のみ待つ）
+  - `run-tests!` に新テスト2件を追加
+    - 実行中 future があっても新規候補を起動できることの検証
+    - 実行中チケットが重複起動されないことの検証
+
+## 維持する仕様
+
+- Task Board lane を source of truth とするチケット単位ロック
+- heartbeat、同期、実行結果による lane/frontmatter 更新
+- assignee/lane による候補判定
+- stale lock 回復


### PR DESCRIPTION
## Summary

- `in-flight-futures` atom (ticket-id → future) を追加し、`tick!` をまたいで実行中 future を管理
- `collect-completed-futures!` を追加して、各 tick の先頭で完了済み future を回収
- `tick!` を書き換え：`in-flight-futures` に登録済みのチケットはスキップし、新規候補のみ future を起動して即返却（全 future の完了を待つブロッキングを廃止）
- `loop!` を簡略化（`tick!` の完了のみ待てばよくなったため）
- 新テスト2件追加：`collect-completed-futures!` の動作、`tick!` が in-flight チケットを重複起動せず新規候補を並行起動することの検証

## Test plan

- [x] `bb task_board_runner.bb test` 全テスト通過
- [x] `git diff --check` 問題なし
- [x] 既存の assignee-model マッピングテスト通過

## 対応チケット

BOXP-89

🤖 Generated with [Claude Code](https://claude.com/claude-code)