### PR TITLE
feat(cloudflare/k8s): BOXP-114 WARP split tunnel include リストを Terraform 管理化

### DIFF
--- a/terraform/cloudflare/b0xp.io/k8s/backend.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
   backend "s3" {
     bucket = "tfaction-state"
     key    = "terraform/cloudflare/b0xp.io/k8s/v1/terraform.tfstate"

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -19,8 +19,16 @@ resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
     description = "starRupture"
   }
   tunnels {
+    address     = "192.168.10.88/32"
+    description = "Grafana"
+  }
+  tunnels {
     address     = "192.168.10.95/32"
     description = "llama-server"
+  }
+  tunnels {
+    address     = "192.168.10.96/32"
+    description = "Kubernetes Dashboard"
   }
   tunnels {
     address     = "192.168.10.97/32"

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -42,5 +42,5 @@ resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
 
 import {
   to = cloudflare_zero_trust_split_tunnel.warp_include
-  id = "${var.account_id}/include"
+  id = "${var.account_id}//include"
 }

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -42,5 +42,5 @@ resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
 
 import {
   to = cloudflare_zero_trust_split_tunnel.warp_include
-  id = "${var.account_id}/include"
+  id = "${var.account_id}/default/include"
 }

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -1,0 +1,46 @@
+resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
+  account_id = var.account_id
+  mode       = "include"
+
+  tunnels {
+    address     = "192.168.10.99/32"
+    description = "cluster VIP (keepalived)"
+  }
+  tunnels {
+    address     = "192.168.10.98/32"
+    description = "codex-workspace VIP (MetalLB)"
+  }
+  tunnels {
+    address     = "192.168.10.102/32"
+    description = "shanghai-1 control plane node"
+  }
+  tunnels {
+    address     = "192.168.10.103/32"
+    description = "shanghai-2 control plane node"
+  }
+  tunnels {
+    address     = "192.168.10.104/32"
+    description = "shanghai-3 control plane node"
+  }
+  tunnels {
+    address     = "192.168.10.101/32"
+    description = "golyat-1 worker node"
+  }
+  tunnels {
+    address     = "192.168.10.105/32"
+    description = "golyat-2 worker node"
+  }
+  tunnels {
+    address     = "192.168.10.106/32"
+    description = "golyat-3 worker node"
+  }
+  tunnels {
+    address     = "192.168.10.107/32"
+    description = "golyat-4 worker node"
+  }
+}
+
+import {
+  to = cloudflare_zero_trust_split_tunnel.warp_include
+  id = "${var.account_id}/include"
+}

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -42,5 +42,5 @@ resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
 
 import {
   to = cloudflare_zero_trust_split_tunnel.warp_include
-  id = "${var.account_id}//include"
+  id = "${var.account_id}/include"
 }

--- a/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
+++ b/terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf
@@ -2,41 +2,69 @@ resource "cloudflare_zero_trust_split_tunnel" "warp_include" {
   account_id = var.account_id
   mode       = "include"
 
+  lifecycle {
+    ignore_changes = [policy_id]
+  }
+
   tunnels {
-    address     = "192.168.10.99/32"
-    description = "cluster VIP (keepalived)"
+    address     = "192.168.10.29/32"
+    description = "ark asa"
+  }
+  tunnels {
+    address     = "192.168.10.30/32"
+    description = "minecraft"
+  }
+  tunnels {
+    address     = "192.168.10.31/32"
+    description = "starRupture"
+  }
+  tunnels {
+    address     = "192.168.10.95/32"
+    description = "llama-server"
+  }
+  tunnels {
+    address     = "192.168.10.97/32"
+    description = "palserver"
   }
   tunnels {
     address     = "192.168.10.98/32"
-    description = "codex-workspace VIP (MetalLB)"
+    description = "argocd"
   }
   tunnels {
-    address     = "192.168.10.102/32"
-    description = "shanghai-1 control plane node"
+    address     = "192.168.10.99/32"
+    description = "lolice"
   }
   tunnels {
-    address     = "192.168.10.103/32"
-    description = "shanghai-2 control plane node"
-  }
-  tunnels {
-    address     = "192.168.10.104/32"
-    description = "shanghai-3 control plane node"
+    address     = "192.168.10.100/32"
+    description = "Ooedo"
   }
   tunnels {
     address     = "192.168.10.101/32"
-    description = "golyat-1 worker node"
+    description = "golyat-1"
+  }
+  tunnels {
+    address     = "192.168.10.102/32"
+    description = "shanghai-1"
+  }
+  tunnels {
+    address     = "192.168.10.103/32"
+    description = "shanghai-2"
+  }
+  tunnels {
+    address     = "192.168.10.104/32"
+    description = "shanghai-3"
   }
   tunnels {
     address     = "192.168.10.105/32"
-    description = "golyat-2 worker node"
-  }
-  tunnels {
-    address     = "192.168.10.106/32"
-    description = "golyat-3 worker node"
+    description = "golyat-2"
   }
   tunnels {
     address     = "192.168.10.107/32"
-    description = "golyat-4 worker node"
+    description = "golyat-4"
+  }
+  tunnels {
+    address     = "192.168.10.108/32"
+    description = "palserver-2"
   }
 }
 


### PR DESCRIPTION
## Summary

- `cloudflare_zero_trust_split_tunnel` リソースを `terraform/cloudflare/b0xp.io/k8s/split_tunnel.tf` に新規追加
- Cloudflare Zero Trust の default デバイスプロファイルの WARP split tunnel（include モード）を Terraform 管理化
- 現在ダッシュボードで管理している全 IP/CIDR を include リストに定義
- `import` ブロックで既存設定を取り込む構成

## 含まれる IP/CIDR

| IP | 種別 | 説明 |
|---|---|---|
| 192.168.10.99/32 | cluster VIP | keepalived |
| 192.168.10.98/32 | codex-workspace VIP | MetalLB |
| 192.168.10.102/32 | control plane | shanghai-1 |
| 192.168.10.103/32 | control plane | shanghai-2 |
| 192.168.10.104/32 | control plane | shanghai-3 |
| 192.168.10.101/32 | worker node | golyat-1 |
| 192.168.10.105/32 | worker node | golyat-2 |
| 192.168.10.106/32 | worker node | golyat-3 |
| 192.168.10.107/32 | worker node | golyat-4 |

## Test plan

- [ ] CI の tfaction plan で `terraform plan` が差分なしで通ること（import 後に drift がない）
- [ ] `terraform apply` が CI（tfaction）経由で正常に完了すること

## Notes

- import ブロックの ID は `{account_id}/include`（default デバイスプロファイル向け）
- 今後 node IP や VIP を追加する際は Ansible vars と同一 PR でこのファイルも変更するフローにする

Closes #BOXP-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)