### PR TITLE
feat(BOXP-88): task board runner で assignee に reasoning level を指定できるようにする

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -20,8 +20,6 @@
 
 (def default-vault "/home/boxp/Documents/obsidian-headless/BOXP")
 (def default-root "/home/boxp/.codex-task-board")
-(def supported-assignees #{"codex" "codex-sol" "codex-full" "codex-terra" "codex-mini" "fable"})
-
 (def assignee->model
   ;; GPT-5.6 performance order: Sol > Terra > Luna.
   ;; codex (default) / codex-terra route to Terra (GPT-5.5-equivalent, cost-efficient default).
@@ -32,6 +30,8 @@
    "codex-full"  "gpt-5.6-sol"
    "codex-terra" "gpt-5.6-terra"
    "codex-mini"  "gpt-5.6-luna"})
+
+(def reasoning-levels #{"minimal" "low" "medium" "high" "xhigh"})
 
 (def board-mutex (Object.))
 (def log-mutex (Object.))
@@ -53,6 +53,23 @@
 
 (defn env [k default]
   (or (System/getenv k) default))
+
+(defn parse-codex-assignee [assignee]
+  (cond
+    (contains? assignee->model assignee)
+    {:base-assignee assignee}
+
+    :else
+    (when-let [[_ base-assignee reasoning-effort]
+               (re-matches #"^(.*)-([^-]+)$" (or assignee ""))]
+      (when (and (contains? assignee->model base-assignee)
+                 (contains? reasoning-levels reasoning-effort))
+        {:base-assignee base-assignee
+         :reasoning-effort reasoning-effort}))))
+
+(defn supported-assignee? [assignee]
+  (or (= "fable" assignee)
+      (some? (parse-codex-assignee assignee))))
 
 (defn root []
   (env "CODEX_TASK_BOARD_ROOT" default-root))
@@ -648,7 +665,7 @@
 
 (defn get-codex-model [assignee env-model]
   (or (when (seq env-model) env-model)
-      (get assignee->model assignee)))
+      (some-> assignee parse-codex-assignee :base-assignee assignee->model)))
 
 (defn codex-model-profile-args
   ([] (codex-model-profile-args nil))
@@ -657,10 +674,14 @@
          env-profile (env "CODEX_TASK_BOARD_PROFILE" nil)]
      (codex-model-profile-args assignee env-model env-profile)))
   ([assignee env-model env-profile]
-   (let [model (get-codex-model assignee env-model)]
+   (let [model (get-codex-model assignee env-model)
+         reasoning-effort (:reasoning-effort (parse-codex-assignee assignee))]
      (cond-> []
        model
        (conj "--model" model)
+
+       reasoning-effort
+       (into ["-c" (str "model_reasoning_effort=" reasoning-effort)])
 
        (seq env-profile)
        (conj "--profile" env-profile)))))
