### PR TITLE
fix(arc): include kernel for libguestfs

### DIFF
--- a/docker/arc-runner/Dockerfile
+++ b/docker/arc-runner/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         libelf-dev \
         libguestfs-tools \
         libssl-dev \
+        linux-image-virtual \
         make \
         mtd-utils \
         openssh-client \


### PR DESCRIPTION
GPU Worker Image の self-hosted 実行で `virt-resize` が supermin のカーネル未検出により失敗したため、runner image に `linux-image-virtual` を追加します。

検証: `git diff --check`