### PR TITLE
Fix Novel Board pi agent empty output and nsfw bidirectional sync (BOXP-100)

### DIFF
--- a/docker/codex-workspace/novel-board/novel_board_runner.bb
+++ b/docker/codex-workspace/novel-board/novel_board_runner.bb
@@ -356,6 +356,25 @@
       assignee (replace-or-append-metadata "assignee" assignee))
     line))
 
+(defn update-card-nsfw
+  "Add or remove the #nsfw tag in the tail of a board card line for the given novel-id.
+  Only the portion after the closing ]] is modified to avoid touching the card label."
+  [line novel-id nsfw]
+  (if-not (re-find (re-pattern (str "\\[\\[Novels/" (java.util.regex.Pattern/quote novel-id) "(?:\\||\\]\\])")) line)
+    line
+    (let [bracket-end (some-> (str/index-of line "]]") (+ 2))]
+      (if-not bracket-end
+        line
+        (let [prefix (subs line 0 bracket-end)
+              tail (subs line bracket-end)
+              has-nsfw (token-present? tail "#nsfw")]
+          (cond
+            (and nsfw (not has-nsfw))
+            (str prefix (str/replace-first tail #"(#novel)(?=\s|$)" "$1 #nsfw"))
+            (and (not nsfw) has-nsfw)
+            (str prefix (str/replace tail #"\s#nsfw(?=\s|$)" ""))
+            :else line))))))
+
 (defn move-card-lines! [lines card-index novel-id target-status assignee]
   (let [path (board-path)
         target-lane (get status->lane target-status)]
@@ -450,14 +469,24 @@
          (create-note! current)
          (let [fm (note-frontmatter novel-id)
                effective-assignee (or (:assignee current) (:assignee fm) "boxp")
-               synced (assoc current :assignee effective-assignee)
-               next-lines (mapv #(update-card-line % novel-id (:status current) effective-assignee) lines)]
+               ;; nsfw is bidirectional: note frontmatter can set #nsfw on the board card.
+               ;; Either source being true makes the novel NSFW. To clear NSFW, remove
+               ;; #nsfw from the board card and set nsfw: false in the management note.
+               ;; Note: parse-frontmatter-lines returns the string "true"/"false" for
+               ;; unquoted YAML booleans, so compare explicitly with = "true".
+               note-nsfw (= "true" (str (:nsfw fm)))
+               effective-nsfw (or (:nsfw current) note-nsfw false)
+               synced (assoc current :assignee effective-assignee :nsfw effective-nsfw)
+               next-lines (mapv #(-> %
+                                     (update-card-line novel-id (:status current) effective-assignee)
+                                     (update-card-nsfw novel-id effective-nsfw))
+                                lines)]
            (when (not= lines next-lines) (write-lines! (board-path) next-lines))
            (update-frontmatter! novel-id
                                 {:status (:status current)
                                  :title (:title current)
                                  :assignee effective-assignee
-                                 :nsfw (:nsfw current)
+                                 :nsfw effective-nsfw
                                  :work-dir (work-dir novel-id)
                                  :manuscript (manuscript-path novel-id)})
            synced))))))
@@ -705,6 +734,8 @@
                 "Produce a reviewable manuscript, then append a concise entry under Change History without deleting prior history.\n")
            :revise
            (str "Revise the existing manuscript in place using the latest Review Instructions. Preserve previous review instructions and append a concise Change History entry describing the changes.\n"))
+         "File editing: prefer bash (e.g. printf '%s' 'CONTENT' > 'PATH') or the write tool (path, content) for whole-file writes. "
+         "If using the edit tool, its required schema is: {\"path\": \"/abs/path\", \"edits\": [{\"oldText\": \"text to replace\", \"newText\": \"replacement\"}]}.\n"
          "Never write a draft into the SFW or NSFW publication folders. Do not edit existing novels, Task Board files, or daily cron files.\n"
          "If a human decision or missing requirement prevents completion, record the reason and exact resume condition in Run History.\n"
          "End your final response with exactly one line: NOVEL_BOARD_RESULT: review or NOVEL_BOARD_RESULT: blocked.\n\n"

--- a/tests/codex-workspace/novel-board-runner-test.sh
+++ b/tests/codex-workspace/novel-board-runner-test.sh
@@ -380,6 +380,27 @@ test_manual_title_scaffold() {
   [[ "${card_count}" -eq 2 ]] || fail "Novel scaffold duplicated a Board card"
 }
 
