### PR TITLE
feat(task-board): 計画 rollout の lock を安全に回収する (BOXP-91)

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -703,10 +703,10 @@
 
 (defn recover-planned-shutdown-locks! []
   (let [markers (read-shutdown-markers)
-        ;; A helper command running inside the terminating Pod must never reclaim that
-        ;; Pod's own locks. Recreate gives the replacement Pod a different UID, so only
-        ;; another owner is allowed to consume a planned-shutdown marker.
-        recoverable-markers (remove current-owner-marker? markers)]
+        ;; The runner that wrote a marker must not reclaim its own locks while it is
+        ;; draining. A restarted runner can reuse the Pod UID, though, so a different
+        ;; instance under the same owner must be allowed to recover the old instance.
+        recoverable-markers (remove current-runner-marker? markers)]
     (doseq [marker recoverable-markers]
       (recover-planned-shutdown-marker! marker))))
 

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -74,6 +74,31 @@
 (defn root []
   (env "CODEX_TASK_BOARD_ROOT" default-root))
 
+(defn owner-id []
+  (env "CODEX_TASK_BOARD_OWNER_ID"
+       (or (System/getenv "HOSTNAME") "unknown-owner")))
+
+(def runner-instance-id
+  (env "CODEX_TASK_BOARD_RUNNER_INSTANCE_ID"
+       (str (java.util.UUID/randomUUID))))
+
+(defn safe-owner-id [value]
+  (str/replace (str value) #"[^A-Za-z0-9._-]" "_"))
+
+(defn owners-dir []
+  (fs/path (root) "owners"))
+
+(defn terminating-owners-dir []
+  (fs/path (root) "terminating-owners"))
+
+(defn owner-state-path
+  ([] (owner-state-path (owner-id)))
+  ([value] (fs/path (owners-dir) (str (safe-owner-id value) ".edn"))))
+
+(defn shutdown-marker-path
+  ([] (shutdown-marker-path (owner-id)))
+  ([value] (fs/path (terminating-owners-dir) (str (safe-owner-id value) ".edn"))))
+
 (defn vault []
   (env "CODEX_TASK_BOARD_VAULT" default-vault))
 
@@ -104,7 +129,9 @@
 (defn ensure-root! []
   (doseq [path [(root)
                 (fs/path (root) "locks")
-                (fs/path (root) "runs")]]
+                (fs/path (root) "runs")
+                (owners-dir)
+                (terminating-owners-dir)]]
     (fs/create-dirs path)))
 
 (defn read-edn-file [path fallback]
@@ -115,6 +142,41 @@
 (defn write-edn-file! [path value]
   (fs/create-dirs (fs/parent path))
   (spit (str path) (str (pr-str value) "\n")))
+
+(defn activate-owner! []
+  (write-edn-file! (owner-state-path)
+                   {:owner-id (owner-id)
+                    :instance-id runner-instance-id
+                    :host (or (System/getenv "HOSTNAME") "unknown")
+                    :pid (.pid (java.lang.ProcessHandle/current))
+                    :started-at (now-str)}))
+
+(defn prepare-shutdown! []
+  (ensure-root!)
+  (let [active (try
+                 (read-edn-file (owner-state-path) {})
+                 (catch Exception _ {}))
+        marker {:owner-id (owner-id)
+                :instance-id (:instance-id active)
+                :host (or (:host active) (System/getenv "HOSTNAME") "unknown")
+                :requested-at (now-str)}]
+    (write-edn-file! (shutdown-marker-path) marker)
+    (log! (str "prepared shutdown for owner " (:owner-id marker)
+               ", instance=" (or (:instance-id marker) "unknown")))
+    marker))
+
+(defn current-runner-marker? [marker]
+  (and (= (owner-id) (:owner-id marker))
+       (= runner-instance-id (:instance-id marker))))
+
+(defn current-owner-marker? [marker]
+  (= (owner-id) (:owner-id marker)))
+
+(defn draining? []
+  (try
+    (when (fs/exists? (shutdown-marker-path))
+      (current-runner-marker? (read-edn-file (shutdown-marker-path) {})))
+    (catch Exception _ false)))
 
 (defn read-lines [path]
   (if (fs/exists? path)
@@ -335,7 +397,26 @@
 
 (defn stale-lock? [lock]
   (> (seconds-since (:heartbeat-at lock))
-     (Long/parseLong (env "CODEX_TASK_BOARD_LOCK_STALE_SECONDS" "1800"))))
+     (Long/parseLong (env "CODEX_TASK_BOARD_LOCK_STALE_SECONDS" "180"))))
+
+(defn current-runner-lock? [lock]
+  (and (= (owner-id) (:owner-id lock))
+       (= runner-instance-id (:owner-instance-id lock))))
+
+(defn same-ticket-lock? [expected actual]
+  (and (= (:ticket expected) (:ticket actual))
+       (= (:run-id expected) (:run-id actual))
+       (= (:owner-id expected) (:owner-id actual))
+       (= (:owner-instance-id expected) (:owner-instance-id actual))))
+
+(defn delete-lock-if-matches! [ticket-id expected]
+  (locking (ticket-file-mutex ticket-id)
+    (let [path (lock-path ticket-id)
+          actual (try
+                   (read-edn-file path nil)
+                   (catch Exception _ nil))]
+      (when (same-ticket-lock? expected actual)
+        (fs/delete-if-exists path)))))
 
 (defn mark-run! [ticket-id run-id status extra]
   (let [summary (merge {:ticket ticket-id
@@ -345,14 +426,25 @@
                        extra)]
     (write-edn-file! (fs/path (run-dir ticket-id run-id) "summary.edn") summary)))
 
-(defn close-stale-lock! [ticket-id lock]
-  (when-let [stale-run (:run-id lock)]
-    (mark-run! ticket-id stale-run :interrupted
-               {:reason "heartbeat timeout"
+(defn close-interrupted-lock! [ticket-id lock reason note]
+  (when-let [interrupted-run (:run-id lock)]
+    (mark-run! ticket-id interrupted-run :interrupted
+               {:reason reason
                 :previous-lock lock})
     (when (fs/exists? (ticket-path ticket-id))
-      (append-note! ticket-id (str "Codex run " stale-run " was marked interrupted after heartbeat timeout."))))
-  (fs/delete-if-exists (lock-path ticket-id)))
+      (append-note! ticket-id (str "Codex run " interrupted-run " " note))))
+  (delete-lock-if-matches! ticket-id lock))
+
+(defn close-stale-lock! [ticket-id lock]
+  (close-interrupted-lock! ticket-id lock
+                           "heartbeat timeout"
+                           "was marked interrupted after heartbeat timeout."))
+
+(defn close-planned-shutdown-lock! [ticket-id lock marker]
+  (close-interrupted-lock! ticket-id lock
+                           "planned workspace shutdown"
+                           (str "was marked interrupted after planned workspace shutdown of owner "
+                                (:owner-id marker) ".")))
 
 (defn close-corrupt-lock! [ticket-id path error]
   (log! (str "closing corrupt lock: " ticket-id " (" (.getMessage error) ")"))
@@ -370,49 +462,120 @@
               :let [ticket-id (lock-ticket-id path)]
               :when ticket-id]
         (try
-          (let [lock (read-edn-file path {})]
-            (when (stale-lock? lock)
-              (log! (str "closing stale lock: " ticket-id))
-              (close-stale-lock! ticket-id lock)))
+          (locking (ticket-file-mutex ticket-id)
+            (let [lock (read-edn-file path {})]
+              (when (and (stale-lock? lock)
+                         (not (current-runner-lock? lock)))
+                (log! (str "closing stale lock: " ticket-id))
+                (close-stale-lock! ticket-id lock))))
           (catch Exception e
             (close-corrupt-lock! ticket-id path e)))))))
 
-(defn acquire-lock! [ticket-id action lane]
-  (let [path (lock-path ticket-id)
-        run (run-id)
-        lock {:ticket ticket-id
-              :run-id run
-              :action action
-              :lane lane
-              :host (or (System/getenv "HOSTNAME") "unknown")
-              :pid (.pid (java.lang.ProcessHandle/current))
-              :started-at (now-str)
-              :heartbeat-at (now-str)}]
-    (fs/create-dirs (fs/parent path))
-    (if (.createNewFile (io/file (str path)))
-      (do
-        (write-edn-file! path lock)
-        lock)
-      (try
-        (let [existing (read-edn-file path {})]
-          (if (stale-lock? existing)
-            (do
-              (close-stale-lock! ticket-id existing)
-              (acquire-lock! ticket-id action lane))
-            (do
-              (log! (str "ticket already locked: " ticket-id))
-              nil)))
-        (catch Exception e
-          (close-corrupt-lock! ticket-id path e)
-          (acquire-lock! ticket-id action lane))))))
+(defn read-shutdown-markers []
+  (let [dir (terminating-owners-dir)]
+    (if-not (fs/exists? dir)
+      []
+      (reduce (fn [markers path]
+                (try
+                  (let [marker (read-edn-file path {})]
+                    (if (and (seq (:owner-id marker))
+                             (seq (:instance-id marker)))
+                      (conj markers (assoc marker :path path))
+                      (do
+                        (log! (str "discarding incomplete shutdown marker: " path))
+                        (fs/delete-if-exists path)
+                        markers)))
+                  (catch Exception e
+                    (log! (str "discarding corrupt shutdown marker " path ": " (.getMessage e)))
+                    (fs/delete-if-exists path)
+                    markers)))
+              []
+              (fs/list-dir dir)))))
 
