### PR TITLE
Fix Novel Board pi agent silently exiting due to --offline flag

### DIFF
--- a/docker/codex-workspace/novel-board/novel_board_runner.bb
+++ b/docker/codex-workspace/novel-board/novel_board_runner.bb
@@ -764,7 +764,7 @@
                           (conj "--dangerously-skip-permissions")
                           (System/getenv "CODEX_NOVEL_BOARD_FABLE_MODEL")
                           (into ["--model" (System/getenv "CODEX_NOVEL_BOARD_FABLE_MODEL")]))
-                 :pi (cond-> ["pi" "--offline"
+                 :pi (cond-> ["pi"
                               "--no-extensions" "--no-skills"
                               "--no-prompt-templates" "--no-context-files"
                               "--print" "--approve" "--mode" "text"

--- a/tests/codex-workspace/novel-board-runner-test.sh
+++ b/tests/codex-workspace/novel-board-runner-test.sh
@@ -430,6 +430,7 @@ test_write_review_and_pi_revision() {
   FAKE_ARG_LOG="${args}" CODEX_NOVEL_BOARD_PI_MODEL="llama.cpp/gemma4-26b-vision" run_tick "${vault}" "${state}" "${bin}" env
   assert_contains "${state}/work/NOVEL-2/manuscript.md" "Pi 改稿済み"
   assert_contains "${args}" "pi --no-extensions --no-skills --no-prompt-templates --no-context-files --print --approve --mode text --session-dir"
+  assert_not_contains "${args}" "--offline"
   assert_contains "${args}" "--model llama.cpp/gemma4-26b-vision"
   assert_contains "${args}" "@${image}"
   assert_contains "${args}" "@${markdown_image}"

--- a/tests/codex-workspace/novel-board-runner-test.sh
+++ b/tests/codex-workspace/novel-board-runner-test.sh
@@ -429,7 +429,7 @@ test_write_review_and_pi_revision() {
   sed -i "/^- Synopsis:/a\\- Vision reference: ![[Attachments/character reference.png]]\\n- Setting reference: ![setting](Attachments/setting.webp)\\n- Rejected external image: ![[${outside}]]" "${vault}/Novels/NOVEL-2.md"
   FAKE_ARG_LOG="${args}" CODEX_NOVEL_BOARD_PI_MODEL="llama.cpp/gemma4-26b-vision" run_tick "${vault}" "${state}" "${bin}" env
   assert_contains "${state}/work/NOVEL-2/manuscript.md" "Pi 改稿済み"
-  assert_contains "${args}" "pi --offline --no-extensions --no-skills --no-prompt-templates --no-context-files --print --approve --mode text --session-dir"
+  assert_contains "${args}" "pi --no-extensions --no-skills --no-prompt-templates --no-context-files --print --approve --mode text --session-dir"
   assert_contains "${args}" "--model llama.cpp/gemma4-26b-vision"
   assert_contains "${args}" "@${image}"
   assert_contains "${args}" "@${markdown_image}"


### PR DESCRIPTION
## Summary

- `--offline` フラグが `pi --print` モードで使用されると、piがプロンプトを処理せずにexit 0で即時終了していた
- 実際の稼働ログ (`NOVEL-1` の `stdout.log` = 0バイト、exit code 0) で確認
- `--offline` を除去することでpiが正常にAPIに接続してタスクを実行するようになった
- テストの `assert_contains` も同様に更新

**根本原因:** `--offline` = `PI_OFFLINE=1` はスタートアップのネットワーク操作を無効化するが、`--print` (非対話)モードでは実際のAPIコールも行われずに終了してしまう動作が確認された

## Test plan

- [ ] ローカルテスト: `bash tests/codex-workspace/novel-board-runner-test.sh` → 全テスト合格済み
- [ ] CI: build-and-push, test-codex-novel-board-runner の成功を確認
- [ ] デプロイ後: Novel Board カードに pi を割り当てて正常実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)