### PR TITLE
fix(arc): add make to runner image

### DIFF
--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         curl \
         git \
         jq \
+        make \
         openssh-client \
         python3 \
         python3-venv \

--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -8,14 +8,33 @@ USER root
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
         ca-certificates \
+        bc \
+        bison \
+        build-essential \
+        bzip2 \
+        cpio \
         curl \
+        device-tree-compiler \
+        file \
+        flex \
+        gcc-arm-linux-gnueabi \
         git \
+        gzip \
         jq \
+        libc6-i386 \
+        lib32z1 \
+        libelf-dev \
+        libssl-dev \
         make \
+        mtd-utils \
         openssh-client \
+        patch \
         python3 \
         python3-venv \
+        rsync \
         unzip \
+        wget \
+        xz-utils \
     && rm -rf /var/lib/apt/lists/* \
     && curl --fail --location --retry 3 --output /tmp/awscliv2.zip \
         https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \


### PR DESCRIPTION
## Summary
- is01-linux の self-hosted CI が実行する `make check` 用に make を ARC runner image へ追加

## Verification
- GitHub Actions の image build で検証予定