-(defn release-lock! [ticket-id]
-  (fs/delete-if-exists (lock-path ticket-id)))
+(defn matching-shutdown-marker [markers lock]
+  (first (filter #(and (= (:owner-id %) (:owner-id lock))
+                       (= (:instance-id %) (:owner-instance-id lock)))
+                 markers)))
+
+(defn recover-planned-shutdown-locks! []
+  (let [markers (read-shutdown-markers)
+        ;; A helper command running inside the terminating Pod must never reclaim that
+        ;; Pod's own locks. Recreate gives the replacement Pod a different UID, so only
+        ;; another owner is allowed to consume a planned-shutdown marker.
+        recoverable-markers (remove current-owner-marker? markers)
+        locks-dir (fs/path (root) "locks")]
+    (when (and (seq recoverable-markers) (fs/exists? locks-dir))
+      (doseq [path (fs/list-dir locks-dir)
+              :let [ticket-id (lock-ticket-id path)]
+              :when ticket-id]
+        (try
+          (locking (ticket-file-mutex ticket-id)
+            (let [lock (read-edn-file path {})]
+              (when-let [marker (matching-shutdown-marker recoverable-markers lock)]
+                (log! (str "closing lock from planned owner shutdown: " ticket-id
+                           " owner=" (:owner-id marker)))
+                (close-planned-shutdown-lock! ticket-id lock marker))))
+          (catch Exception e
+            (close-corrupt-lock! ticket-id path e)))))
+    (doseq [marker recoverable-markers]
+      (fs/delete-if-exists (:path marker))
+      (fs/delete-if-exists (owner-state-path (:owner-id marker))))))
+
+(defn recover-locks! []
+  (ensure-root!)
+  (recover-planned-shutdown-locks!)
+  (cleanup-stale-locks!))
+
+(defn acquire-lock! [ticket-id action lane]
+  (when-not (draining?)
+    (locking (ticket-file-mutex ticket-id)
+      (let [path (lock-path ticket-id)
+            run (run-id)
+            lock {:ticket ticket-id
+                  :run-id run
+                  :action action
+                  :lane lane
+                  :owner-id (owner-id)
+                  :owner-instance-id runner-instance-id
+                  :host (or (System/getenv "HOSTNAME") "unknown")
+                  :pid (.pid (java.lang.ProcessHandle/current))
+                  :started-at (now-str)
+                  :heartbeat-at (now-str)}]
+        (fs/create-dirs (fs/parent path))
+        (if (.createNewFile (io/file (str path)))
+          (do
+            (write-edn-file! path lock)
+            lock)
+          (try
+            (let [existing (read-edn-file path {})]
+              (if (and (stale-lock? existing)
+                       (not (current-runner-lock? existing)))
+                (do
+                  (close-stale-lock! ticket-id existing)
+                  (acquire-lock! ticket-id action lane))
+                (do
+                  (log! (str "ticket already locked: " ticket-id))
+                  nil)))
+            (catch Exception e
+              (close-corrupt-lock! ticket-id path e)
+              (acquire-lock! ticket-id action lane))))))))
+
+(defn release-lock! [ticket-id lock]
+  (delete-lock-if-matches! ticket-id lock))
 
 (defn heartbeat! [ticket-id lock stop?]
   (future
     (while (not @stop?)
-      (write-edn-file! (lock-path ticket-id) (assoc lock :heartbeat-at (now-str)))
+      (locking (ticket-file-mutex ticket-id)
+        (let [path (lock-path ticket-id)
+              existing (try
+                         (read-edn-file path nil)
+                         (catch Exception _ nil))]
+          (if (same-ticket-lock? lock existing)
+            (write-edn-file! path (assoc existing :heartbeat-at (now-str)))
+            (do
+              (log! (str "heartbeat stopped because lock ownership changed: " ticket-id))
+              (reset! stop? true)))))
       (Thread/sleep 1000))))
 
 (defn previous-run-summaries [ticket-id]
@@ -1099,7 +1262,7 @@
               (finally
                 (reset! stop? true)
                 @hb
-                (release-lock! ticket-id)))))))))
+                (release-lock! ticket-id lock)))))))))
 
 (defn ticket-assignee [ticket-id]
   (let [path (ticket-path ticket-id)]
@@ -1134,41 +1297,46 @@
     completed-ids))
 
 (defn tick! []
-  (ensure-root!)
-  (cleanup-stale-locks!)
-  (sync-all!)
-  (let [done (collect-completed-futures!)
-        in-flight-ids (set (keys @in-flight-futures))
-        candidates (candidate-cards)
-        new-candidates (remove #(contains? in-flight-ids (:ticket-id %)) candidates)]
-    (doseq [card new-candidates]
-      (let [f (future
-                (log! (str "processing " (:ticket-id card) " from " (:lane card)))
-                (let [started? (process-card! card)]
-                  (when-not started?
-                    (log! (str "candidate could not start, leaving it for a future tick: " (:ticket-id card))))
-                  {:ticket-id (:ticket-id card)
-                   :started? (boolean started?)}))]
-        (swap! in-flight-futures assoc (:ticket-id card) f)))
-    (sync-all!)
-    (when (seq done)
-      (log! (str "collected " (count done) " completed ticket(s): " (str/join ", " done))))
-    (log! (cond
-            (empty? candidates)
-            "no supported-agent-assigned Task Board tickets"
+  (recover-locks!)
+  (if (draining?)
+    (log! (str "runner owner " (owner-id) " is draining; not accepting new tickets"))
+    (do
+      (sync-all!)
+      (let [done (collect-completed-futures!)
+            in-flight-ids (set (keys @in-flight-futures))
+            candidates (candidate-cards)
+            new-candidates (remove #(contains? in-flight-ids (:ticket-id %)) candidates)]
+        (doseq [card new-candidates]
+          (let [f (future
+                    (log! (str "processing " (:ticket-id card) " from " (:lane card)))
+                    (let [started? (process-card! card)]
+                      (when-not started?
+                        (log! (str "candidate could not start, leaving it for a future tick: " (:ticket-id card))))
+                      {:ticket-id (:ticket-id card)
+                       :started? (boolean started?)}))]
+            (swap! in-flight-futures assoc (:ticket-id card) f)))
+        (sync-all!)
+        (when (seq done)
+          (log! (str "collected " (count done) " completed ticket(s): " (str/join ", " done))))
+        (log! (cond
+                (empty? candidates)
+                "no supported-agent-assigned Task Board tickets"
 
-            (and (empty? new-candidates) (seq in-flight-ids))
-            (str (count in-flight-ids) " ticket(s) already in flight, no new candidates this tick")
+                (and (empty? new-candidates) (seq in-flight-ids))
+                (str (count in-flight-ids) " ticket(s) already in flight, no new candidates this tick")
 
-            (empty? new-candidates)
-            "no supported-agent-assigned Task Board tickets could start"
+                (empty? new-candidates)
+                "no supported-agent-assigned Task Board tickets could start"
 
-            :else
-            (str "started " (count new-candidates) " new ticket(s), "
-                 (count @in-flight-futures) " total in flight")))))
+                :else
+                (str "started " (count new-candidates) " new ticket(s), "
+                     (count @in-flight-futures) " total in flight")))))))
 
 (defn loop! []
-  (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)))
+  (recover-locks!)
+  (activate-owner!)
+  (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)
+             ", owner=" (owner-id) ", instance=" runner-instance-id))
   (loop []
     (try
       (tick!)
@@ -1179,7 +1347,7 @@
     (recur)))
 
 (defn usage []
-  (println "usage: task_board_runner.bb <tick|loop|sync>")
+  (println "usage: task_board_runner.bb <tick|loop|sync|prepare-shutdown|recover>")
   (System/exit 2))
 
 (defn arg-value [args flag]
@@ -1289,8 +1457,8 @@
                            {:ticket-id "TEST-B" :lane "In Progress" :status "in-progress"}]]
       (swap! in-flight-futures assoc "TEST-A" f-a)
       (with-redefs [candidate-cards (fn [] test-candidates)
-                    ensure-root! (fn [] nil)
-                    cleanup-stale-locks! (fn [] nil)
+                    recover-locks! (fn [] nil)
+                    draining? (fn [] false)
                     sync-all! (fn [] nil)
                     process-card! (fn [{:keys [ticket-id]}]
                                     (swap! started-ids conj ticket-id)
@@ -1380,8 +1548,10 @@
   (reset! in-flight-futures {}))
 
 (case (or (first *command-line-args*) "tick")
-  "tick" (do (tick!) (drain-in-flight!) (sync-all!))
+  "tick" (do (recover-locks!) (activate-owner!) (tick!) (drain-in-flight!) (sync-all!))
   "loop" (loop!)
   "sync" (do (ensure-root!) (sync-all!))
+  "prepare-shutdown" (prepare-shutdown!)
+  "recover" (recover-locks!)
   "test" (run-tests!)
   (usage))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -42,9 +42,16 @@
 (def ^:private ticket-lock-stripes
   (vec (repeatedly 256 #(Object.))))
 
+(def ^:private owner-lock-stripes
+  (vec (repeatedly 256 #(Object.))))
+
 (defn ticket-mutex [ticket-id]
   (nth ticket-lock-stripes
        (Math/floorMod (.hashCode (str ticket-id)) (count ticket-lock-stripes))))
+
+(defn owner-mutex [owner]
+  (nth owner-lock-stripes
+       (Math/floorMod (.hashCode (str owner)) (count owner-lock-stripes))))
 
 (defn log! [message]
   (locking log-mutex
@@ -93,6 +100,9 @@
 (defn lock-guards-dir []
   (fs/path (root) "lock-guards"))
 
+(defn owner-lock-guards-dir []
+  (fs/path (root) "owner-lock-guards"))
+
 (defn owner-state-path
   ([] (owner-state-path (owner-id)))
   ([value] (fs/path (owners-dir) (str (safe-owner-id value) ".edn"))))
@@ -100,6 +110,21 @@
 (defn shutdown-marker-path
   ([] (shutdown-marker-path (owner-id)))
   ([value] (fs/path (terminating-owners-dir) (str (safe-owner-id value) ".edn"))))
+
+(defn owner-lock-guard-path [value]
+  (fs/path (owner-lock-guards-dir) (str (safe-owner-id value) ".lock")))
+
+(defn with-owner-lock-guard [value f]
+  ;; Planned-shutdown marker changes and every lock acquisition for an owner must
+  ;; share one cross-process critical section. Ticket guards cannot close the gap
+  ;; between a directory-wide rescan and deleting the owner marker.
+  (let [guard-key (safe-owner-id value)]
+    (locking (owner-mutex guard-key)
+      (fs/create-dirs (owner-lock-guards-dir))
+      (with-open [file (java.io.RandomAccessFile. (str (owner-lock-guard-path guard-key)) "rw")
+                  channel (.getChannel file)]
+        (let [_file-lock (.lock channel)]
+          (f))))))
 
 (defn vault []
   (env "CODEX_TASK_BOARD_VAULT" default-vault))
@@ -141,7 +166,8 @@
                 (fs/path (root) "runs")
                 (owners-dir)
                 (terminating-owners-dir)
-                (lock-guards-dir)]]
+                (lock-guards-dir)
+                (owner-lock-guards-dir)]]
     (fs/create-dirs path)))
 
 (defn read-edn-file [path fallback]
@@ -154,26 +180,40 @@
   (spit (str path) (str (pr-str value) "\n")))
 
 (defn activate-owner! []
-  (write-edn-file! (owner-state-path)
-                   {:owner-id (owner-id)
-                    :instance-id runner-instance-id
-                    :host (or (System/getenv "HOSTNAME") "unknown")
-                    :pid (.pid (java.lang.ProcessHandle/current))
-                    :started-at (now-str)}))
+  (with-owner-lock-guard
+   (owner-id)
+   #(write-edn-file! (owner-state-path)
+                     {:owner-id (owner-id)
+                      :instance-id runner-instance-id
+                      :status :active
+                      :host (or (System/getenv "HOSTNAME") "unknown")
+                      :pid (.pid (java.lang.ProcessHandle/current))
+                      :started-at (now-str)})))
 
 (defn prepare-shutdown! []
   (ensure-root!)
-  (let [active (try
-                 (read-edn-file (owner-state-path) {})
-                 (catch Exception _ {}))
-        marker {:owner-id (owner-id)
-                :instance-id (:instance-id active)
-                :host (or (:host active) (System/getenv "HOSTNAME") "unknown")
-                :requested-at (now-str)}]
-    (write-edn-file! (shutdown-marker-path) marker)
-    (log! (str "prepared shutdown for owner " (:owner-id marker)
-               ", instance=" (or (:instance-id marker) "unknown")))
-    marker))
+  (with-owner-lock-guard
+   (owner-id)
+   (fn []
+     (let [active (try
+                    (read-edn-file (owner-state-path) {})
+                    (catch Exception _ {}))
+           instance (or (:instance-id active) runner-instance-id)
+           requested-at (now-str)
+           marker {:owner-id (owner-id)
+                   :instance-id instance
+                   :host (or (:host active) (System/getenv "HOSTNAME") "unknown")
+                   :requested-at requested-at}]
+       (write-edn-file! (owner-state-path)
+                        (merge active
+                               {:owner-id (owner-id)
+                                :instance-id instance
+                                :status :terminating
+                                :shutdown-requested-at requested-at}))
+       (write-edn-file! (shutdown-marker-path) marker)
+       (log! (str "prepared shutdown for owner " (:owner-id marker)
+                  ", instance=" (or (:instance-id marker) "unknown")))
+       marker))))
 
 (def shutdown-hook-installed? (atom false))
 
@@ -197,10 +237,16 @@
 (defn current-owner-marker? [marker]
   (= (owner-id) (:owner-id marker)))
 
+(defn stopping-owner-state? [state]
+  (and (= (owner-id) (:owner-id state))
+       (contains? #{:terminating :terminated} (:status state))))
+
 (defn draining? []
   (try
-    (when (fs/exists? (shutdown-marker-path))
-      (current-runner-marker? (read-edn-file (shutdown-marker-path) {})))
+    (or (when (fs/exists? (shutdown-marker-path))
+          (current-owner-marker? (read-edn-file (shutdown-marker-path) {})))
+        (when (fs/exists? (owner-state-path))
+          (stopping-owner-state? (read-edn-file (owner-state-path) {}))))
     (catch Exception _ false)))
 
 (defn read-lines [path]
@@ -505,6 +551,9 @@
 (defn lock-ticket-id [path]
   (second (re-find #"(BOXP-\d+)\.edn$" (str path))))
 
+(defn shutdown-marker-owner-key [path]
+  (str/replace (str (.getFileName (fs/path path))) #"\.edn$" ""))
+
 (defn cleanup-stale-locks! []
   (let [locks-dir (fs/path (root) "locks")]
     (when (fs/exists? locks-dir)
@@ -528,19 +577,22 @@
     (if-not (fs/exists? dir)
       []
       (reduce (fn [markers path]
-                (try
-                  (let [marker (read-edn-file path {})]
-                    (if (and (seq (:owner-id marker))
-                             (seq (:instance-id marker)))
-                      (conj markers (assoc marker :path path))
-                      (do
-                        (log! (str "discarding incomplete shutdown marker: " path))
-                        (fs/delete-if-exists path)
-                        markers)))
-                  (catch Exception e
-                    (log! (str "discarding corrupt shutdown marker " path ": " (.getMessage e)))
-                    (fs/delete-if-exists path)
-                    markers)))
+                (with-owner-lock-guard
+                 (shutdown-marker-owner-key path)
+                 (fn []
+                   (try
+                     (let [marker (read-edn-file path {})]
+                       (if (and (seq (:owner-id marker))
+                                (seq (:instance-id marker)))
+                         (conj markers (assoc marker :path path))
+                         (do
+                           (log! (str "discarding incomplete shutdown marker: " path))
+                           (fs/delete-if-exists path)
+                           markers)))
+                     (catch Exception e
+                       (log! (str "discarding corrupt shutdown marker " path ": " (.getMessage e)))
+                       (fs/delete-if-exists path)
+                       markers)))))
               []
               (fs/list-dir dir)))))
 
@@ -548,6 +600,28 @@
   (first (filter #(and (= (:owner-id %) (:owner-id lock))
                        (= (:instance-id %) (:owner-instance-id lock)))
                  markers)))
+
+(defn same-shutdown-marker? [expected actual]
+  (and (= (:owner-id expected) (:owner-id actual))
+       (= (:instance-id expected) (:instance-id actual))
+       (= (:requested-at expected) (:requested-at actual))))
+
+(defn owner-instance-for-lock-under-guard []
+  (let [state (try
+                (read-edn-file (owner-state-path) {})
+                (catch Exception _ {}))]
+    (if (and (= (owner-id) (:owner-id state))
+             (seq (:instance-id state))
+             (not (contains? #{:terminating :terminated} (:status state))))
+      (:instance-id state)
+      runner-instance-id)))
+
+(defn owner-accepting-locks-under-guard? []
+  (let [state (try
+                (read-edn-file (owner-state-path) {})
+                (catch Exception _ {}))]
+    (and (not (fs/exists? (shutdown-marker-path)))
+         (not (stopping-owner-state? state)))))
 
 (defn matching-shutdown-lock-exists? [marker]
   (let [locks-dir (fs/path (root) "locks")]
@@ -564,45 +638,77 @@
                          (catch Exception _ false))))))
                 (fs/list-dir locks-dir))))))
 
+(defn retire-owner-under-guard! [marker]
+  (let [path (owner-state-path (:owner-id marker))
+        state (try
+                (read-edn-file path {})
+                (catch Exception _ {}))]
+    ;; Do not overwrite a newer instance if an owner ID was unexpectedly reused.
+    (when (or (empty? state)
+              (= (:instance-id marker) (:instance-id state)))
+      (write-edn-file! path
+                       (merge state
+                              {:owner-id (:owner-id marker)
+                               :instance-id (:instance-id marker)
+                               :status :terminated
+                               :terminated-at (now-str)}))
+      true)))
+
+(defn recover-planned-shutdown-marker! [marker]
+  (with-owner-lock-guard
+   (:owner-id marker)
+   (fn []
+     ;; The marker may have been replaced while marker paths were enumerated. Only
+     ;; consume the exact generation observed by this recovery pass.
+     (let [current-marker (try
+                            (read-edn-file (:path marker) {})
+                            (catch Exception _ {}))
+           recovered? (atom false)
+           locks-dir (fs/path (root) "locks")]
+       (when (same-shutdown-marker? marker current-marker)
+         (when (fs/exists? locks-dir)
+           (doseq [path (fs/list-dir locks-dir)
+                   :let [ticket-id (lock-ticket-id path)]
+                   :when ticket-id]
+             (with-ticket-lock-guard
+              ticket-id
+              (fn []
+                (try
+                  (let [lock (read-edn-file path {})]
+                    (when (matching-shutdown-marker [marker] lock)
+                      (log! (str "closing lock from planned owner shutdown: " ticket-id
+                                 " owner=" (:owner-id marker)))
+                      (when (close-planned-shutdown-lock! ticket-id lock marker)
+                        (reset! recovered? true))))
+                  (catch Exception e
+                    (close-corrupt-lock! ticket-id path e)))))))
+         ;; Give deterministic black-box tests a point to create a second matching lock
+         ;; after the first directory scan but before the final guarded recheck.
+         (when @recovered?
+           (when-let [signal-path (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_SIGNAL")]
+             (spit signal-path "ready\n"))
+           (when-let [hold-ms (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_MILLIS")]
+             (Thread/sleep (Long/parseLong hold-ms))))
+         ;; Lock creation for this owner takes the same owner guard. Marking the owner
+         ;; terminated before deleting the marker also prevents a waiter from creating
+         ;; a lock immediately after this critical section ends.
+         (when (and @recovered?
+                    (not (matching-shutdown-lock-exists? marker))
+                    (same-shutdown-marker? marker
+                                           (try
+                                             (read-edn-file (:path marker) {})
+                                             (catch Exception _ {})))
+                    (retire-owner-under-guard! marker))
+           (fs/delete-if-exists (:path marker))))))))
+
 (defn recover-planned-shutdown-locks! []
   (let [markers (read-shutdown-markers)
         ;; A helper command running inside the terminating Pod must never reclaim that
         ;; Pod's own locks. Recreate gives the replacement Pod a different UID, so only
         ;; another owner is allowed to consume a planned-shutdown marker.
-        recoverable-markers (remove current-owner-marker? markers)
-        recovered-marker-paths (atom #{})
-        locks-dir (fs/path (root) "locks")]
-    (when (and (seq recoverable-markers) (fs/exists? locks-dir))
-      (doseq [path (fs/list-dir locks-dir)
-              :let [ticket-id (lock-ticket-id path)]
-              :when ticket-id]
-        (with-ticket-lock-guard
-         ticket-id
-         (fn []
-          (try
-            (let [lock (read-edn-file path {})]
-              (when-let [marker (matching-shutdown-marker recoverable-markers lock)]
-                (log! (str "closing lock from planned owner shutdown: " ticket-id
-                           " owner=" (:owner-id marker)))
-                (when (close-planned-shutdown-lock! ticket-id lock marker)
-                  (swap! recovered-marker-paths conj (:path marker)))))
-            (catch Exception e
-              (close-corrupt-lock! ticket-id path e)))))))
-    ;; Give deterministic black-box tests a point to create a second matching lock
-    ;; after the first directory scan but before marker cleanup.
-    (when (seq @recovered-marker-paths)
-      (when-let [signal-path (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_SIGNAL")]
-        (spit signal-path "ready\n"))
-      (when-let [hold-ms (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_MILLIS")]
-        (Thread/sleep (Long/parseLong hold-ms))))
-    ;; Keep unmatched markers and recovered markers that still have another matching
-    ;; lock. A lock may appear late in the shared directory enumeration; deleting its
-    ;; owner marker would defer it to the heartbeat timeout instead of the next scan.
-    (doseq [marker recoverable-markers
-            :when (contains? @recovered-marker-paths (:path marker))
-            :when (not (matching-shutdown-lock-exists? marker))]
-      (fs/delete-if-exists (:path marker))
-      (fs/delete-if-exists (owner-state-path (:owner-id marker))))))
+        recoverable-markers (remove current-owner-marker? markers)]
+    (doseq [marker recoverable-markers]
+      (recover-planned-shutdown-marker! marker))))
 
 (defn recover-locks! []
   (ensure-root!)
@@ -615,44 +721,47 @@
     lock))
 
 (defn acquire-lock! [ticket-id action lane]
-  (when-not (draining?)
-    (with-ticket-lock-guard
-     ticket-id
-     (fn []
-      (let [path (lock-path ticket-id)
-            run (run-id)
-            lock {:ticket ticket-id
-                  :run-id run
-                  :action action
-                  :lane lane
-                  :owner-id (owner-id)
-                  :owner-instance-id runner-instance-id
-                  :host (or (System/getenv "HOSTNAME") "unknown")
-                  :pid (.pid (java.lang.ProcessHandle/current))
-                  :started-at (now-str)
-                  :heartbeat-at (now-str)}]
-        (fs/create-dirs (fs/parent path))
-        (if-let [created (create-lock-under-guard! path lock)]
-          created
-          (try
-            (let [existing (read-edn-file path {})]
-              (if (and (stale-lock? existing)
-                       (not (current-runner-lock? existing)))
-                (do
-                  (close-stale-lock! ticket-id existing)
-                  (or (create-lock-under-guard! path lock)
-                      (do
-                        (log! (str "ticket lock changed while recovering: " ticket-id))
-                        nil)))
-                (do
-                  (log! (str "ticket already locked: " ticket-id))
-                  nil)))
-            (catch Exception e
-              (close-corrupt-lock! ticket-id path e)
-              (or (create-lock-under-guard! path lock)
-                  (do
-                    (log! (str "ticket lock changed while clearing corruption: " ticket-id))
-                    nil))))))))))
+  (with-owner-lock-guard
+   (owner-id)
+   (fn []
+     (when (owner-accepting-locks-under-guard?)
+       (with-ticket-lock-guard
+        ticket-id
+        (fn []
+         (let [path (lock-path ticket-id)
+               run (run-id)
+               lock {:ticket ticket-id
+                     :run-id run
+                     :action action
+                     :lane lane
+                     :owner-id (owner-id)
+                     :owner-instance-id (owner-instance-for-lock-under-guard)
+                     :host (or (System/getenv "HOSTNAME") "unknown")
+                     :pid (.pid (java.lang.ProcessHandle/current))
+                     :started-at (now-str)
+                     :heartbeat-at (now-str)}]
+           (fs/create-dirs (fs/parent path))
+           (if-let [created (create-lock-under-guard! path lock)]
+             created
+             (try
+               (let [existing (read-edn-file path {})]
+                 (if (and (stale-lock? existing)
+                          (not (current-runner-lock? existing)))
+                   (do
+                     (close-stale-lock! ticket-id existing)
+                     (or (create-lock-under-guard! path lock)
+                         (do
+                           (log! (str "ticket lock changed while recovering: " ticket-id))
+                           nil)))
+                   (do
+                     (log! (str "ticket already locked: " ticket-id))
+                     nil)))
+               (catch Exception e
+                 (close-corrupt-lock! ticket-id path e)
+                 (or (create-lock-under-guard! path lock)
+                     (do
+                       (log! (str "ticket lock changed while clearing corruption: " ticket-id))
+                       nil))))))))))))
 
 (defn release-lock! [ticket-id lock]
   (delete-lock-if-matches! ticket-id lock))

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -1538,11 +1538,11 @@
                      (count @in-flight-futures) " total in flight")))))))
 
 (defn loop! []
+  ;; Register before recovery or owner activation so direct SIGTERM during startup
+  ;; can still persist the planned-shutdown marker.
+  (install-shutdown-hook!)
   (recover-locks!)
   (activate-owner!)
-  ;; preStop is the explicit deployment contract. The process-level hook preserves
-  ;; the same owner marker when the runner receives SIGTERM directly.
-  (install-shutdown-hook!)
   (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)
              ", owner=" (owner-id) ", instance=" runner-instance-id))
   (loop []
@@ -1564,6 +1564,21 @@
 
 (defn run-tests! []
   (let [failures (atom [])]
+    (let [calls (atom [])]
+      (try
+        (with-redefs [install-shutdown-hook! #(swap! calls conj :install-shutdown-hook)
+                      recover-locks! #(swap! calls conj :recover-locks)
+                      activate-owner! #(do
+                                         (swap! calls conj :activate-owner)
+                                         (throw (ex-info "stop loop startup test" {})))]
+          (loop!))
+        (catch Exception _))
+      (if (= [:install-shutdown-hook :recover-locks :activate-owner] @calls)
+        (println "PASS: loop installs shutdown hook before recovery and owner activation")
+        (do
+          (println (str "FAIL: loop startup order expected hook/recover/activate got=" @calls))
+          (swap! failures conj "loop startup shutdown hook order"))))
+
     (let [timestamp "20260710T000000Z"
           first-id (unique-run-id timestamp)
           second-id (unique-run-id timestamp)

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -91,6 +91,9 @@
 (defn terminating-owners-dir []
   (fs/path (root) "terminating-owners"))
 
+(defn lock-guards-dir []
+  (fs/path (root) "lock-guards"))
+
 (defn owner-state-path
   ([] (owner-state-path (owner-id)))
   ([value] (fs/path (owners-dir) (str (safe-owner-id value) ".edn"))))
@@ -138,7 +141,8 @@
                 (fs/path (root) "locks")
                 (fs/path (root) "runs")
                 (owners-dir)
-                (terminating-owners-dir)]]
+                (terminating-owners-dir)
+                (lock-guards-dir)]]
     (fs/create-dirs path)))
 
 (defn read-edn-file [path fallback]
@@ -431,14 +435,39 @@
        (= (:owner-id expected) (:owner-id actual))
        (= (:owner-instance-id expected) (:owner-instance-id actual))))
 
