### PR TITLE
feat(arc): run image builds on self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   labels:
-    - arc-runners
+    - arc-runners-arch

--- a/.github/actions/build-orange-pi-image/action.yml
+++ b/.github/actions/build-orange-pi-image/action.yml
@@ -19,17 +19,11 @@ runs:
       with:
         platforms: linux/arm64
 
-    - name: Install Armbian build dependencies
+    - name: Verify Armbian build dependencies
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          git \
-          build-essential \
-          qemu-user-static \
-          debootstrap \
-          rsync \
-          bc
+        command -v debootstrap
+        command -v qemu-aarch64-static
 
     - name: Clone Armbian build system
       shell: bash

--- a/.github/workflows/build-gpu-worker-image.yml
+++ b/.github/workflows/build-gpu-worker-image.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-22.04
+    runs-on: arc-runners-arch
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -41,19 +41,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install image build dependencies
+      - name: Verify image build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            curl \
-            jq \
-            libguestfs-tools \
-            qemu-utils \
-            xz-utils
-          sudo chmod 0644 /boot/vmlinuz-*
-          if [ -e /dev/kvm ]; then
-            sudo chmod 0666 /dev/kvm
-          fi
+          command -v qemu-img
+          command -v virt-customize
+          command -v virt-resize
 
       - name: Build GPU worker image
         id: build

--- a/.github/workflows/build-orange-pi-images.yml
+++ b/.github/workflows/build-orange-pi-images.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-images:
     needs: determine-nodes
-    runs-on: ubuntu-latest
+    runs-on: arc-runners-arch
     timeout-minutes: 120
     permissions:
       id-token: write

--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         bzip2 \
         cpio \
         curl \
+        debootstrap \
         device-tree-compiler \
         file \
         flex \
@@ -24,6 +25,7 @@ RUN apt-get update \
         libc6-i386 \
         lib32z1 \
         libelf-dev \
+        libguestfs-tools \
         libssl-dev \
         make \
         mtd-utils \
@@ -31,11 +33,16 @@ RUN apt-get update \
         patch \
         python3 \
         python3-venv \
+        qemu-utils \
+        qemu-user-static \
         rsync \
+        sudo \
         unzip \
         wget \
         xz-utils \
     && rm -rf /var/lib/apt/lists/* \
+    && echo 'runner ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/runner \
+    && chmod 0440 /etc/sudoers.d/runner \
     && curl --fail --location --retry 3 --output /tmp/awscliv2.zip \
         https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
     && unzip -q /tmp/awscliv2.zip -d /tmp \


### PR DESCRIPTION
## Summary
- Orange Pi Zero 3 と GPU Worker image build を arc-runners-arch へ移行
- DIND/guestfs/Armbian build に必要なツールを custom runner image に追加
- GitHub-hosted runner 固有の package install を image 事前導入へ置換

## Verification
- actionlint 対象 workflows
- ghalint 対象 workflows