### PR TITLE
Disable edit tool for pi agent to fix assignee revert (BOXP-100)

### DIFF
--- a/docker/codex-workspace/novel-board/novel_board_runner.bb
+++ b/docker/codex-workspace/novel-board/novel_board_runner.bb
@@ -734,8 +734,8 @@
                 "Produce a reviewable manuscript, then append a concise entry under Change History without deleting prior history.\n")
            :revise
            (str "Revise the existing manuscript in place using the latest Review Instructions. Preserve previous review instructions and append a concise Change History entry describing the changes.\n"))
-         "File editing: prefer bash (e.g. printf '%s' 'CONTENT' > 'PATH') or the write tool (path, content) for whole-file writes. "
-         "If using the edit tool, its required schema is: {\"path\": \"/abs/path\", \"edits\": [{\"oldText\": \"text to replace\", \"newText\": \"replacement\"}]}.\n"
+         "File editing: use bash (e.g. printf '%s' 'CONTENT' > 'PATH') or the write tool (path, content). "
+         "Do NOT use the edit tool — it is disabled for this session.\n"
          "Never write a draft into the SFW or NSFW publication folders. Do not edit existing novels, Task Board files, or daily cron files.\n"
          "If a human decision or missing requirement prevents completion, record the reason and exact resume condition in Run History.\n"
          "End your final response with exactly one line: NOVEL_BOARD_RESULT: review or NOVEL_BOARD_RESULT: blocked.\n\n"
@@ -798,6 +798,7 @@
                  :pi (cond-> ["pi"
                               "--no-extensions" "--no-skills"
                               "--no-prompt-templates" "--no-context-files"
+                              "--exclude-tools" "edit"
                               "--print" "--approve" "--mode" "text"
                               "--session-dir" (str pi-session-dir)]
                        (System/getenv "CODEX_NOVEL_BOARD_PI_MODEL")

--- a/tests/codex-workspace/novel-board-runner-test.sh
+++ b/tests/codex-workspace/novel-board-runner-test.sh
@@ -450,7 +450,7 @@ test_write_review_and_pi_revision() {
   sed -i "/^- Synopsis:/a\\- Vision reference: ![[Attachments/character reference.png]]\\n- Setting reference: ![setting](Attachments/setting.webp)\\n- Rejected external image: ![[${outside}]]" "${vault}/Novels/NOVEL-2.md"
   FAKE_ARG_LOG="${args}" CODEX_NOVEL_BOARD_PI_MODEL="llama.cpp/gemma4-26b-vision" run_tick "${vault}" "${state}" "${bin}" env
   assert_contains "${state}/work/NOVEL-2/manuscript.md" "Pi 改稿済み"
-  assert_contains "${args}" "pi --no-extensions --no-skills --no-prompt-templates --no-context-files --print --approve --mode text --session-dir"
+  assert_contains "${args}" "pi --no-extensions --no-skills --no-prompt-templates --no-context-files --exclude-tools edit --print --approve --mode text --session-dir"
   assert_not_contains "${args}" "--offline"
   assert_contains "${args}" "--model llama.cpp/gemma4-26b-vision"
   assert_contains "${args}" "@${image}"
@@ -458,9 +458,10 @@ test_write_review_and_pi_revision() {
   assert_not_contains "${args}" "@${outside}"
   prompt_log="$(grep -l -F 'Reference images attached to the agent:' "${state}/runs/NOVEL-2"/*/prompt.md | head -n 1)"
   assert_contains "${prompt_log}" "Reference images attached to the agent:"
-  # Prompt must include file-tool hint so local models know the correct schema
+  # Prompt must tell local models to use bash/write and not the disabled edit tool
   assert_contains "${prompt_log}" "File editing:"
-  assert_contains "${prompt_log}" "oldText"
+  assert_contains "${prompt_log}" "Do NOT use the edit tool"
+  assert_not_contains "${prompt_log}" "oldText"
   assert_contains "${vault}/Boards/Novel Board.md" "status::review assignee::boxp"
 }
 


### PR DESCRIPTION
## Summary

- Root cause of `pi` assignee reverting to `boxp`: Gemma4-26B model (default pi backend) consistently produces wrong `edit` tool schemas—missing the required `path` field and using `newText`-only instead of `oldText`/`newText` pairs. After the validation failure the model returns empty content with no `NOVEL_BOARD_RESULT:` marker, so the runner always treated pi runs as failed and reset the card to Draft with `assignee::boxp`.
- Fix: add `--exclude-tools edit` to the pi CLI invocation so the model is forced to use `bash` or the `write` tool for file operations.
- Update prompt to say "Do NOT use the edit tool — it is disabled for this session." instead of the previous mixed message that described the schema while also saying to prefer bash.
- Update test assertion to expect the new flag and the new prompt text.

## Test plan

- [x] `tests/codex-workspace/novel-board-runner-test.sh` all tests pass locally
- [ ] CI build-and-push passes
- [ ] Deploy updated image via lolice PR after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)