-(defn delete-lock-if-matches! [ticket-id expected]
+(defn ticket-lock-guard-path [ticket-id]
+  (fs/path (lock-guards-dir) (str (safe-owner-id ticket-id) ".lock")))
+
+(defn with-ticket-lock-guard [ticket-id f]
+  ;; `locking` serializes threads in this JVM. FileLock extends the same critical
+  ;; section to helper commands and replacement runner JVMs sharing the PVC.
   (locking (ticket-file-mutex ticket-id)
-    (let [path (lock-path ticket-id)
-          actual (try
-                   (read-edn-file path nil)
-                   (catch Exception _ nil))]
-      (when (same-ticket-lock? expected actual)
-        (fs/delete-if-exists path)))))
+    (fs/create-dirs (lock-guards-dir))
+    (with-open [file (java.io.RandomAccessFile. (str (ticket-lock-guard-path ticket-id)) "rw")
+                channel (.getChannel file)]
+      (let [_file-lock (.lock channel)]
+        ;; Closing the channel releases all of its locks; Babashka does not expose
+        ;; FileLock.release on the JDK's internal FileLock implementation.
+        (f)))))
+
+(defn delete-lock-if-matches-under-guard! [ticket-id expected]
+  (let [path (lock-path ticket-id)
+        actual (try
+                 (read-edn-file path nil)
+                 (catch Exception _ nil))]
+    (when (same-ticket-lock? expected actual)
+      ;; Deterministic black-box race hook; unset in the deployment.
+      (when-let [signal-path (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_LOCK_DELETE_SIGNAL")]
+        (spit signal-path "ready\n"))
+      (when-let [hold-ms (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_LOCK_DELETE_MILLIS")]
+        (Thread/sleep (Long/parseLong hold-ms)))
+      (fs/delete-if-exists path)
+      true)))
+
+(defn delete-lock-if-matches! [ticket-id expected]
+  (with-ticket-lock-guard
+   ticket-id
+   #(delete-lock-if-matches-under-guard! ticket-id expected)))
 
 (defn mark-run! [ticket-id run-id status extra]
   (let [summary (merge {:ticket ticket-id
@@ -455,7 +484,7 @@
                 :previous-lock lock})
     (when (fs/exists? (ticket-path ticket-id))
       (append-note! ticket-id (str "Codex run " interrupted-run " " note))))
-  (delete-lock-if-matches! ticket-id lock))
+  (delete-lock-if-matches-under-guard! ticket-id lock))
 
 (defn close-stale-lock! [ticket-id lock]
   (close-interrupted-lock! ticket-id lock
@@ -483,15 +512,17 @@
       (doseq [path (fs/list-dir locks-dir)
               :let [ticket-id (lock-ticket-id path)]
               :when ticket-id]
-        (try
-          (locking (ticket-file-mutex ticket-id)
+        (with-ticket-lock-guard
+         ticket-id
+         (fn []
+          (try
             (let [lock (read-edn-file path {})]
               (when (and (stale-lock? lock)
                          (not (current-runner-lock? lock)))
                 (log! (str "closing stale lock: " ticket-id))
-                (close-stale-lock! ticket-id lock))))
-          (catch Exception e
-            (close-corrupt-lock! ticket-id path e)))))))
+                (close-stale-lock! ticket-id lock)))
+            (catch Exception e
+              (close-corrupt-lock! ticket-id path e)))))))))
 
 (defn read-shutdown-markers []
   (let [dir (terminating-owners-dir)]
@@ -530,15 +561,17 @@
       (doseq [path (fs/list-dir locks-dir)
               :let [ticket-id (lock-ticket-id path)]
               :when ticket-id]
-        (try
-          (locking (ticket-file-mutex ticket-id)
+        (with-ticket-lock-guard
+         ticket-id
+         (fn []
+          (try
             (let [lock (read-edn-file path {})]
               (when-let [marker (matching-shutdown-marker recoverable-markers lock)]
                 (log! (str "closing lock from planned owner shutdown: " ticket-id
                            " owner=" (:owner-id marker)))
-                (close-planned-shutdown-lock! ticket-id lock marker))))
-          (catch Exception e
-            (close-corrupt-lock! ticket-id path e)))))
+                (close-planned-shutdown-lock! ticket-id lock marker)))
+            (catch Exception e
+              (close-corrupt-lock! ticket-id path e)))))))
     (doseq [marker recoverable-markers]
       (fs/delete-if-exists (:path marker))
       (fs/delete-if-exists (owner-state-path (:owner-id marker))))))
@@ -548,9 +581,16 @@
   (recover-planned-shutdown-locks!)
   (cleanup-stale-locks!))
 
+(defn create-lock-under-guard! [path lock]
+  (when (.createNewFile (io/file (str path)))
+    (write-edn-file! path lock)
+    lock))
+
 (defn acquire-lock! [ticket-id action lane]
   (when-not (draining?)
-    (locking (ticket-file-mutex ticket-id)
+    (with-ticket-lock-guard
+     ticket-id
+     (fn []
       (let [path (lock-path ticket-id)
             run (run-id)
             lock {:ticket ticket-id
@@ -564,23 +604,27 @@
                   :started-at (now-str)
                   :heartbeat-at (now-str)}]
         (fs/create-dirs (fs/parent path))
-        (if (.createNewFile (io/file (str path)))
-          (do
-            (write-edn-file! path lock)
-            lock)
+        (if-let [created (create-lock-under-guard! path lock)]
+          created
           (try
             (let [existing (read-edn-file path {})]
               (if (and (stale-lock? existing)
                        (not (current-runner-lock? existing)))
                 (do
                   (close-stale-lock! ticket-id existing)
-                  (acquire-lock! ticket-id action lane))
+                  (or (create-lock-under-guard! path lock)
+                      (do
+                        (log! (str "ticket lock changed while recovering: " ticket-id))
+                        nil)))
                 (do
                   (log! (str "ticket already locked: " ticket-id))
                   nil)))
             (catch Exception e
               (close-corrupt-lock! ticket-id path e)
-              (acquire-lock! ticket-id action lane))))))))
+              (or (create-lock-under-guard! path lock)
+                  (do
+                    (log! (str "ticket lock changed while clearing corruption: " ticket-id))
+                    nil))))))))))
 
 (defn release-lock! [ticket-id lock]
   (delete-lock-if-matches! ticket-id lock))
