### PR TITLE
refactor(ci): run Orange Pi builds on hosted runners

### DIFF
--- a/.github/workflows/build-orange-pi-images.yml
+++ b/.github/workflows/build-orange-pi-images.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-images:
     needs: determine-nodes
-    runs-on: arc-runners-arch
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
       id-token: write


### PR DESCRIPTION
Orange Pi ビルドは self-hosted runner で高速化しなかったため、GitHub-hosted `ubuntu-latest` に戻します。

検証: `actionlint`; `ghalint run`; `git diff --check`