### PR TITLE
feat(task-board): add investigation steps to :groom prompt (BOXP-117)

### DIFF
--- a/docker/codex-workspace/task-board/task_board_runner.bb
+++ b/docker/codex-workspace/task-board/task_board_runner.bb
@@ -985,7 +985,8 @@
       :groom
       (str common
            "Goal: clarify this backlog ticket only. Do not implement code, do not create commits, and do not open PRs.\n"
-           "Update the ticket file so Summary, Acceptance Criteria, Context, Plan, and Notes are specific enough for a human to review.\n"
+           "First investigate before writing: read ticket Notes and related Obsidian documents, inspect relevant GitHub repository state (issues, PRs, discussions via gh CLI), check related repo/git conventions, run Web searches for key technologies if needed, and for infra tickets check kubectl pod/deployment state; for performance/incident tickets check Grafana metrics.\n"
+           "Then update the ticket file so Summary, Acceptance Criteria, Context, Plan, and Notes are specific enough for a human to review. Fill Context with investigation findings (system state, related docs, design rationale). Fill Plan with concrete implementation steps derived from findings.\n"
            "Keep the scope practical and preserve existing decisions.\n"
            "End your final message with exactly one marker line: TASK_BOARD_RESULT: review\n")
 

--- a/tests/codex-workspace/task-board-runner-test.sh
+++ b/tests/codex-workspace/task-board-runner-test.sh
@@ -1281,6 +1281,46 @@ test_review_gate_pass_after_retry_moves_review() {
   assert_file_not_contains "${state}/state.edn" 'BOXP-415'
 }
 
+test_groom_prompt_contains_investigation_steps() {
+  local tmp vault state bin prompt_log
+  tmp="$(mktemp -d)"
+  vault="${tmp}/vault"
+  state="${tmp}/state"
+  bin="${tmp}/bin"
+  prompt_log="${tmp}/codex-prompt.log"
+  mkdir -p "${bin}" "${vault}/Boards" "${vault}/Tickets"
+  make_fake_codex "${bin}"
+  cat >"${vault}/Boards/Task Board.md" <<'EOF'
+# Task Board
+
+## Backlog
+- [ ] [[Tickets/BOXP-600|BOXP-600: groom prompt]] #ticket status::backlog
+
+## Ready
+
+## In Progress
+
+## Blocked
+
+## Review
+
+## Done
+EOF
+  write_ticket "${vault}" BOXP-600 backlog codex
+
+  PATH="${bin}:$PATH" \
+    CODEX_FAKE_PROMPT_LOG="${prompt_log}" \
+    CODEX_FAKE_MESSAGE='TASK_BOARD_RESULT: review' \
+    run_tick "${vault}" "${state}" env >/tmp/task-board-groom-prompt.out
+
+  assert_file_contains "${prompt_log}" 'First investigate before writing'
+  assert_file_contains "${prompt_log}" 'Notes'
+  assert_file_contains "${prompt_log}" 'GitHub'
+  assert_file_contains "${prompt_log}" 'gh CLI'
+  assert_file_contains "${prompt_log}" 'Fill Context with investigation findings'
+  assert_file_contains "${prompt_log}" 'Fill Plan with concrete implementation steps'
+}
+
 test_assignee_model_routing() {
   bb "${RUNNER}" test
 }
@@ -1386,6 +1426,7 @@ test_review_with_draft_pr_is_retried
 test_review_with_behind_merge_state_times_out
 test_review_gate_retry_limit_blocks
 test_review_gate_pass_after_retry_moves_review
+test_groom_prompt_contains_investigation_steps
 test_assignee_model_routing
 test_assignee_model_tick_routing
 test_assignee_reasoning_tick_routing


### PR DESCRIPTION
## Summary

- `task_board_runner.bb` の `:groom` プロンプトに調査ステップを追加
- `:implement` と同様に「First investigate before writing:」指示を先頭に配置
- 調査対象: チケット Notes・Obsidian ドキュメント・GitHub リポジトリ（gh CLI）・repo/git 状態・Web 検索・kubectl/Grafana（チケット種別による）
- 調査結果を Context・Plan セクションへ書き込む指示を追加
- CI テストに groom プロンプトの調査指示検証を追加

## Changes

- `docker/codex-workspace/task-board/task_board_runner.bb`: `:groom` ケースのプロンプトを拡充
- `tests/codex-workspace/task-board-runner-test.sh`: `test_groom_prompt_contains_investigation_steps` テスト追加

## Test plan

- [ ] CI テスト `tests/codex-workspace/task-board-runner-test.sh` が通過することを確認
- [ ] groom プロンプトに「First investigate before writing」が含まれていること
- [ ] groom プロンプトに「GitHub」「gh CLI」が含まれていること
- [ ] groom プロンプトに「Fill Context with investigation findings」が含まれていること

Closes BOXP-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)