### PR TITLE
feat(arc): add custom runner image build

### DIFF
--- a/.github/workflows/build-arc-runner-image.yml
+++ b/.github/workflows/build-arc-runner-image.yml
@@ -1,0 +1,49 @@
+name: Build ARC Runner Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['docker/arc-runner/**', '.github/workflows/build-arc-runner-image.yml']
+  pull_request:
+    paths: ['docker/arc-runner/**', '.github/workflows/build-arc-runner-image.yml']
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/boxp/arch/arc-runner
+          tags: |
+            type=raw,value={{date 'YYYYMMDDHHmm'}},enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker/arc-runner
+          # A manually dispatched feature build publishes only its immutable SHA tag.
+          push: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -1,0 +1,21 @@
+FROM ghcr.io/actions/actions-runner:2.335.1
+
+USER root
+
+# The upstream runner image deliberately contains only the runner runtime.  Keep
+# the tools used by this repository's self-hosted workflows here instead of
+# relying on the GitHub-hosted ubuntu-latest VM tool cache.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        awscli \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        openssh-client \
+        python3 \
+        python3-venv \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+USER runner

--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -7,7 +7,6 @@ USER root
 # relying on the GitHub-hosted ubuntu-latest VM tool cache.
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-        awscli \
         ca-certificates \
         curl \
         git \
@@ -16,6 +15,11 @@ RUN apt-get update \
         python3 \
         python3-venv \
         unzip \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail --location --retry 3 --output /tmp/awscliv2.zip \
+        https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
 
 USER runner


### PR DESCRIPTION
## Summary
- actions/actions-runner 2.335.1 をベースに AWS CLI 等を追加した ARC Runner イメージを追加
- ghcr.io/boxp/arch/arc-runner へ公開する GitHub Actions ワークフローを追加

## Verification
- actionlint .github/workflows/build-arc-runner-image.yml
- ghalint run .github/workflows/build-arc-runner-image.yml
- Dockerfile のローカルビルドを開始し、ベースイメージの取得を確認