@@ -961,7 +982,7 @@
       {:exit exit :result marker :run-id run :dir (str dir) :last-message last-message})))
 
 (defn candidate-action [{:keys [lane status]} assignee]
-  (when (contains? supported-assignees assignee)
+  (when (supported-assignee? assignee)
     (case status
       "backlog" :groom
       "ready" :implement
@@ -1178,6 +1199,43 @@
           (do
             (println (str "FAIL: " assignee " expected=" expected-model " actual=" actual-model))
             (swap! failures conj assignee)))))
+    (doseq [[base-assignee expected-model] assignee->model
+            reasoning-effort reasoning-levels]
+      (let [assignee (str base-assignee "-" reasoning-effort)
+            args (codex-model-profile-args assignee nil nil)
+            actual-model (arg-value args "--model")
+            actual-reasoning (arg-value args "-c")]
+        (if (and (= actual-model expected-model)
+                 (= actual-reasoning (str "model_reasoning_effort=" reasoning-effort))
+                 (supported-assignee? assignee))
+          (println (str "PASS: " assignee " -> " actual-model ", " actual-reasoning))
+          (do
+            (println (str "FAIL: " assignee " expected model=" expected-model " reasoning level=" reasoning-effort " args=" args))
+            (swap! failures conj assignee)))))
+    (doseq [assignee (keys assignee->model)]
+      (let [args (codex-model-profile-args assignee nil nil)]
+        (if (nil? (arg-value args "-c"))
+          (println (str "PASS: " assignee " keeps Codex reasoning default"))
+          (do
+            (println (str "FAIL: " assignee " unexpectedly overrides reasoning: " args))
+            (swap! failures conj assignee)))))
+    (doseq [[lane status expected-action] [["Backlog" "backlog" :groom]
+                                           ["Ready" "ready" :implement]
+                                           ["In Progress" "in-progress" :implement]
+                                           ["Review" "review" :review-fix]
+                                           ["Blocked" "blocked" :blocked-retry]]]
+      (let [action (candidate-action {:lane lane :status status} "codex-sol-high")]
+        (if (= action expected-action)
+          (println (str "PASS: " lane " recognizes codex-sol-high"))
+          (do
+            (println (str "FAIL: " lane " expected action=" expected-action " actual=" action))
+            (swap! failures conj lane)))))
+    (doseq [assignee ["codex-invalid" "codex-terra-ultra" "unknown-high" "fable-high"]]
+      (if (not (supported-assignee? assignee))
+        (println (str "PASS: unsupported assignee ignored: " assignee))
+        (do
+          (println (str "FAIL: invalid assignee was supported: " assignee))
+          (swap! failures conj assignee))))
     (let [args (codex-model-profile-args "codex-full" "gpt-test-override" nil)
           actual-model (arg-value args "--model")]
       (if (= actual-model "gpt-test-override")

--- a/docker/hermes-agent/skills/obsidian-task-board/SKILL.md
+++ b/docker/hermes-agent/skills/obsidian-task-board/SKILL.md
@@ -117,6 +117,12 @@ The Task Board runner specification is the operational source for lane behavior:
 Projects/codex-task-board-runner/spec.md
 ```
 
+### Codex assignee と reasoning level
+
+既存の `codex`、`codex-sol`、`codex-full`、`codex-terra`、`codex-mini` はそのまま使用できます。これらには必要に応じて `-minimal`、`-low`、`-medium`、`-high`、`-xhigh` を付加できます。例えば `assignee: codex-sol-high` は Sol モデルを選び、Codex CLI に `model_reasoning_effort=high` を明示します。
+
+サフィックスなしの既存名は runner から reasoning を強制せず、Codex の既存設定を使います。未知のベース名または許容外の suffix は実行対象になりません。`fable` は reasoning suffix を受け付けず、従来どおり `fable` のみが有効です。
+
 ## Failure Handling
 
 If the helper refuses a change, report the exact command and error. Common causes are missing ticket files, malformed frontmatter delimiters, missing board lanes, or multiple board cards for one ticket. Prefer `show` and `list --json` to inspect state before retrying.

--- a/docs/project_docs/BOXP-88/plan.md
+++ b/docs/project_docs/BOXP-88/plan.md
@@ -1,0 +1,19 @@
+# BOXP-88: Task Board runner の Codex reasoning level 指定
+
+## Goal
+
+Task Board の `assignee` に既存の Codex アサイン名と reasoning level を組み合わせて指定できるようにし、既存のアサインと環境変数によるモデル・profile 指定の挙動を維持する。
+
+## Plan
+
+1. Codex アサインをベース名と任意の reasoning suffix に解析する共通処理を追加し、supported assignee 判定とモデル解決に使用する。
+2. suffix 指定時だけ `-c model_reasoning_effort=<level>` を Codex CLI 引数に追加し、元のアサイン文字列は run の記録・再試行に保持する。
+3. runner 内蔵テストと fake Codex を使うシェルテストで、全 level、既存名、無効値、起動引数を検証する。
+4. Task Board 操作スキルにアサイン文法と `fable` の対象外を記載する。
+5. 関連テスト、構文チェック、差分チェックを実行し、コミット・push・draft PR を作成する。
+
+## Validation
+
+- `bb docker/codex-workspace/task-board/task_board_runner.bb test`
+- `tests/codex-workspace/task-board-runner-test.sh`
+- `git diff --check`

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -775,7 +775,7 @@ test_assignee_model_routing() {
 
 test_assignee_model_tick_routing() {
   local tmp vault state bin args_log assignee expected_model
-  local pairs=("codex-sol:gpt-5.6-sol" "codex-full:gpt-5.6-sol" "codex-terra:gpt-5.6-terra" "codex-mini:gpt-5.6-luna")
+  local pairs=("codex:gpt-5.6-terra" "codex-sol:gpt-5.6-sol" "codex-full:gpt-5.6-sol" "codex-terra:gpt-5.6-terra" "codex-mini:gpt-5.6-luna")
   for pair in "${pairs[@]}"; do
     assignee="${pair%%:*}"
     expected_model="${pair##*:}"
@@ -791,6 +791,52 @@ test_assignee_model_tick_routing() {
     write_ticket "${vault}" BOXP-500 in-progress "${assignee}"
     PATH="${bin}:$PATH" CODEX_FAKE_ARG_LOG="${args_log}" run_tick "${vault}" "${state}" env >"/tmp/task-board-model-tick-${assignee}.out"
     assert_file_contains "${args_log}" "exec.*--model ${expected_model}"
+    assert_file_not_contains "${args_log}" 'model_reasoning_effort='
+  done
+}
+
+test_assignee_reasoning_tick_routing() {
+  local tmp vault state bin args_log assignee expected_model level
+  local pairs=(
+    "codex-minimal:gpt-5.6-terra:minimal"
+    "codex-sol-low:gpt-5.6-sol:low"
+    "codex-full-medium:gpt-5.6-sol:medium"
+    "codex-terra-high:gpt-5.6-terra:high"
+    "codex-mini-xhigh:gpt-5.6-luna:xhigh"
+  )
+  for pair in "${pairs[@]}"; do
+    IFS=: read -r assignee expected_model level <<<"${pair}"
+    tmp="$(mktemp -d)"
+    vault="${tmp}/vault"
+    state="${tmp}/state"
+    bin="${tmp}/bin"
+    args_log="${tmp}/codex-args.log"
+    mkdir -p "${bin}"
+    make_fake_codex "${bin}"
+    write_board "${vault}" "- [ ] [[Tickets/BOXP-501|BOXP-501: reasoning tick]] #ticket status::in-progress"
+    write_ticket "${vault}" BOXP-501 in-progress "${assignee}"
+    PATH="${bin}:$PATH" CODEX_FAKE_ARG_LOG="${args_log}" run_tick "${vault}" "${state}" env >"/tmp/task-board-reasoning-tick-${assignee}.out"
+    assert_file_contains "${args_log}" "exec.*--model ${expected_model}.*-c model_reasoning_effort=${level}"
+    assert_file_contains "${vault}/Tickets/BOXP-501.md" '^status: done$'
+  done
+}
+
+test_invalid_reasoning_assignees_are_ignored() {
+  local tmp vault state bin args_log assignee
+  local assignees=("codex-terra-ultra" "unknown-high" "fable-high")
+  for assignee in "${assignees[@]}"; do
+    tmp="$(mktemp -d)"
+    vault="${tmp}/vault"
+    state="${tmp}/state"
+    bin="${tmp}/bin"
+    args_log="${tmp}/codex-args.log"
+    mkdir -p "${bin}"
+    make_fake_codex "${bin}"
+    write_board "${vault}" "- [ ] [[Tickets/BOXP-502|BOXP-502: invalid reasoning]] #ticket status::in-progress"
+    write_ticket "${vault}" BOXP-502 in-progress "${assignee}"
+    PATH="${bin}:$PATH" CODEX_FAKE_ARG_LOG="${args_log}" run_tick "${vault}" "${state}" env >"/tmp/task-board-invalid-reasoning-${assignee}.out"
+    [[ ! -e "${args_log}" ]] || fail "expected codex not to start for invalid assignee ${assignee}"
+    [[ ! -d "${state}/runs/BOXP-502" ]] || fail "expected no run directory for invalid assignee ${assignee}"
   done
 }
 
@@ -819,5 +865,7 @@ test_review_gate_retry_limit_blocks
 test_review_gate_pass_after_retry_moves_review
 test_assignee_model_routing
 test_assignee_model_tick_routing
+test_assignee_reasoning_tick_routing
+test_invalid_reasoning_assignees_are_ignored
 
 echo "task-board-runner tests passed"


### PR DESCRIPTION
## Summary

- `<既存Codexアサイン名>-<reasoning-level>` 形式（例: `codex-sol-high`）を supported assignee として認識
- Codex 起動時に `-c model_reasoning_effort=<level>` を自動付加
- 既存アサイン名（`codex`, `codex-sol`, `codex-full`, `codex-terra`, `codex-mini`）は後方互換を維持し、reasoning override を追加しない
- 許容 level: `minimal` / `low` / `medium` / `high` / `xhigh`
- 不正なベース名または許容外 suffix は supported assignee として扱われない
- `fable` は reasoning suffix を受け付けない（従来どおり `fable` のみ有効）

## Changes

- `docker/codex-workspace/task-board/task_board_runner.bb`: `parse-codex-assignee` / `supported-assignee?` 関数を追加し、`codex-model-profile-args` に reasoning effort オプションを追加
- `tests/codex-workspace/task-board-runner-test.sh`: reasoning 付きアサイン・不正アサインのインテグレーションテストを追加
- `docker/hermes-agent/skills/obsidian-task-board/SKILL.md`: アサイン名の文法と reasoning level に関するドキュメントを追記
- `docs/project_docs/BOXP-88/plan.md`: 実装計画を保存

## Test plan

- [x] `bb task_board_runner.bb test` - 全アサインモデルテストPASS
- [x] `bash tests/codex-workspace/task-board-runner-test.sh` - 全インテグレーションテストPASS
- [x] 既存アサイン名の後方互換確認
- [x] 全 reasoning level の解決確認
- [x] 不正サフィックスが supported assignee でないことを確認

Closes #BOXP-88

🤖 Generated with [Claude Code](https://claude.com/claude-code)