@@ -588,7 +632,9 @@
 (defn heartbeat! [ticket-id lock stop?]
   (future
     (while (not @stop?)
-      (locking (ticket-file-mutex ticket-id)
+      (with-ticket-lock-guard
+       ticket-id
+       (fn []
         (let [path (lock-path ticket-id)
               existing (try
                          (read-edn-file path nil)
@@ -597,7 +643,7 @@
             (write-edn-file! path (assoc existing :heartbeat-at (now-str)))
             (do
               (log! (str "heartbeat stopped because lock ownership changed: " ticket-id))
-              (reset! stop? true)))))
+              (reset! stop? true))))))
       (Thread/sleep 1000))))
 
 (defn previous-run-summaries [ticket-id]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -117,9 +117,16 @@
 (defn today []
   (str (java.time.LocalDate/now java.time.ZoneOffset/UTC)))
 
+(defn run-timestamp []
+  (env "CODEX_TASK_BOARD_RUN_TIMESTAMP"
+       (.format (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'")
+                (java.time.ZonedDateTime/now java.time.ZoneOffset/UTC))))
+
+(defn unique-run-id [timestamp]
+  (str timestamp "-" (java.util.UUID/randomUUID)))
+
 (defn run-id []
-  (.format (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'")
-           (java.time.ZonedDateTime/now java.time.ZoneOffset/UTC)))
+  (unique-run-id (run-timestamp)))
 
 (defn fail [message]
   (binding [*out* *err*]
@@ -1374,6 +1381,18 @@
 
 (defn run-tests! []
   (let [failures (atom [])]
+    (let [timestamp "20260710T000000Z"
+          first-id (unique-run-id timestamp)
+          second-id (unique-run-id timestamp)
+          expected-pattern #"^20260710T000000Z-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"]
+      (if (and (not= first-id second-id)
+               (re-matches expected-pattern first-id)
+               (re-matches expected-pattern second-id))
+        (println "PASS: run IDs remain unique within the same second")
+        (do
+          (println (str "FAIL: same-second run IDs must be unique: " first-id " / " second-id))
+          (swap! failures conj "same-second run ID uniqueness"))))
+
     (doseq [[assignee expected-model] [["codex"       "gpt-5.6-terra"]
                                        ["codex-sol"   "gpt-5.6-sol"]
                                        ["codex-full"  "gpt-5.6-sol"]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -36,16 +36,15 @@
 (def board-mutex (Object.))
 (def log-mutex (Object.))
 
-;; Fixed pool of 256 lock objects (striped locking). Prevents read-modify-write races
-;; between sync-ticket-statuses! and in-flight process-card! workers, with bounded
-;; memory regardless of how many distinct ticket IDs are processed over the lifetime
-;; of the process.
-(def ^:private ticket-file-lock-stripes
+;; Fixed pool of 256 lock objects (striped locking). Serializes all ticket-scoped
+;; mutations in this JVM, including frontmatter / Notes writes and the process-shared
+;; lock guard, with bounded memory regardless of the number of distinct ticket IDs.
+(def ^:private ticket-lock-stripes
   (vec (repeatedly 256 #(Object.))))
 
-(defn ticket-file-mutex [ticket-id]
-  (nth ticket-file-lock-stripes
-       (mod (Math/abs (.hashCode (str ticket-id))) 256)))
+(defn ticket-mutex [ticket-id]
+  (nth ticket-lock-stripes
+       (Math/floorMod (.hashCode (str ticket-id)) (count ticket-lock-stripes))))
 
 (defn log! [message]
   (locking log-mutex
@@ -348,7 +347,7 @@
       (conj (vec fm-lines) replacement))))
 
 (defn update-frontmatter! [ticket-id updates]
-  (locking (ticket-file-mutex ticket-id)
+  (locking (ticket-mutex ticket-id)
     (let [path (ticket-path ticket-id)
           lines (vec (read-lines path))
           {:keys [end]} (or (frontmatter-range lines)
@@ -367,7 +366,7 @@
   (frontmatter-map (vec (read-lines (ticket-path ticket-id)))))
 
 (defn append-note! [ticket-id note]
-  (locking (ticket-file-mutex ticket-id)
+  (locking (ticket-mutex ticket-id)
     (let [path (ticket-path ticket-id)
           lines (vec (read-lines path))
           bullet (str "- " (today) ": " note)
@@ -441,7 +440,7 @@
 (defn with-ticket-lock-guard [ticket-id f]
   ;; `locking` serializes threads in this JVM. FileLock extends the same critical
   ;; section to helper commands and replacement runner JVMs sharing the PVC.
-  (locking (ticket-file-mutex ticket-id)
+  (locking (ticket-mutex ticket-id)
     (fs/create-dirs (lock-guards-dir))
     (with-open [file (java.io.RandomAccessFile. (str (ticket-lock-guard-path ticket-id)) "rw")
                 channel (.getChannel file)]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -237,6 +237,10 @@
 (defn current-owner-marker? [marker]
   (= (owner-id) (:owner-id marker)))
 
+(defn previous-runner-marker? [marker]
+  (and (current-owner-marker? marker)
+       (not (current-runner-marker? marker))))
+
 (defn stopping-owner-state? [state]
   (and (= (owner-id) (:owner-id state))
        (contains? #{:terminating :terminated} (:status state))))
@@ -654,7 +658,7 @@
                                :terminated-at (now-str)}))
       true)))
 
-(defn recover-planned-shutdown-marker! [marker]
+(defn recover-planned-shutdown-marker! [marker retire-empty-marker?]
   (with-owner-lock-guard
    (:owner-id marker)
    (fn []
@@ -692,7 +696,7 @@
          ;; Lock creation for this owner takes the same owner guard. Marking the owner
          ;; terminated before deleting the marker also prevents a waiter from creating
          ;; a lock immediately after this critical section ends.
-         (when (and @recovered?
+         (when (and (or @recovered? retire-empty-marker?)
                     (not (matching-shutdown-lock-exists? marker))
                     (same-shutdown-marker? marker
                                            (try
@@ -701,19 +705,31 @@
                     (retire-owner-under-guard! marker))
            (fs/delete-if-exists (:path marker))))))))
 
-(defn recover-planned-shutdown-locks! []
-  (let [markers (read-shutdown-markers)
-        ;; The runner that wrote a marker must not reclaim its own locks while it is
-        ;; draining. A restarted runner can reuse the Pod UID, though, so a different
-        ;; instance under the same owner must be allowed to recover the old instance.
-        recoverable-markers (remove current-runner-marker? markers)]
-    (doseq [marker recoverable-markers]
-      (recover-planned-shutdown-marker! marker))))
+(defn recover-planned-shutdown-locks!
+  ([] (recover-planned-shutdown-locks! false))
+  ([runner-startup?]
+   (let [markers (read-shutdown-markers)
+         ;; Helper commands keep excluding the whole current owner. Only loop startup
+         ;; may recover a previous instance that reused the Pod UID.
+         current-marker? (if runner-startup?
+                           current-runner-marker?
+                           current-owner-marker?)
+         recoverable-markers (remove current-marker? markers)]
+     (doseq [marker recoverable-markers]
+       ;; A replacement loop starts only after the old container process exited. Under
+       ;; the owner guard it may therefore retire an old same-owner marker even when
+       ;; that instance had no in-flight locks. Other owners retain empty markers so a
+       ;; late matching lock can still be recovered on a future scan.
+       (recover-planned-shutdown-marker!
+        marker
+        (and runner-startup? (previous-runner-marker? marker)))))))
 
-(defn recover-locks! []
-  (ensure-root!)
-  (recover-planned-shutdown-locks!)
-  (cleanup-stale-locks!))
+(defn recover-locks!
+  ([] (recover-locks! false))
+  ([runner-startup?]
+   (ensure-root!)
+   (recover-planned-shutdown-locks! runner-startup?)
+   (cleanup-stale-locks!)))
 
 (defn create-lock-under-guard! [path lock]
   (when (.createNewFile (io/file (str path)))
@@ -1541,7 +1557,7 @@
   ;; Register before recovery or owner activation so direct SIGTERM during startup
   ;; can still persist the planned-shutdown marker.
   (install-shutdown-hook!)
-  (recover-locks!)
+  (recover-locks! true)
   (activate-owner!)
   (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)
              ", owner=" (owner-id) ", instance=" runner-instance-id))
@@ -1567,7 +1583,7 @@
     (let [calls (atom [])]
       (try
         (with-redefs [install-shutdown-hook! #(swap! calls conj :install-shutdown-hook)
-                      recover-locks! #(swap! calls conj :recover-locks)
+                      recover-locks! (fn [& _] (swap! calls conj :recover-locks))
                       activate-owner! #(do
                                          (swap! calls conj :activate-owner)
                                          (throw (ex-info "stop loop startup test" {})))]

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -549,6 +549,21 @@
                        (= (:instance-id %) (:owner-instance-id lock)))
                  markers)))
 
+(defn matching-shutdown-lock-exists? [marker]
+  (let [locks-dir (fs/path (root) "locks")]
+    (and (fs/exists? locks-dir)
+         (boolean
+          (some (fn [path]
+                  (when-let [ticket-id (lock-ticket-id path)]
+                    (with-ticket-lock-guard
+                     ticket-id
+                     (fn []
+                       (try
+                         (some? (matching-shutdown-marker [marker]
+                                                          (read-edn-file path {})))
+                         (catch Exception _ false))))))
+                (fs/list-dir locks-dir))))))
+
 (defn recover-planned-shutdown-locks! []
   (let [markers (read-shutdown-markers)
         ;; A helper command running inside the terminating Pod must never reclaim that
@@ -573,11 +588,19 @@
                   (swap! recovered-marker-paths conj (:path marker)))))
             (catch Exception e
               (close-corrupt-lock! ticket-id path e)))))))
-    ;; Keep unmatched markers for the next scan. A matching lock may be created while
-    ;; this process is enumerating the shared directory, and dropping the marker here
-    ;; would defer that lock to the heartbeat timeout instead of planned recovery.
+    ;; Give deterministic black-box tests a point to create a second matching lock
+    ;; after the first directory scan but before marker cleanup.
+    (when (seq @recovered-marker-paths)
+      (when-let [signal-path (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_SIGNAL")]
+        (spit signal-path "ready\n"))
+      (when-let [hold-ms (System/getenv "CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_MILLIS")]
+        (Thread/sleep (Long/parseLong hold-ms))))
+    ;; Keep unmatched markers and recovered markers that still have another matching
+    ;; lock. A lock may appear late in the shared directory enumeration; deleting its
+    ;; owner marker would defer it to the heartbeat timeout instead of the next scan.
     (doseq [marker recoverable-markers
-            :when (contains? @recovered-marker-paths (:path marker))]
+            :when (contains? @recovered-marker-paths (:path marker))
+            :when (not (matching-shutdown-lock-exists? marker))]
       (fs/delete-if-exists (:path marker))
       (fs/delete-if-exists (owner-state-path (:owner-id marker))))))
 

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -165,6 +165,21 @@
                ", instance=" (or (:instance-id marker) "unknown")))
     marker))
 
+(def shutdown-hook-installed? (atom false))
+
+(defn install-shutdown-hook! []
+  (when (compare-and-set! shutdown-hook-installed? false true)
+    (.addShutdownHook
+     (Runtime/getRuntime)
+     (Thread.
+      ^Runnable
+      (fn []
+        (try
+          (prepare-shutdown!)
+          (catch Exception e
+            (binding [*out* *err*]
+              (println (str "failed to prepare task-board shutdown: " (.getMessage e)))))))))))
+
 (defn current-runner-marker? [marker]
   (and (= (owner-id) (:owner-id marker))
        (= runner-instance-id (:instance-id marker))))
@@ -1335,6 +1350,9 @@
 (defn loop! []
   (recover-locks!)
   (activate-owner!)
+  ;; preStop is the explicit deployment contract. The process-level hook preserves
+  ;; the same owner marker when the runner receives SIGTERM directly.
+  (install-shutdown-hook!)
   (log! (str "codex task-board runner started, vault=" (vault) ", root=" (root)
              ", owner=" (owner-id) ", instance=" runner-instance-id))
   (loop []

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -1659,7 +1659,7 @@
   (reset! in-flight-futures {}))
 
 (case (or (first *command-line-args*) "tick")
-  "tick" (do (recover-locks!) (activate-owner!) (tick!) (drain-in-flight!) (sync-all!))
+  "tick" (do (recover-locks!) (tick!) (drain-in-flight!) (sync-all!))
   "loop" (loop!)
   "sync" (do (ensure-root!) (sync-all!))
   "prepare-shutdown" (prepare-shutdown!)

--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -556,6 +556,7 @@
         ;; Pod's own locks. Recreate gives the replacement Pod a different UID, so only
         ;; another owner is allowed to consume a planned-shutdown marker.
         recoverable-markers (remove current-owner-marker? markers)
+        recovered-marker-paths (atom #{})
         locks-dir (fs/path (root) "locks")]
     (when (and (seq recoverable-markers) (fs/exists? locks-dir))
       (doseq [path (fs/list-dir locks-dir)
@@ -569,10 +570,15 @@
               (when-let [marker (matching-shutdown-marker recoverable-markers lock)]
                 (log! (str "closing lock from planned owner shutdown: " ticket-id
                            " owner=" (:owner-id marker)))
-                (close-planned-shutdown-lock! ticket-id lock marker)))
+                (when (close-planned-shutdown-lock! ticket-id lock marker)
+                  (swap! recovered-marker-paths conj (:path marker)))))
             (catch Exception e
               (close-corrupt-lock! ticket-id path e)))))))
-    (doseq [marker recoverable-markers]
+    ;; Keep unmatched markers for the next scan. A matching lock may be created while
+    ;; this process is enumerating the shared directory, and dropping the marker here
+    ;; would defer that lock to the heartbeat timeout instead of planned recovery.
+    (doseq [marker recoverable-markers
+            :when (contains? @recovered-marker-paths (:path marker))]
       (fs/delete-if-exists (:path marker))
       (fs/delete-if-exists (owner-state-path (:owner-id marker))))))
 

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -37,6 +37,7 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - loop process の SIGTERM shutdown hook からも同じ marker を永続化し、manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
 - marker のない fresh active lock と、別 owner の lock は維持する。
+- run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
 - stale / corrupt lock の既存復旧と Task Board lane source-of-truth は変更しない。
 - black-box test で即時回収、owner 不一致の非回収、owner metadata、lane/frontmatter/Notes の整合を検証する。
 
@@ -67,6 +68,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - 一時 vault / state を使い、fresh heartbeat の旧 owner lock + shutdown marker を新 owner が即時回収し、同じ tick で再実行できることを時間計測する。
 - loop process へ直接 SIGTERM を送り、preStop command なしでも owner / instance 一致の shutdown marker が作成されることを確認する。
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
+- 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
 - render 後 manifest で replica / strategy、Pod UID env、preStop、timeout、既存 container / Service / PVC mount が維持されることを確認する。
 - merge 後の実環境 rollout では旧 Pod UID、停止開始時刻、新 Pod Ready 時刻、planned recovery log、最初の新規 ticket 開始時刻を採取し、5 分以内と二重起動なしを確認する。
@@ -91,6 +93,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - validation environment: 一時 vault / state、fake Codex、旧 owner の fresh lock と planned-shutdown marker を使う black-box rollout simulation は 1 秒で `interrupted` 記録、Notes 追記、新 owner lock 取得、同 tick 再実行、最終 lane/frontmatter 更新まで完了した。
 - graceful signal: loop process に直接 SIGTERM を送り、preStop command を実行しない条件でも owner / instance 一致の shutdown marker が書かれる black-box test が通過した。
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
+- same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
 - companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -36,6 +36,7 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - `prepare-shutdown` command で owner-scoped marker を永続化する。
 - loop process の SIGTERM shutdown hook からも同じ marker を永続化し、manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
+- marker は一致 lock を実際に compare-and-delete できた場合だけ owner state とともに削除し、一致 lock がまだ見えない場合は次回走査まで保持する。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
 - ticket ごとの永続 guard file を Java `FileLock` で共有し、runner / helper / replacement JVM 間でも lock の compare-and-delete、acquire、heartbeat、release を同じ critical section で行う。
@@ -69,6 +70,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - 一時 vault / state を使い、fresh heartbeat の旧 owner lock + shutdown marker を新 owner が即時回収し、同じ tick で再実行できることを時間計測する。
 - loop process へ直接 SIGTERM を送り、preStop command なしでも owner / instance 一致の shutdown marker が作成されることを確認する。
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
+- marker の走査時点で一致 lock がなくても marker / owner state が保持され、後続走査で遅れて現れた一致 lock を即時回収できることを確認する。
 - 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
 - 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
@@ -97,6 +99,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
 - cross-process ownership: recovery JVM を compare-and-delete 中で停止し、別 JVM が同じ永続 guard を取得して replacement lock を作る競合テストで、replacement lock が維持されることを確認した。
+- marker enumeration race: 一致 lock のない shutdown marker / owner state が初回 recovery 後も残り、その後に作成された fresh な一致 lock を次回 recovery で planned shutdown として回収することを確認した。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
 - companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -37,6 +37,7 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - loop process は recovery / owner activation より先に SIGTERM shutdown hook を登録し、起動直後を含めて同じ marker を永続化する。manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
 - marker は一致 lock を実際に compare-and-delete できた場合だけ削除し、一致 lock がまだ見えない場合は次回走査まで保持する。削除時は owner state を同じ instance の `:terminated` tombstone に更新して残し、marker 削除待ちだった旧 owner が後から lock を作らないようにする。
+- recovery では owner だけでなく runner instance まで一致する現在 process の marker だけを除外する。同じ Pod UID のまま runner container が再起動した場合は、異なる instance の旧 marker / lock を回収してから owner state を新 instance で activate する。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
 - ticket ごとの永続 guard file を Java `FileLock` で共有し、runner / helper / replacement JVM 間でも lock の compare-and-delete、acquire、heartbeat、release を同じ critical section で行う。
@@ -72,6 +73,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - loop process へ直接 SIGTERM を送り、preStop command なしでも owner / instance 一致の shutdown marker が作成されることを確認する。
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
 - marker の走査時点で一致 lock がなくても marker / owner state が保持され、後続走査で遅れて現れた一致 lock を即時回収できることを確認する。
+- 同じ Pod UID（同一 owner）で runner instance だけが変わる container restart を再現し、旧 instance の fresh lock / marker を即時回収して新 instance が ticket 受付を再開できることを確認する。
 - 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
 - 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。marker cleanup 後も `:terminated` owner は新しい lock を取得できないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -36,10 +36,11 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - `prepare-shutdown` command で owner-scoped marker を永続化する。
 - loop process の SIGTERM shutdown hook からも同じ marker を永続化し、manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
-- marker は一致 lock を実際に compare-and-delete できた場合だけ owner state とともに削除し、一致 lock がまだ見えない場合は次回走査まで保持する。
+- marker は一致 lock を実際に compare-and-delete できた場合だけ削除し、一致 lock がまだ見えない場合は次回走査まで保持する。削除時は owner state を同じ instance の `:terminated` tombstone に更新して残し、marker 削除待ちだった旧 owner が後から lock を作らないようにする。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
 - ticket ごとの永続 guard file を Java `FileLock` で共有し、runner / helper / replacement JVM 間でも lock の compare-and-delete、acquire、heartbeat、release を同じ critical section で行う。
+- owner ごとの永続 guard file も Java `FileLock` で共有し、shutdown marker の作成、owner state 遷移、lock acquire、全 lock の最終再走査、marker 削除を同じ critical section にする。lock 順序は owner guard → ticket guard に統一する。
 - stale / corrupt lock の既存復旧と Task Board lane source-of-truth は変更しない。
 - black-box test で即時回収、owner 不一致の非回収、owner metadata、lane/frontmatter/Notes の整合を検証する。
 
@@ -72,7 +73,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
 - marker の走査時点で一致 lock がなくても marker / owner state が保持され、後続走査で遅れて現れた一致 lock を即時回収できることを確認する。
 - 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
-- 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。
+- 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。marker cleanup 後も `:terminated` owner は新しい lock を取得できないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
 - render 後 manifest で replica / strategy、Pod UID env、preStop、timeout、既存 container / Service / PVC mount が維持されることを確認する。
 - merge 後の実環境 rollout では旧 Pod UID、停止開始時刻、新 Pod Ready 時刻、planned recovery log、最初の新規 ticket 開始時刻を採取し、5 分以内と二重起動なしを確認する。
@@ -101,7 +102,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
 - cross-process ownership: recovery JVM を compare-and-delete 中で停止し、別 JVM が同じ永続 guard を取得して replacement lock を作る競合テストで、replacement lock が維持されることを確認した。
 - marker enumeration race: 一致 lock のない shutdown marker / owner state が初回 recovery 後も残り、その後に作成された fresh な一致 lock を次回 recovery で planned shutdown として回収することを確認した。
-- multi-lock marker race: 同じ owner / instance の lock を1件回収した直後に2件目が列挙へ現れる競合でも marker / owner state を保持し、次回 recovery で2件目を回収してから marker を削除することを確認した。
+- multi-lock marker race: 同じ owner / instance の lock を1件回収した直後に2件目が列挙へ現れる競合でも marker / owner state を保持し、次回 recovery で2件目を回収してから marker を削除することを確認した。owner guard 内で最終再走査と marker の compare-and-delete を行い、owner state を `:terminated` にしてから guard を解放するため、同一 owner の待機中 acquire は marker 削除後も失敗する。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
 - companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -34,7 +34,7 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 
 - lock に `CODEX_TASK_BOARD_OWNER_ID`（manifest 適用後は Pod UID、未設定時は Pod hostname）を記録する。
 - `prepare-shutdown` command で owner-scoped marker を永続化する。
-- loop process の SIGTERM shutdown hook からも同じ marker を永続化し、manifest hook がない場合も計画停止を通知する。
+- loop process は recovery / owner activation より先に SIGTERM shutdown hook を登録し、起動直後を含めて同じ marker を永続化する。manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
 - marker は一致 lock を実際に compare-and-delete できた場合だけ削除し、一致 lock がまだ見えない場合は次回走査まで保持する。削除時は owner state を同じ instance の `:terminated` tombstone に更新して残し、marker 削除待ちだった旧 owner が後から lock を作らないようにする。
 - marker のない fresh active lock と、別 owner の lock は維持する。
@@ -97,6 +97,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - 実環境 baseline: Deployment generation 89 / revision 83、`replicas=1`、`Recreate`、Pod `codex-workspace-858bcf8d45-zwswr`（UID `00aad169-dd98-4975-b339-a75c35efc2a5`）で 7 container が Ready。active lock は 1 秒間隔で heartbeat を更新していたが、現行 image の lock には owner metadata がなく、stale 設定は 1,800 秒だった。
 - validation environment: 一時 vault / state、fake Codex、旧 owner の fresh lock と planned-shutdown marker を使う black-box rollout simulation は 1 秒で `interrupted` 記録、Notes 追記、新 owner lock 取得、同 tick 再実行、最終 lane/frontmatter 更新まで完了した。
 - graceful signal: loop process に直接 SIGTERM を送り、preStop command を実行しない条件でも owner / instance 一致の shutdown marker が書かれる black-box test が通過した。
+- startup signal window: loop の shutdown hook が recovery / owner activation より先に登録されることを内蔵テストで固定し、起動直後の直接 SIGTERM でも planned-shutdown 通知経路が有効になるようにした。
 - owner state isolation: 同じ Pod owner で one-shot `tick` を実行しても常駐 `loop` の owner instance を上書きせず、その後の SIGTERM marker が loop instance と一致することを確認した。
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -1,0 +1,79 @@
+# BOXP-91: codex-workspace の計画 rollout 復旧
+
+## 目的と完了条件
+
+`codex-workspace` の image / Pod template 更新時も、RWO の `/home/boxp` PVC と singleton writer を増やさず、Task Board runner が中断 run を安全に閉じて 5 分以内に新規受付を再開できるようにする。SSH / Even Terminal、Obsidian 同期、draft watcher、Codex cron、Docker、dashboard と既存データは維持する。
+
+## 現行構成の棚卸し
+
+| container | 主な読み書き先 | 性質 | 採用構成 |
+| --- | --- | --- | --- |
+| `fetch-ssh-keys` init | `/home/boxp/.ssh`、`.pi/agent/models.json` | home 初期化 writer | Pod ごとに 1 回 |
+| `install-docker-cli` init | `docker-cli` emptyDir | Pod 内 stateless | Pod ごとに 1 回 |
+| `workspace` | home 全体、SSH / Even Terminal、認証状態 | 対話・永続 writer | singleton |
+| `obsidian-sync` | Obsidian vault | continuous sync writer | singleton |
+| `obsidian-task-board-draft` | vault の draft / ticket | watcher writer | singleton |
+| `docker` | `docker-graph-storage` emptyDir | workspace / runner と localhost 結合 | Pod ごとに 1 個 |
+| `codex-cron-scheduler` | vault の Cron 定義、home の agent 状態 | scheduler writer | singleton |
+| `task-board-runner` | vault、`.codex-task-board`、run workspace | lane / lock / run writer | singleton |
+| `task-board-dashboard` | `.codex-task-board` | read only | 理論上複製可能だが RWO と同居を維持 |
+
+Service は `app=codex-workspace` の単一 Pod を選択し、image updater の Kustomize image 置換は同じ image を使う全 container を同一 Pod template rollout の対象にする。home PVC は `ReadWriteOnce` であり、Longhorn の volume replica 数は複数 process の同時書き込み安全性を提供しない。
+
+## 比較と採用判断
+
+1. runner の独立 Deployment 化は、同じ RWO PVC を複数 Pod が mount するため同一 node への暗黙依存が増える。runner は Docker daemon、home の agent 認証、vault sync とも結合しており、同じ image の自動更新対象でもあるため、今回の最小変更では採用しない。
+2. dashboard 等の read-only 部分だけを複製しても Task Board 受付停止は改善せず、RWO volume の scheduling 制約だけが増えるため採用しない。
+3. `replicas: 1` / `Recreate` を安全条件として維持し、Pod UID を runner lock owner に記録する。`preStop` が計画停止 marker を PVC へ書き、次 Pod が marker と owner の一致する lock だけを即時に `interrupted` 回収する方式を採用する。
+
+`Recreate` により新 Pod は旧 Pod の終了後にだけ開始するため、計画停止 marker を持つ owner の process は回収時点ですでに存在せず、同一チケットを並行実行しない。marker がない fresh lock は回収しない。preStop がない旧 image からの初回 rollout や強制終了では heartbeat timeout を fallback とし、stale 判定を 180 秒、poll を 30 秒にして、最後の heartbeat から最大約 210 秒で再受付する。
+
+## 実装
+
+### boxp/arch
+
+- lock に `CODEX_TASK_BOARD_OWNER_ID`（Pod UID）を記録する。
+- `prepare-shutdown` command で owner-scoped marker を永続化する。
+- startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
+- marker のない fresh active lock と、別 owner の lock は維持する。
+- stale / corrupt lock の既存復旧と Task Board lane source-of-truth は変更しない。
+- black-box test で即時回収、owner 不一致の非回収、owner metadata、lane/frontmatter/Notes の整合を検証する。
+
+### boxp/lolice
+
+- downward API で Pod UID を `CODEX_TASK_BOARD_OWNER_ID` に注入する。
+- runner container の `preStop` から `prepare-shutdown` を実行する。
+- `CODEX_TASK_BOARD_LOCK_STALE_SECONDS=180`、`CODEX_TASK_BOARD_POLL_SECONDS=30`、`terminationGracePeriodSeconds=60` を設定する。
+- `replicas: 1` / `Recreate` を維持する。
+- README に rollout / rollback、lock 診断、安全な手動復旧、残る単一障害点を記録する。
+
+## 検証計画
+
+- `boxp/arch/tests/codex-workspace/task-board-runner-test.sh` の全ケース。
+- 一時 vault / state を使い、fresh heartbeat の旧 owner lock + shutdown marker を新 owner が即時回収し、同じ tick で再実行できることを時間計測する。
+- marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
+- `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
+- render 後 manifest で replica / strategy、Pod UID env、preStop、timeout、既存 container / Service / PVC mount が維持されることを確認する。
+- merge 後の実環境 rollout では旧 Pod UID、停止開始時刻、新 Pod Ready 時刻、planned recovery log、最初の新規 ticket 開始時刻を採取し、5 分以内と二重起動なしを確認する。
+
+## rollout / rollback の安全条件
+
+- rollout は通常の Argo CD sync / image updater に任せ、Pod の force delete は行わない。
+- rollout 前に Deployment が `replicas: 1` / `Recreate` であることを確認する。
+- rollback は両 repository の変更を revert する。runner image を先に戻す場合も lock の追加 key は EDN の未知 key として無害で、lolice manifest の preStop は対応 command を含む image と同時に戻す。
+- lock の手動削除は、現 Pod UID と lock owner が不一致、該当 owner Pod が存在しない、heartbeat が stale であることを確認し、`task_board_runner.bb recover` が失敗した場合の最終手段に限定する。
+
+## 残る単一障害点
+
+- 単一 Pod、単一 RWO home PVC、配置 node、Kubernetes control plane / Longhorn、Obsidian remote、GitHub / agent API は HA 化しない。
+- SSH / Even Terminal や個々の agent session の live migration は行わず、Pod 再作成中は短時間切断される。
+- SIGKILL、node 障害、preStop 未実行時は owner marker を利用できないため、180 秒 heartbeat fallback で回収する。
+
+## 検証記録（2026-07-10 UTC）
+
+- 実環境 baseline: Deployment generation 89 / revision 83、`replicas=1`、`Recreate`、Pod `codex-workspace-858bcf8d45-zwswr`（UID `00aad169-dd98-4975-b339-a75c35efc2a5`）で 7 container が Ready。active lock は 1 秒間隔で heartbeat を更新していたが、現行 image の lock には owner metadata がなく、stale 設定は 1,800 秒だった。
+- validation environment: 一時 vault / state、fake Codex、旧 owner の fresh lock と planned-shutdown marker を使う black-box rollout simulation は 1 秒で `interrupted` 記録、Notes 追記、新 owner lock 取得、同 tick 再実行、最終 lane/frontmatter 更新まで完了した。
+- active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
+- `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
+- `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
+- 未 merge の manifest / image を実クラスタへ直接 apply すると実行中 Task Board run を中断するため、本 run では live rollout を行わず、上記 validation environment の再現テストを採用した。merge 後の初回 rollout は旧 lock に owner metadata がない可能性があるため 180 秒 fallback、次回以降は planned marker の即時回収を runbook に従って実測する。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -96,6 +96,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - 実環境 baseline: Deployment generation 89 / revision 83、`replicas=1`、`Recreate`、Pod `codex-workspace-858bcf8d45-zwswr`（UID `00aad169-dd98-4975-b339-a75c35efc2a5`）で 7 container が Ready。active lock は 1 秒間隔で heartbeat を更新していたが、現行 image の lock には owner metadata がなく、stale 設定は 1,800 秒だった。
 - validation environment: 一時 vault / state、fake Codex、旧 owner の fresh lock と planned-shutdown marker を使う black-box rollout simulation は 1 秒で `interrupted` 記録、Notes 追記、新 owner lock 取得、同 tick 再実行、最終 lane/frontmatter 更新まで完了した。
 - graceful signal: loop process に直接 SIGTERM を送り、preStop command を実行しない条件でも owner / instance 一致の shutdown marker が書かれる black-box test が通過した。
+- owner state isolation: 同じ Pod owner で one-shot `tick` を実行しても常駐 `loop` の owner instance を上書きせず、その後の SIGTERM marker が loop instance と一致することを確認した。
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
 - cross-process ownership: recovery JVM を compare-and-delete 中で停止し、別 JVM が同じ永続 guard を取得して replacement lock を作る競合テストで、replacement lock が維持されることを確認した。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -38,6 +38,7 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
+- ticket ごとの永続 guard file を Java `FileLock` で共有し、runner / helper / replacement JVM 間でも lock の compare-and-delete、acquire、heartbeat、release を同じ critical section で行う。
 - stale / corrupt lock の既存復旧と Task Board lane source-of-truth は変更しない。
 - black-box test で即時回収、owner 不一致の非回収、owner metadata、lane/frontmatter/Notes の整合を検証する。
 
@@ -69,6 +70,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - loop process へ直接 SIGTERM を送り、preStop command なしでも owner / instance 一致の shutdown marker が作成されることを確認する。
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
 - 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
+- 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
 - render 後 manifest で replica / strategy、Pod UID env、preStop、timeout、既存 container / Service / PVC mount が維持されることを確認する。
 - merge 後の実環境 rollout では旧 Pod UID、停止開始時刻、新 Pod Ready 時刻、planned recovery log、最初の新規 ticket 開始時刻を採取し、5 分以内と二重起動なしを確認する。
@@ -94,6 +96,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - graceful signal: loop process に直接 SIGTERM を送り、preStop command を実行しない条件でも owner / instance 一致の shutdown marker が書かれる black-box test が通過した。
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
+- cross-process ownership: recovery JVM を compare-and-delete 中で停止し、別 JVM が同じ永続 guard を取得して replacement lock を作る競合テストで、replacement lock が維持されることを確認した。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
 - companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -36,8 +36,8 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - `prepare-shutdown` command で owner-scoped marker を永続化する。
 - loop process は recovery / owner activation より先に SIGTERM shutdown hook を登録し、起動直後を含めて同じ marker を永続化する。manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
-- marker は一致 lock を実際に compare-and-delete できた場合だけ削除し、一致 lock がまだ見えない場合は次回走査まで保持する。削除時は owner state を同じ instance の `:terminated` tombstone に更新して残し、marker 削除待ちだった旧 owner が後から lock を作らないようにする。
-- recovery では owner だけでなく runner instance まで一致する現在 process の marker だけを除外する。同じ Pod UID のまま runner container が再起動した場合は、異なる instance の旧 marker / lock を回収してから owner state を新 instance で activate する。
+- marker は一致 lock を実際に compare-and-delete できた場合だけ削除し、一致 lock がまだ見えない場合は次回走査まで保持する。例外として loop startup では、同じ Pod UID（owner）の旧 instance はすでに終了しているため、owner guard 内の最終走査で一致 lock が 0 件なら空 marker も retire する。削除時は owner state を同じ instance の `:terminated` tombstone に更新して残し、marker 削除待ちだった旧 owner が後から lock を作らないようにする。
+- 通常の helper `recover` / `tick` は current owner 全体を除外し、loop startup だけが owner に加えて runner instance を比較する。同じ Pod UID のまま runner container が再起動した場合は、異なる instance の旧 marker / lock を回収してから owner state を新 instance で activate する。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - run ID を秒 timestamp + UUID とし、即時再開が旧 run と同じ秒でも summary / workspace / branch を再利用しない。
 - ticket ごとの永続 guard file を Java `FileLock` で共有し、runner / helper / replacement JVM 間でも lock の compare-and-delete、acquire、heartbeat、release を同じ critical section で行う。
@@ -74,6 +74,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
 - marker の走査時点で一致 lock がなくても marker / owner state が保持され、後続走査で遅れて現れた一致 lock を即時回収できることを確認する。
 - 同じ Pod UID（同一 owner）で runner instance だけが変わる container restart を再現し、旧 instance の fresh lock / marker を即時回収して新 instance が ticket 受付を再開できることを確認する。
+- 同一 owner・旧 instance の marker に一致する lock が 0 件の container restart でも、loop startup が空 marker を retire し、新 instance が draining に残らず ticket 受付を再開できることを確認する。
 - 同一 timestamp の旧 run を planned shutdown で回収しても、置換 run が別 UUID の artifact directory を使い、旧 summary を上書きしないことを確認する。
 - 別 JVM が旧 lock の比較後に replacement lock を作ろうとする競合を再現し、guard 解放後に作られた replacement lock を旧 recovery が削除しないことを確認する。marker cleanup 後も `:terminated` owner は新しい lock を取得できないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -52,7 +52,14 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 
 runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pull/11010)、Deployment の変更は [boxp/lolice PR #723](https://github.com/boxp/lolice/pull/723) で同時にレビューする。lolice 側には `task-board-runner` の `preStop` から `prepare-shutdown` を呼ぶ設定、downward API の `metadata.uid` を `CODEX_TASK_BOARD_OWNER_ID` へ注入する設定、stale 180 秒 / poll 30 秒 / grace 60 秒が含まれる。PR #723 の ArgoCD diff と gitleaks は成功しており、render 上でもこれらの Deployment 差分を確認済みである。
 
-適用順は arch → lolice とする。arch の image だけが先に rollout した場合、終了する旧 image は marker を作れないが、新 image の default stale 180 秒と既存 poll 60 秒により最大約 240 秒で復旧する。以後は runner 自身の SIGTERM hook が hostname owner marker を作り、lolice 適用後は Pod UID と preStop を加えた二重化された経路になる。
+初回導入は次の順序を必須とし、arch image を先に rollout しない。
+
+1. lolice PR #723 を先に merge / Argo CD sync し、現行 arch image のまま Deployment を rollout する。終了する旧 Pod は新しい preStop をまだ持たないため、この1回目は marker なしの fallback になる。
+2. rollout 完了後、実 Pod の `CODEX_TASK_BOARD_LOCK_STALE_SECONDS=180` と `CODEX_TASK_BOARD_POLL_SECONDS=30` を確認する。停止した旧 lock は最後の heartbeat から最大約 210 秒で回収される。
+3. timeout 低減と受付再開を確認してから arch PR #11010 を merge し、image updater による rollout を許可する。この2回目に終了する Pod は preStop を持つが旧 runner は `prepare-shutdown` に未対応のため、hook が失敗しても先に適用済みの 180 秒 / 30 秒設定により最大約 210 秒で復旧する。
+4. 新 arch image の起動後は Pod UID owner、runner の SIGTERM hook、preStop の二重化された経路が有効になり、以後の計画 rollout は一致 lock を即時回収する。
+
+手順 2 の確認前に arch PR を merge しないことを cross-repository deployment gate とする。これにより、旧 manifest の明示値 1,800 秒が runner の default 180 秒を上書きする arch-only rollout を防ぐ。
 
 ## 検証計画
 
@@ -68,6 +75,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 
 - rollout は通常の Argo CD sync / image updater に任せ、Pod の force delete は行わない。
 - rollout 前に Deployment が `replicas: 1` / `Recreate` であることを確認する。
+- 初回導入では lolice PR #723 を先に sync し、実 Pod の stale 180 秒 / poll 30 秒と受付再開を確認するまで arch PR #11010 を merge しない。
 - rollback は両 repository の変更を revert する。runner image を先に戻す場合も lock の追加 key は EDN の未知 key として無害で、lolice manifest の preStop は対応 command を含む image と同時に戻す。
 - lock の手動削除は、現 Pod UID と lock owner が不一致、該当 owner Pod が存在しない、heartbeat が stale であることを確認し、`task_board_runner.bb recover` が失敗した場合の最終手段に限定する。
 

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -24,16 +24,17 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 
 1. runner の独立 Deployment 化は、同じ RWO PVC を複数 Pod が mount するため同一 node への暗黙依存が増える。runner は Docker daemon、home の agent 認証、vault sync とも結合しており、同じ image の自動更新対象でもあるため、今回の最小変更では採用しない。
 2. dashboard 等の read-only 部分だけを複製しても Task Board 受付停止は改善せず、RWO volume の scheduling 制約だけが増えるため採用しない。
-3. `replicas: 1` / `Recreate` を安全条件として維持し、Pod UID を runner lock owner に記録する。`preStop` が計画停止 marker を PVC へ書き、次 Pod が marker と owner の一致する lock だけを即時に `interrupted` 回収する方式を採用する。
+3. `replicas: 1` / `Recreate` を安全条件として維持し、Pod UID を runner lock owner に記録する。runner の SIGTERM shutdown hook と `preStop` が計画停止 marker を PVC へ書き、次 Pod が marker と owner の一致する lock だけを即時に `interrupted` 回収する方式を採用する。
 
-`Recreate` により新 Pod は旧 Pod の終了後にだけ開始するため、計画停止 marker を持つ owner の process は回収時点ですでに存在せず、同一チケットを並行実行しない。marker がない fresh lock は回収しない。preStop がない旧 image からの初回 rollout や強制終了では heartbeat timeout を fallback とし、stale 判定を 180 秒、poll を 30 秒にして、最後の heartbeat から最大約 210 秒で再受付する。
+`Recreate` により新 Pod は旧 Pod の終了後にだけ開始するため、計画停止 marker を持つ owner の process は回収時点ですでに存在せず、同一チケットを並行実行しない。marker がない fresh lock は回収しない。旧 image からの初回 rollout、SIGKILL、node 障害など shutdown hook と preStop の両方が動かない場合は heartbeat timeout を fallback とし、stale 判定を 180 秒、poll を 30 秒にして、最後の heartbeat から最大約 210 秒で再受付する。
 
 ## 実装
 
 ### boxp/arch
 
-- lock に `CODEX_TASK_BOARD_OWNER_ID`（Pod UID）を記録する。
+- lock に `CODEX_TASK_BOARD_OWNER_ID`（manifest 適用後は Pod UID、未設定時は Pod hostname）を記録する。
 - `prepare-shutdown` command で owner-scoped marker を永続化する。
+- loop process の SIGTERM shutdown hook からも同じ marker を永続化し、manifest hook がない場合も計画停止を通知する。
 - startup / `recover` で marker と lock owner が一致する fresh lock を `:interrupted` にし、Notes に計画停止理由を残す。
 - marker のない fresh active lock と、別 owner の lock は維持する。
 - stale / corrupt lock の既存復旧と Task Board lane source-of-truth は変更しない。
@@ -47,10 +48,17 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 - `replicas: 1` / `Recreate` を維持する。
 - README に rollout / rollback、lock 診断、安全な手動復旧、残る単一障害点を記録する。
 
+### cross-repository deployment contract
+
+runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pull/11010)、Deployment の変更は [boxp/lolice PR #723](https://github.com/boxp/lolice/pull/723) で同時にレビューする。lolice 側には `task-board-runner` の `preStop` から `prepare-shutdown` を呼ぶ設定、downward API の `metadata.uid` を `CODEX_TASK_BOARD_OWNER_ID` へ注入する設定、stale 180 秒 / poll 30 秒 / grace 60 秒が含まれる。PR #723 の ArgoCD diff と gitleaks は成功しており、render 上でもこれらの Deployment 差分を確認済みである。
+
+適用順は arch → lolice とする。arch の image だけが先に rollout した場合、終了する旧 image は marker を作れないが、新 image の default stale 180 秒と既存 poll 60 秒により最大約 240 秒で復旧する。以後は runner 自身の SIGTERM hook が hostname owner marker を作り、lolice 適用後は Pod UID と preStop を加えた二重化された経路になる。
+
 ## 検証計画
 
 - `boxp/arch/tests/codex-workspace/task-board-runner-test.sh` の全ケース。
 - 一時 vault / state を使い、fresh heartbeat の旧 owner lock + shutdown marker を新 owner が即時回収し、同じ tick で再実行できることを時間計測する。
+- loop process へ直接 SIGTERM を送り、preStop command なしでも owner / instance 一致の shutdown marker が作成されることを確認する。
 - marker のない fresh lock、owner 不一致の marker、現在 heartbeat 中の lock が回収されないことを確認する。
 - `kubectl kustomize argoproj/codex-workspace` と repository の Argo CD manifest validation を通す。
 - render 後 manifest で replica / strategy、Pod UID env、preStop、timeout、既存 container / Service / PVC mount が維持されることを確認する。
@@ -67,13 +75,15 @@ Service は `app=codex-workspace` の単一 Pod を選択し、image updater の
 
 - 単一 Pod、単一 RWO home PVC、配置 node、Kubernetes control plane / Longhorn、Obsidian remote、GitHub / agent API は HA 化しない。
 - SSH / Even Terminal や個々の agent session の live migration は行わず、Pod 再作成中は短時間切断される。
-- SIGKILL、node 障害、preStop 未実行時は owner marker を利用できないため、180 秒 heartbeat fallback で回収する。
+- SIGKILL、node 障害など shutdown hook と preStop の両方が実行されない場合は owner marker を利用できないため、180 秒 heartbeat fallback で回収する。
 
 ## 検証記録（2026-07-10 UTC）
 
 - 実環境 baseline: Deployment generation 89 / revision 83、`replicas=1`、`Recreate`、Pod `codex-workspace-858bcf8d45-zwswr`（UID `00aad169-dd98-4975-b339-a75c35efc2a5`）で 7 container が Ready。active lock は 1 秒間隔で heartbeat を更新していたが、現行 image の lock には owner metadata がなく、stale 設定は 1,800 秒だった。
 - validation environment: 一時 vault / state、fake Codex、旧 owner の fresh lock と planned-shutdown marker を使う black-box rollout simulation は 1 秒で `interrupted` 記録、Notes 追記、新 owner lock 取得、同 tick 再実行、最終 lane/frontmatter 更新まで完了した。
+- graceful signal: loop process に直接 SIGTERM を送り、preStop command を実行しない条件でも owner / instance 一致の shutdown marker が書かれる black-box test が通過した。
 - active safety: 現 owner marker と owner-instance 不一致 marker の fresh lock は回収されず、新 run が開始されないテストが通った。replacement lock 取得後は旧 heartbeat / release が別 owner lock を更新・削除しない実装とした。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
+- companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。
 - 未 merge の manifest / image を実クラスタへ直接 apply すると実行中 Task Board run を中断するため、本 run では live rollout を行わず、上記 validation environment の再現テストを採用した。merge 後の初回 rollout は旧 lock に owner metadata がない可能性があるため 180 秒 fallback、次回以降は planned marker の即時回収を runbook に従って実測する。

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -76,7 +76,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - rollout は通常の Argo CD sync / image updater に任せ、Pod の force delete は行わない。
 - rollout 前に Deployment が `replicas: 1` / `Recreate` であることを確認する。
 - 初回導入では lolice PR #723 を先に sync し、実 Pod の stale 180 秒 / poll 30 秒と受付再開を確認するまで arch PR #11010 を merge しない。
-- rollback は両 repository の変更を revert する。runner image を先に戻す場合も lock の追加 key は EDN の未知 key として無害で、lolice manifest の preStop は対応 command を含む image と同時に戻す。
+- rollback は active lock がない maintenance window で両 repository の変更を一体として revert し、image updater / Argo CD sync を調整して旧 runner image と旧 manifest を同じ変更単位で適用する。旧 image だけを先行 rollout すると新 manifest の `preStop prepare-shutdown` が失敗するため、単独 image downgrade は行わない。両方を調整できない場合は downgrade せず forward fix を優先する。lock の追加 key は旧 runner から未知 key として無視される。
 - lock の手動削除は、現 Pod UID と lock owner が不一致、該当 owner Pod が存在しない、heartbeat が stale であることを確認し、`task_board_runner.bb recover` が失敗した場合の最終手段に限定する。
 
 ## 残る単一障害点

--- a/docs/project_docs/BOXP-91/plan.md
+++ b/docs/project_docs/BOXP-91/plan.md
@@ -100,6 +100,7 @@ runner image の変更は [boxp/arch PR #11010](https://github.com/boxp/arch/pul
 - same-second recovery: 旧 run と同じ timestamp を固定して planned recovery を実行し、置換 run が UUID suffix 付きの別 summary directory を使い、旧 summary の `interrupted` 状態を維持するテストが通った。
 - cross-process ownership: recovery JVM を compare-and-delete 中で停止し、別 JVM が同じ永続 guard を取得して replacement lock を作る競合テストで、replacement lock が維持されることを確認した。
 - marker enumeration race: 一致 lock のない shutdown marker / owner state が初回 recovery 後も残り、その後に作成された fresh な一致 lock を次回 recovery で planned shutdown として回収することを確認した。
+- multi-lock marker race: 同じ owner / instance の lock を1件回収した直後に2件目が列挙へ現れる競合でも marker / owner state を保持し、次回 recovery で2件目を回収してから marker を削除することを確認した。
 - `tests/codex-workspace/task-board-runner-test.sh`、runner 内蔵 test、`tests/codex-workspace/recurring-events-test.sh` が通過した。recurring-events の passwordless sudo を要する ownership test だけは環境条件により skip された。
 - `kustomize build argoproj/codex-workspace` と、Calico NetworkPolicy 文書を除く client-side `kubectl apply --dry-run=client --validate=false` が通過した。Calico 文書は kubectl client の CRD patch 構造化変換制約のため render 成功で確認した。
 - companion の lolice PR #723 で ArgoCD diff と gitleaks が成功し、rendered Deployment に `preStop prepare-shutdown`、Pod UID の `CODEX_TASK_BOARD_OWNER_ID`、stale 180 秒、poll 30 秒、grace 60 秒が現れることを確認した。

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -451,6 +451,42 @@ EOF
   echo "planned shutdown recovery simulation passed in ${elapsed}s"
 }
 
+test_sigterm_writes_shutdown_marker_without_prestop() {
+  local tmp vault state output pid marker attempt
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  output="${tmp}/runner.out"
+  marker="${state}/terminating-owners/old-pod.edn"
+  write_board "${vault}" ""
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=old-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=old-instance \
+    CODEX_TASK_BOARD_POLL_SECONDS=60 \
+    bb "${RUNNER}" loop >"${output}" 2>&1 &
+  pid=$!
+
+  for attempt in $(seq 1 50); do
+    [[ -e "${state}/owners/old-pod.edn" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -e "${state}/owners/old-pod.edn" ]]; then
+    kill -KILL "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    fail "expected loop runner to activate old-pod owner"
+  fi
+
+  kill -TERM "${pid}"
+  wait "${pid}" 2>/dev/null || true
+
+  [[ -e "${marker}" ]] || fail "expected SIGTERM shutdown hook to write owner marker"
+  assert_file_contains "${marker}" ':owner-id "old-pod"'
+  assert_file_contains "${marker}" ':instance-id "old-instance"'
+  assert_file_contains "${output}" 'prepared shutdown for owner old-pod, instance=old-instance'
+}
+
 test_current_owner_shutdown_marker_drains_without_recovery() {
   local tmp vault state bin old_run heartbeat start_log
   tmp="$(mktemp -d)"
@@ -963,6 +999,7 @@ test_codex_full_assignee_includes_delegation_policy
 test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
 test_planned_shutdown_lock_recovers_immediately
+test_sigterm_writes_shutdown_marker_without_prestop
 test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_review_without_pr_is_blocked

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -691,7 +691,9 @@ EOF
 
   [[ ! -e "${state}/locks/BOXP-206.edn" ]] || fail "expected late matching lock to be recovered"
   [[ ! -e "${marker}" ]] || fail "expected consumed marker to be removed"
-  [[ ! -e "${owner_state}" ]] || fail "expected recovered owner state to be removed"
+  [[ -e "${owner_state}" ]] || fail "expected recovered owner state to remain as a termination tombstone"
+  assert_file_contains "${owner_state}" ':status :terminated'
+  assert_file_contains "${owner_state}" ':instance-id "old-instance"'
   assert_file_contains "${state}/runs/BOXP-206/${old_run}/summary.edn" ':status :interrupted'
   assert_file_contains "${state}/runs/BOXP-206/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
 }
@@ -761,9 +763,39 @@ EOF
 
   [[ ! -e "${state}/locks/BOXP-208.edn" ]] || fail "expected the late lock to be recovered on the next scan"
   [[ ! -e "${marker}" ]] || fail "expected marker removal after all matching locks were recovered"
-  [[ ! -e "${owner_state}" ]] || fail "expected owner state removal after all matching locks were recovered"
+  [[ -e "${owner_state}" ]] || fail "expected owner termination tombstone after all matching locks were recovered"
+  assert_file_contains "${owner_state}" ':status :terminated'
+  assert_file_contains "${owner_state}" ':instance-id "old-instance"'
   assert_file_contains "${state}/runs/BOXP-208/${late_run}/summary.edn" ':status :interrupted'
   assert_file_contains "${state}/runs/BOXP-208/${late_run}/summary.edn" ':reason "planned workspace shutdown"'
+}
+
+test_terminated_owner_cannot_create_lock_after_marker_cleanup() {
+  local tmp vault state bin start_log heartbeat
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  start_log="${tmp}/starts.log"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "${bin}" "${state}/owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-209|BOXP-209: retired owner]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-209 in-progress codex
+  cat >"${state}/owners/old-pod.edn" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :status :terminated :host "old-pod" :terminated-at "${heartbeat}"}
+EOF
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_OWNER_ID=old-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=old-instance \
+    CODEX_FAKE_START_LOG="${start_log}" \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-terminated-owner.out
+
+  [[ ! -e "${start_log}" ]] || fail "expected a terminated owner not to start an agent"
+  [[ ! -e "${state}/locks/BOXP-209.edn" ]] || fail "expected a terminated owner not to create a lock"
+  assert_file_contains /tmp/task-board-terminated-owner.out 'is draining; not accepting new tickets'
+  assert_file_contains "${vault}/Tickets/BOXP-209.md" '^status: in-progress$'
 }
 
 test_review_without_pr_is_blocked() {
@@ -1218,6 +1250,7 @@ test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_shutdown_marker_waits_for_late_matching_lock
 test_shutdown_marker_survives_late_second_lock
+test_terminated_owner_cannot_create_lock_after_marker_cleanup
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
 test_review_without_repo_marker_skips_pr_gates

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -455,6 +455,58 @@ EOF
   echo "planned shutdown recovery simulation passed in ${elapsed}s"
 }
 
+test_cross_process_lock_guard_preserves_replacement_lock() {
+  local tmp vault state old_run heartbeat signal recover_pid replacement
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  old_run="20260710T000050Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  signal="${tmp}/before-delete"
+  mkdir -p "${state}/locks" "${state}/runs/BOXP-205/${old_run}"
+  write_board "${vault}" ""
+  cat >"${state}/locks/BOXP-205.edn" <<EOF
+{:ticket "BOXP-205" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "old-instance" :heartbeat-at "2000-01-01T00:00:00Z"}
+EOF
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_TASK_BOARD_TEST_BEFORE_LOCK_DELETE_SIGNAL="${signal}" \
+    CODEX_TASK_BOARD_TEST_BEFORE_LOCK_DELETE_MILLIS=1500 \
+    bb "${RUNNER}" recover >/tmp/task-board-cross-process-recover.out 2>&1 &
+  recover_pid=$!
+
+  for _attempt in $(seq 1 50); do
+    [[ -e "${signal}" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -e "${signal}" ]]; then
+    kill -KILL "${recover_pid}" 2>/dev/null || true
+    wait "${recover_pid}" 2>/dev/null || true
+    fail "expected recovery process to reach guarded compare-and-delete"
+  fi
+
+  replacement="{:ticket \"BOXP-205\" :run-id \"replacement-run\" :action :implement :lane \"In Progress\" :owner-id \"replacement-pod\" :owner-instance-id \"replacement-instance\" :heartbeat-at \"${heartbeat}\"}"
+  bb -e '
+    (let [[guard-path lock-path content] *command-line-args*
+          guard-file (java.io.File. guard-path)]
+      (.mkdirs (.getParentFile guard-file))
+      (with-open [file (java.io.RandomAccessFile. guard-file "rw")
+                  channel (.getChannel file)]
+        (let [_file-lock (.lock channel)]
+          (spit lock-path (str content "\n")))))' \
+    "${state}/lock-guards/BOXP-205.lock" \
+    "${state}/locks/BOXP-205.edn" \
+    "${replacement}"
+
+  wait "${recover_pid}"
+  assert_file_contains "${state}/locks/BOXP-205.edn" ':run-id "replacement-run"'
+  assert_file_contains "${state}/locks/BOXP-205.edn" ':owner-id "replacement-pod"'
+  assert_file_contains "${state}/runs/BOXP-205/${old_run}/summary.edn" ':status :interrupted'
+}
+
 test_sigterm_writes_shutdown_marker_without_prestop() {
   local tmp vault state output pid marker attempt
   tmp="$(mktemp -d)"
@@ -1003,6 +1055,7 @@ test_codex_full_assignee_includes_delegation_policy
 test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
 test_planned_shutdown_lock_recovers_immediately
+test_cross_process_lock_guard_preserves_replacement_lock
 test_sigterm_writes_shutdown_marker_without_prestop
 test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -683,6 +683,59 @@ EOF
   assert_file_contains "${marker}" ':instance-id "new-instance"'
 }
 
+test_same_owner_new_instance_retires_empty_previous_marker() {
+  local tmp vault state bin heartbeat start_log output marker pid
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  start_log="${tmp}/starts.log"
+  output="${tmp}/runner.out"
+  marker="${state}/terminating-owners/restarted-empty-pod.edn"
+  mkdir -p "${bin}" "${state}/terminating-owners" "${state}/owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-211|BOXP-211: empty container restart]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-211 in-progress codex
+  cat >"${state}/owners/restarted-empty-pod.edn" <<EOF
+{:owner-id "restarted-empty-pod" :instance-id "old-instance" :status :terminating :host "restarted-empty-pod" :shutdown-requested-at "${heartbeat}"}
+EOF
+  cat >"${marker}" <<EOF
+{:owner-id "restarted-empty-pod" :instance-id "old-instance" :host "restarted-empty-pod" :requested-at "${heartbeat}"}
+EOF
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=restarted-empty-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_TASK_BOARD_POLL_SECONDS=1 \
+    CODEX_FAKE_START_LOG="${start_log}" \
+    bb "${RUNNER}" loop >"${output}" 2>&1 &
+  pid=$!
+
+  for _attempt in $(seq 1 100); do
+    if [[ -e "${start_log}" ]] && grep -Eq '^status: done$' "${vault}/Tickets/BOXP-211.md"; then
+      break
+    fi
+    sleep 0.1
+  done
+  if [[ ! -e "${start_log}" ]] || ! grep -Eq '^status: done$' "${vault}/Tickets/BOXP-211.md"; then
+    kill -KILL "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    fail "expected a new runner instance to retire an empty previous marker and accept tickets"
+  fi
+
+  [[ ! -e "${marker}" ]] || fail "expected the empty previous instance marker to be retired"
+  assert_file_contains "${state}/owners/restarted-empty-pod.edn" ':instance-id "new-instance"'
+  assert_file_contains "${state}/owners/restarted-empty-pod.edn" ':status :active'
+  assert_file_not_contains "${output}" 'is draining; not accepting new tickets'
+
+  kill -TERM "${pid}"
+  wait "${pid}" 2>/dev/null || true
+  assert_file_contains "${marker}" ':instance-id "new-instance"'
+}
+
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock() {
   local tmp vault state bin old_run heartbeat start_log
   tmp="$(mktemp -d)"
@@ -1311,6 +1364,7 @@ test_sigterm_writes_shutdown_marker_without_prestop
 test_one_shot_tick_does_not_replace_loop_owner_instance
 test_current_owner_shutdown_marker_drains_without_recovery
 test_same_owner_new_instance_recovers_previous_instance
+test_same_owner_new_instance_retires_empty_previous_marker
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_shutdown_marker_waits_for_late_matching_lock
 test_shutdown_marker_survives_late_second_lock

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -620,6 +620,69 @@ EOF
   assert_file_contains "${vault}/Tickets/BOXP-203.md" '^status: in-progress$'
 }
 
+test_same_owner_new_instance_recovers_previous_instance() {
+  local tmp vault state bin old_run heartbeat start_log output marker pid
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  old_run="20260710T000150Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  start_log="${tmp}/starts.log"
+  output="${tmp}/runner.out"
+  marker="${state}/terminating-owners/restarted-pod.edn"
+  mkdir -p \
+    "${bin}" \
+    "${state}/locks" \
+    "${state}/runs/BOXP-210/${old_run}" \
+    "${state}/terminating-owners" \
+    "${state}/owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-210|BOXP-210: container restart]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-210 in-progress codex
+  cat >"${state}/owners/restarted-pod.edn" <<EOF
+{:owner-id "restarted-pod" :instance-id "old-instance" :status :terminating :host "restarted-pod" :shutdown-requested-at "${heartbeat}"}
+EOF
+  cat >"${marker}" <<EOF
+{:owner-id "restarted-pod" :instance-id "old-instance" :host "restarted-pod" :requested-at "${heartbeat}"}
+EOF
+  cat >"${state}/locks/BOXP-210.edn" <<EOF
+{:ticket "BOXP-210" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "restarted-pod" :owner-instance-id "old-instance" :heartbeat-at "${heartbeat}"}
+EOF
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=restarted-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_TASK_BOARD_POLL_SECONDS=1 \
+    CODEX_FAKE_START_LOG="${start_log}" \
+    bb "${RUNNER}" loop >"${output}" 2>&1 &
+  pid=$!
+
+  for _attempt in $(seq 1 100); do
+    if [[ -e "${start_log}" ]] && grep -Eq '^status: done$' "${vault}/Tickets/BOXP-210.md"; then
+      break
+    fi
+    sleep 0.1
+  done
+  if [[ ! -e "${start_log}" ]] || ! grep -Eq '^status: done$' "${vault}/Tickets/BOXP-210.md"; then
+    kill -KILL "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    fail "expected a new runner instance with the same owner to recover and accept tickets"
+  fi
+
+  [[ ! -e "${marker}" ]] || fail "expected the previous instance marker to be consumed"
+  assert_file_contains "${state}/owners/restarted-pod.edn" ':instance-id "new-instance"'
+  assert_file_contains "${state}/owners/restarted-pod.edn" ':status :active'
+  assert_file_contains "${state}/runs/BOXP-210/${old_run}/summary.edn" ':status :interrupted'
+  assert_file_contains "${state}/runs/BOXP-210/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
+
+  kill -TERM "${pid}"
+  wait "${pid}" 2>/dev/null || true
+  assert_file_contains "${marker}" ':instance-id "new-instance"'
+}
+
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock() {
   local tmp vault state bin old_run heartbeat start_log
   tmp="$(mktemp -d)"
@@ -1247,6 +1310,7 @@ test_cross_process_lock_guard_preserves_replacement_lock
 test_sigterm_writes_shutdown_marker_without_prestop
 test_one_shot_tick_does_not_replace_loop_owner_instance
 test_current_owner_shutdown_marker_drains_without_recovery
+test_same_owner_new_instance_recovers_previous_instance
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_shutdown_marker_waits_for_late_matching_lock
 test_shutdown_marker_survives_late_second_lock

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -543,6 +543,48 @@ test_sigterm_writes_shutdown_marker_without_prestop() {
   assert_file_contains "${output}" 'prepared shutdown for owner old-pod, instance=old-instance'
 }
 
+test_one_shot_tick_does_not_replace_loop_owner_instance() {
+  local tmp vault state output pid marker
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  output="${tmp}/runner.out"
+  marker="${state}/terminating-owners/pod-x.edn"
+  write_board "${vault}" ""
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=pod-x \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=loop-instance \
+    CODEX_TASK_BOARD_POLL_SECONDS=60 \
+    bb "${RUNNER}" loop >"${output}" 2>&1 &
+  pid=$!
+
+  for _attempt in $(seq 1 50); do
+    [[ -e "${state}/owners/pod-x.edn" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -e "${state}/owners/pod-x.edn" ]]; then
+    kill -KILL "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    fail "expected loop runner to register its owner instance"
+  fi
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=pod-x \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=tick-instance \
+    bb "${RUNNER}" tick >/tmp/task-board-owner-one-shot-tick.out
+  assert_file_contains "${state}/owners/pod-x.edn" ':instance-id "loop-instance"'
+  assert_file_not_contains "${state}/owners/pod-x.edn" ':instance-id "tick-instance"'
+
+  kill -TERM "${pid}"
+  wait "${pid}" 2>/dev/null || true
+  [[ -e "${marker}" ]] || fail "expected loop shutdown to create an owner marker"
+  assert_file_contains "${marker}" ':instance-id "loop-instance"'
+  assert_file_not_contains "${marker}" ':instance-id "tick-instance"'
+}
+
 test_current_owner_shutdown_marker_drains_without_recovery() {
   local tmp vault state bin old_run heartbeat start_log
   tmp="$(mktemp -d)"
@@ -1171,6 +1213,7 @@ test_stale_lock_recovers
 test_planned_shutdown_lock_recovers_immediately
 test_cross_process_lock_guard_preserves_replacement_lock
 test_sigterm_writes_shutdown_marker_without_prestop
+test_one_shot_tick_does_not_replace_loop_owner_instance
 test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_shutdown_marker_waits_for_late_matching_lock

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -606,8 +606,52 @@ EOF
 
   [[ ! -e "${start_log}" ]] || fail "expected mismatched marker not to start a replacement run"
   [[ -e "${state}/locks/BOXP-204.edn" ]] || fail "expected fresh mismatched lock to remain"
+  [[ -e "${state}/terminating-owners/old-pod.edn" ]] || fail "expected unmatched marker to remain for a later scan"
   assert_file_not_contains "${vault}/Tickets/BOXP-204.md" 'marked interrupted'
   assert_file_contains "${vault}/Tickets/BOXP-204.md" '^status: in-progress$'
+}
+
+test_shutdown_marker_waits_for_late_matching_lock() {
+  local tmp vault state old_run heartbeat marker owner_state
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  old_run="20260710T000300Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  marker="${state}/terminating-owners/old-pod.edn"
+  owner_state="${state}/owners/old-pod.edn"
+  mkdir -p "${state}/locks" "${state}/runs/BOXP-206/${old_run}" "${state}/terminating-owners" "${state}/owners"
+  write_board "${vault}" ""
+  cat >"${marker}" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :host "old-pod" :requested-at "${heartbeat}"}
+EOF
+  cat >"${owner_state}" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :host "old-pod" :pid 10 :started-at "${heartbeat}"}
+EOF
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    bb "${RUNNER}" recover >/tmp/task-board-marker-before-lock.out
+
+  [[ -e "${marker}" ]] || fail "expected marker without a matching lock to survive recovery"
+  [[ -e "${owner_state}" ]] || fail "expected owner state to remain with an unmatched marker"
+  cat >"${state}/locks/BOXP-206.edn" <<EOF
+{:ticket "BOXP-206" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "old-instance" :heartbeat-at "${heartbeat}"}
+EOF
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    bb "${RUNNER}" recover >/tmp/task-board-marker-after-lock.out
+
+  [[ ! -e "${state}/locks/BOXP-206.edn" ]] || fail "expected late matching lock to be recovered"
+  [[ ! -e "${marker}" ]] || fail "expected consumed marker to be removed"
+  [[ ! -e "${owner_state}" ]] || fail "expected recovered owner state to be removed"
+  assert_file_contains "${state}/runs/BOXP-206/${old_run}/summary.edn" ':status :interrupted'
+  assert_file_contains "${state}/runs/BOXP-206/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
 }
 
 test_review_without_pr_is_blocked() {
@@ -1059,6 +1103,7 @@ test_cross_process_lock_guard_preserves_replacement_lock
 test_sigterm_writes_shutdown_marker_without_prestop
 test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
+test_shutdown_marker_waits_for_late_matching_lock
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
 test_review_without_repo_marker_skips_pr_gates

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -70,6 +70,9 @@ fi
 if [[ -n "${CODEX_FAKE_START_LOG:-}" ]]; then
   printf '%s %s\n' "${ticket}" "$(date +%s)" >>"${CODEX_FAKE_START_LOG}"
 fi
+if [[ -n "${CODEX_FAKE_LOCK_SNAPSHOT:-}" && -n "${CODEX_FAKE_LOCK_FILE:-}" ]]; then
+  cp "${CODEX_FAKE_LOCK_FILE}" "${CODEX_FAKE_LOCK_SNAPSHOT}"
+fi
 sleep "${CODEX_FAKE_SLEEP:-0}"
 printf '%s\n' "${CODEX_FAKE_MESSAGE:-TASK_BOARD_RESULT: done}" >"${last_message}"
 rm -f "${prompt}"
@@ -230,7 +233,7 @@ run_tick() {
   shift 2
   CODEX_TASK_BOARD_VAULT="${vault}" \
   CODEX_TASK_BOARD_ROOT="${state_root}" \
-  CODEX_TASK_BOARD_LOCK_STALE_SECONDS="${CODEX_TASK_BOARD_LOCK_STALE_SECONDS:-1800}" \
+  CODEX_TASK_BOARD_LOCK_STALE_SECONDS="${CODEX_TASK_BOARD_LOCK_STALE_SECONDS:-180}" \
   "$@" bb "${RUNNER}" tick
 }
 
@@ -400,6 +403,119 @@ EOF
   assert_file_contains "${vault}/Tickets/BOXP-201.md" 'marked interrupted after heartbeat timeout'
   assert_file_contains "${vault}/Tickets/BOXP-201.md" '^status: done$'
   [[ ! -e "${state}/locks/BOXP-201.edn" ]] || fail "expected stale lock to be released"
+}
+
+test_planned_shutdown_lock_recovers_immediately() {
+  local tmp vault state bin old_run lock_snapshot started elapsed heartbeat
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  old_run="20260710T000000Z"
+  lock_snapshot="${tmp}/new-lock.edn"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "${bin}" "${state}/locks" "${state}/runs/BOXP-202/${old_run}" "${state}/owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-202|BOXP-202: planned restart]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-202 in-progress codex
+  cat >"${state}/owners/old-pod.edn" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :host "old-pod" :pid 10 :started-at "${heartbeat}"}
+EOF
+  cat >"${state}/locks/BOXP-202.edn" <<EOF
+{:ticket "BOXP-202" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "old-instance" :heartbeat-at "${heartbeat}"}
+EOF
+
+  CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=old-pod \
+    bb "${RUNNER}" prepare-shutdown >/tmp/task-board-prepare-shutdown.out
+  assert_file_contains "${state}/terminating-owners/old-pod.edn" ':instance-id "old-instance"'
+
+  started="${SECONDS}"
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_FAKE_LOCK_FILE="${state}/locks/BOXP-202.edn" \
+    CODEX_FAKE_LOCK_SNAPSHOT="${lock_snapshot}" \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-planned-recovery.out
+  elapsed=$((SECONDS - started))
+
+  [[ "${elapsed}" -lt 5 ]] || fail "expected planned shutdown recovery under 5s in simulation, got ${elapsed}s"
+  assert_file_contains "${state}/runs/BOXP-202/${old_run}/summary.edn" ':status :interrupted'
+  assert_file_contains "${state}/runs/BOXP-202/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
+  assert_file_contains "${vault}/Tickets/BOXP-202.md" 'marked interrupted after planned workspace shutdown of owner old-pod'
+  assert_file_contains "${vault}/Tickets/BOXP-202.md" '^status: done$'
+  assert_file_contains "${lock_snapshot}" ':owner-id "new-pod"'
+  assert_file_contains "${lock_snapshot}" ':owner-instance-id "new-instance"'
+  [[ ! -e "${state}/terminating-owners/old-pod.edn" ]] || fail "expected recovered owner marker to be removed"
+  [[ ! -e "${state}/locks/BOXP-202.edn" ]] || fail "expected replacement run to release its lock"
+  echo "planned shutdown recovery simulation passed in ${elapsed}s"
+}
+
+test_current_owner_shutdown_marker_drains_without_recovery() {
+  local tmp vault state bin old_run heartbeat start_log
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  old_run="20260710T000100Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  start_log="${tmp}/starts.log"
+  mkdir -p "${bin}" "${state}/locks" "${state}/runs/BOXP-203/${old_run}" "${state}/owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-203|BOXP-203: draining]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-203 in-progress codex
+  cat >"${state}/owners/current-pod.edn" <<EOF
+{:owner-id "current-pod" :instance-id "current-instance" :host "current-pod" :pid 10 :started-at "${heartbeat}"}
+EOF
+  cat >"${state}/locks/BOXP-203.edn" <<EOF
+{:ticket "BOXP-203" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "current-pod" :owner-instance-id "current-instance" :heartbeat-at "${heartbeat}"}
+EOF
+  CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=current-pod \
+    bb "${RUNNER}" prepare-shutdown >/tmp/task-board-current-prepare.out
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_OWNER_ID=current-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=current-instance \
+    CODEX_FAKE_START_LOG="${start_log}" \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-current-drain.out
+
+  [[ ! -e "${start_log}" ]] || fail "expected draining owner not to start a replacement run"
+  [[ -e "${state}/locks/BOXP-203.edn" ]] || fail "expected current owner lock to remain active"
+  assert_file_contains /tmp/task-board-current-drain.out 'is draining; not accepting new tickets'
+  assert_file_contains "${vault}/Tickets/BOXP-203.md" '^status: in-progress$'
+}
+
+test_mismatched_shutdown_marker_does_not_recover_fresh_lock() {
+  local tmp vault state bin old_run heartbeat start_log
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  old_run="20260710T000200Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  start_log="${tmp}/starts.log"
+  mkdir -p "${bin}" "${state}/locks" "${state}/runs/BOXP-204/${old_run}" "${state}/terminating-owners"
+  make_fake_codex "${bin}"
+  write_board "${vault}" "- [ ] [[Tickets/BOXP-204|BOXP-204: mismatched owner]] #ticket status::in-progress"
+  write_ticket "${vault}" BOXP-204 in-progress codex
+  cat >"${state}/locks/BOXP-204.edn" <<EOF
+{:ticket "BOXP-204" :run-id "${old_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "still-active" :heartbeat-at "${heartbeat}"}
+EOF
+  cat >"${state}/terminating-owners/old-pod.edn" <<EOF
+{:owner-id "old-pod" :instance-id "different-instance" :host "old-pod" :requested-at "${heartbeat}"}
+EOF
+
+  PATH="${bin}:$PATH" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_FAKE_START_LOG="${start_log}" \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-mismatched-owner.out
+
+  [[ ! -e "${start_log}" ]] || fail "expected mismatched marker not to start a replacement run"
+  [[ -e "${state}/locks/BOXP-204.edn" ]] || fail "expected fresh mismatched lock to remain"
+  assert_file_not_contains "${vault}/Tickets/BOXP-204.md" 'marked interrupted'
+  assert_file_contains "${vault}/Tickets/BOXP-204.md" '^status: in-progress$'
 }
 
 test_review_without_pr_is_blocked() {
@@ -846,6 +962,9 @@ test_codex_sol_assignee_includes_delegation_policy
 test_codex_full_assignee_includes_delegation_policy
 test_unsupported_assignee_is_ignored
 test_stale_lock_recovers
+test_planned_shutdown_lock_recovers_immediately
+test_current_owner_shutdown_marker_drains_without_recovery
+test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
 test_review_without_repo_marker_skips_pr_gates

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -406,7 +406,7 @@ EOF
 }
 
 test_planned_shutdown_lock_recovers_immediately() {
-  local tmp vault state bin old_run lock_snapshot started elapsed heartbeat
+  local tmp vault state bin old_run lock_snapshot replacement_run started elapsed heartbeat
   tmp="$(mktemp -d)"
   vault="${tmp}/vault"
   state="${tmp}/state"
@@ -434,14 +434,18 @@ EOF
   PATH="${bin}:$PATH" \
     CODEX_TASK_BOARD_OWNER_ID=new-pod \
     CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_TASK_BOARD_RUN_TIMESTAMP="${old_run}" \
     CODEX_FAKE_LOCK_FILE="${state}/locks/BOXP-202.edn" \
     CODEX_FAKE_LOCK_SNAPSHOT="${lock_snapshot}" \
     run_tick "${vault}" "${state}" env >/tmp/task-board-planned-recovery.out
   elapsed=$((SECONDS - started))
+  replacement_run="$(sed -n 's/.*:run-id "\([^"]*\)".*/\1/p' "${lock_snapshot}" | head -n 1)"
 
   [[ "${elapsed}" -lt 5 ]] || fail "expected planned shutdown recovery under 5s in simulation, got ${elapsed}s"
+  [[ "${replacement_run}" == "${old_run}-"* ]] || fail "expected a unique replacement run ID for the same timestamp, got ${replacement_run}"
   assert_file_contains "${state}/runs/BOXP-202/${old_run}/summary.edn" ':status :interrupted'
   assert_file_contains "${state}/runs/BOXP-202/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
+  assert_file_contains "${state}/runs/BOXP-202/${replacement_run}/summary.edn" ':status :succeeded'
   assert_file_contains "${vault}/Tickets/BOXP-202.md" 'marked interrupted after planned workspace shutdown of owner old-pod'
   assert_file_contains "${vault}/Tickets/BOXP-202.md" '^status: done$'
   assert_file_contains "${lock_snapshot}" ':owner-id "new-pod"'

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -654,6 +654,76 @@ EOF
   assert_file_contains "${state}/runs/BOXP-206/${old_run}/summary.edn" ':reason "planned workspace shutdown"'
 }
 
+test_shutdown_marker_survives_late_second_lock() {
+  local tmp vault state first_run late_run heartbeat marker owner_state signal recover_pid
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  first_run="20260710T000400Z"
+  late_run="20260710T000401Z"
+  heartbeat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  marker="${state}/terminating-owners/old-pod.edn"
+  owner_state="${state}/owners/old-pod.edn"
+  signal="${tmp}/before-marker-delete"
+  mkdir -p \
+    "${state}/locks" \
+    "${state}/runs/BOXP-207/${first_run}" \
+    "${state}/runs/BOXP-208/${late_run}" \
+    "${state}/terminating-owners" \
+    "${state}/owners"
+  write_board "${vault}" ""
+  cat >"${marker}" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :host "old-pod" :requested-at "${heartbeat}"}
+EOF
+  cat >"${owner_state}" <<EOF
+{:owner-id "old-pod" :instance-id "old-instance" :host "old-pod" :pid 10 :started-at "${heartbeat}"}
+EOF
+  cat >"${state}/locks/BOXP-207.edn" <<EOF
+{:ticket "BOXP-207" :run-id "${first_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "old-instance" :heartbeat-at "${heartbeat}"}
+EOF
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_SIGNAL="${signal}" \
+    CODEX_TASK_BOARD_TEST_BEFORE_MARKER_DELETE_MILLIS=1500 \
+    bb "${RUNNER}" recover >/tmp/task-board-marker-late-second.out 2>&1 &
+  recover_pid=$!
+
+  for _attempt in $(seq 1 50); do
+    [[ -e "${signal}" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -e "${signal}" ]]; then
+    kill -KILL "${recover_pid}" 2>/dev/null || true
+    wait "${recover_pid}" 2>/dev/null || true
+    fail "expected recovery to pause before deleting a consumed marker"
+  fi
+  cat >"${state}/locks/BOXP-208.edn" <<EOF
+{:ticket "BOXP-208" :run-id "${late_run}" :action :implement :lane "In Progress" :owner-id "old-pod" :owner-instance-id "old-instance" :heartbeat-at "${heartbeat}"}
+EOF
+  wait "${recover_pid}"
+
+  [[ ! -e "${state}/locks/BOXP-207.edn" ]] || fail "expected the first matching lock to be recovered"
+  [[ -e "${state}/locks/BOXP-208.edn" ]] || fail "expected the late lock to remain for the next scan"
+  [[ -e "${marker}" ]] || fail "expected a marker with a late second lock to be retained"
+  [[ -e "${owner_state}" ]] || fail "expected owner state to remain while a matching lock exists"
+  assert_file_contains "${state}/runs/BOXP-207/${first_run}/summary.edn" ':status :interrupted'
+
+  CODEX_TASK_BOARD_VAULT="${vault}" \
+    CODEX_TASK_BOARD_ROOT="${state}" \
+    CODEX_TASK_BOARD_OWNER_ID=new-pod \
+    CODEX_TASK_BOARD_RUNNER_INSTANCE_ID=new-instance \
+    bb "${RUNNER}" recover >/tmp/task-board-marker-late-second-retry.out
+
+  [[ ! -e "${state}/locks/BOXP-208.edn" ]] || fail "expected the late lock to be recovered on the next scan"
+  [[ ! -e "${marker}" ]] || fail "expected marker removal after all matching locks were recovered"
+  [[ ! -e "${owner_state}" ]] || fail "expected owner state removal after all matching locks were recovered"
+  assert_file_contains "${state}/runs/BOXP-208/${late_run}/summary.edn" ':status :interrupted'
+  assert_file_contains "${state}/runs/BOXP-208/${late_run}/summary.edn" ':reason "planned workspace shutdown"'
+}
+
 test_review_without_pr_is_blocked() {
   local tmp vault state bin
   tmp="$(mktemp -d)"
@@ -1104,6 +1174,7 @@ test_sigterm_writes_shutdown_marker_without_prestop
 test_current_owner_shutdown_marker_drains_without_recovery
 test_mismatched_shutdown_marker_does_not_recover_fresh_lock
 test_shutdown_marker_waits_for_late_matching_lock
+test_shutdown_marker_survives_late_second_lock
 test_review_without_pr_is_blocked
 test_review_with_pr_url_is_noted
 test_review_without_repo_marker_skips_pr_gates


### PR DESCRIPTION
## Summary

- Task Board lock に Pod UID / hostname owner と runner instance ID を記録
- preStop または runner 自身の SIGTERM shutdown hook で owner marker を永続化
- marker と一致する旧 lock だけを次 Pod が即時に interrupted 回収
- ticket ごとの永続 guard file + Java FileLock で、runner / helper / replacement JVM 間の compare-and-delete、acquire、heartbeat、release を直列化
- 現 owner / owner-instance 不一致の fresh lock を維持し、heartbeat / release も所有権一致時だけ更新
- preStop と shutdown hook の両方が動かない場合の stale fallback を 180 秒に短縮
- run ID を秒 timestamp + UUID にし、同一秒の即時再開でも summary / workspace / branch の衝突を防止
- BOXP-91 の設計・実測・validation 記録と black-box test を追加

## Deployment contract

- Companion manifest: https://github.com/boxp/lolice/pull/723
- lolice PR で preStop prepare-shutdown、downward API の Pod UID、poll 30 秒、stale 180 秒、grace 60 秒を設定
- PR #723 の ArgoCD diff / gitleaks とローカル render / client dry-run が成功
- 初回導入順は **lolice #723 を merge / sync → 実 Pod の stale 180 秒・poll 30 秒と受付再開を確認 → arch #11010 を merge** とする
- arch を先に rollout しない。旧 manifest の明示値 1,800 秒が runner default を上書きして5分条件を破るため
- lolice 先行 rollout と続く arch image rollout は旧 runner の marker を前提にせず、先に適用した 180 秒 / 30 秒設定で最後の heartbeat から最大約 210 秒以内に復旧する
- 新 image 起動後は SIGTERM hook + preStop の二重化が有効になる

## Safety invariants

- RWO PVC の writer 数は増やさない
- Task Board lane を source of truth とする既存仕様を維持
- 同一 ticket の active lock は current owner から回収しない
- replacement lock を旧 JVM の release / recovery が削除しない
- manifest-first gate により初回 rollout も 5 分以内に復旧
- rollback は active lock のない maintenance window で両 repository を一体適用し、旧 image の単独先行は行わない

## Validation

- tests/codex-workspace/task-board-runner-test.sh
- bb docker/codex-workspace/task-board/task_board_runner.bb test
- tests/codex-workspace/recurring-events-test.sh（passwordless sudo 必須ケースのみ環境条件で skip）
- direct SIGTERM: preStop command なしで owner / instance 一致 marker を作成
- planned rollout simulation: 1 秒で interrupted 記録、Notes 追記、新 owner 取得、同 tick 再実行
- same-second recovery: 旧 summary を interrupted のまま維持し、置換 run は UUID suffix 付きの別 directory で succeeded
- cross-process race: recovery JVM の compare 後に別 JVM が guard を待って replacement lock を作成し、新 lock が維持されることを確認
- companion manifest の Kustomize render と Calico NetworkPolicy を除く client-side dry-run

Refs: BOXP-91