+test_nsfw_note_to_board_sync() {
+  local tmp vault state bin
+  tmp="$(mktemp -d)"; vault="${tmp}/vault"; state="${tmp}/state"; bin="${tmp}/bin"
+  make_fake_agents "${bin}"
+  # Board card has no #nsfw; management note frontmatter sets nsfw: true (user changed it)
+  write_board "${vault}" "- [ ] [[Novels/NOVEL-N|NOVEL-N: NSFWテスト]] #novel status::backlog assignee::boxp"
+  write_note "${vault}" NOVEL-N backlog boxp "NSFWテスト" "${state}"
+  sed -i 's/^nsfw: false$/nsfw: true/' "${vault}/Novels/NOVEL-N.md"
+
+  run_tick "${vault}" "${state}" "${bin}" env
+
+  # Board card must now carry #nsfw (note frontmatter propagated to board)
+  assert_contains "${vault}/Boards/Novel Board.md" '[[Novels/NOVEL-N|NOVEL-N: NSFWテスト]] #novel #nsfw status::backlog assignee::boxp'
+  assert_contains "${vault}/Novels/NOVEL-N.md" 'nsfw: true'
+
+  # Second tick: board now has #nsfw, note says nsfw: true — state is stable
+  run_tick "${vault}" "${state}" "${bin}" env
+  assert_contains "${vault}/Boards/Novel Board.md" '[[Novels/NOVEL-N|NOVEL-N: NSFWテスト]] #novel #nsfw status::backlog assignee::boxp'
+  assert_contains "${vault}/Novels/NOVEL-N.md" 'nsfw: true'
+}
+
 test_groom_and_human_stop() {
   local tmp vault state bin prompt
   tmp="$(mktemp -d)"; vault="${tmp}/vault"; state="${tmp}/state"; bin="${tmp}/bin"; prompt="${tmp}/prompt.log"
@@ -437,6 +458,9 @@ test_write_review_and_pi_revision() {
   assert_not_contains "${args}" "@${outside}"
   prompt_log="$(grep -l -F 'Reference images attached to the agent:' "${state}/runs/NOVEL-2"/*/prompt.md | head -n 1)"
   assert_contains "${prompt_log}" "Reference images attached to the agent:"
+  # Prompt must include file-tool hint so local models know the correct schema
+  assert_contains "${prompt_log}" "File editing:"
+  assert_contains "${prompt_log}" "oldText"
   assert_contains "${vault}/Boards/Novel Board.md" "status::review assignee::boxp"
 }
 
@@ -1050,6 +1074,7 @@ test_task_board_and_cron_untouched() {
 
 test_seed_and_entrypoint
 test_manual_title_scaffold
+test_nsfw_note_to_board_sync
 test_groom_and_human_stop
 test_write_review_and_pi_revision
 test_agent_timeout_returns_to_human_review


### PR DESCRIPTION
## Summary

- **Pi agent empty stdout fix**: The local model (gemma4-26b-vision) was using incorrect schema for pi's `edit` tool (`edits[].newText` without `path` and `oldText`), getting a validation error, then returning empty content. Added file-editing tool documentation to the agent prompt so models know to prefer `bash`/`write` tools and understand the correct `edit` tool schema (`{path, edits: [{oldText, newText}]}`).

- **nsfw bidirectional sync**: Previously `sync-card!` was one-way (board card `#nsfw` → note frontmatter). Users editing `nsfw: false → true` in Obsidian Properties had their change silently reverted on the next runner tick. `sync-card!` now merges both sources: if either the board card has `#nsfw` or the note frontmatter has `nsfw: true`, the card gets `#nsfw` and the note gets `nsfw: true`. Note: to clear NSFW you must remove `#nsfw` from the board card AND set `nsfw: false` in the note.

## Changes

- `docker/codex-workspace/novel-board/novel_board_runner.bb`
  - Add `update-card-nsfw` function to add/remove `#nsfw` tag from card lines
  - `sync-card!`: compute `effective-nsfw = (or board-nsfw note-nsfw)` with proper string→bool coercion for frontmatter values
  - `prompt-for`: add file-tool schema hint for all agents
- `tests/codex-workspace/novel-board-runner-test.sh`
  - Add `test_nsfw_note_to_board_sync` verifying note `nsfw: true` propagates to board card
  - Add assertions in `test_write_review_and_pi_revision` verifying prompt contains file-tool hint

## Test plan
- [ ] All existing tests pass: `bash tests/codex-workspace/novel-board-runner-test.sh`
- [ ] New test `test_nsfw_note_to_board_sync` passes
- [ ] CI: build-and-push, test, actionlint, gitleaks

🤖 Generated with [Claude Code](https://claude.ai/claude-code)